### PR TITLE
fix(loader): prefill ordering, CDN invalidation, and observability

### DIFF
--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
@@ -240,7 +240,7 @@ describe("Prefill cloudfront", () => {
       });
     });
 
-    it("should warm CloudFront versioned cache after setting isPrefilled", async () => {
+    it("should warm CloudFront versioned cache before setting isPrefilled", async () => {
       await withDb(async (sudo) => {
         setupMocks(sudo);
         process.env.CODEGEN_HOST = CODEGEN_HOST;
@@ -250,11 +250,12 @@ describe("Prefill cloudfront", () => {
 
         await prefillCloudfront(sudo, pool, PKG_VERSION_ID);
 
-        // isPrefilled must be set before any warming fetch is called
+        // Warming fetches must complete before isPrefilled is set so that
+        // status only becomes "ready" once the CDN is actually primed.
         const updateCallOrder = updatePkgVersionMock.mock.invocationCallOrder[0];
-        const firstFetchCallOrder = (global.fetch as jest.Mock).mock
-          .invocationCallOrder[0];
-        expect(updateCallOrder).toBeLessThan(firstFetchCallOrder);
+        const lastFetchCallOrder = (global.fetch as jest.Mock).mock
+          .invocationCallOrder.at(-1);
+        expect(lastFetchCallOrder).toBeLessThan(updateCallOrder);
 
         // One warming GET per unique publishment. All 4 mock publishments have
         // distinct uniqBy keys (react/8/false, nextjs/8/false+i18n, react/8/true,
@@ -307,7 +308,8 @@ describe("Prefill cloudfront", () => {
 
         await prefillCloudfront(sudo, pool, PKG_VERSION_ID);
 
-        // Warming must happen before invalidation
+        // Warming must complete before isPrefilled is set and before invalidation,
+        // so that "status=ready" is only signalled once the CDN is primed.
         const firstFetchOrder = (global.fetch as jest.Mock).mock
           .invocationCallOrder[0];
         const invalidationOrder = mockSend.mock.invocationCallOrder[0];

--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -132,20 +132,12 @@ export async function prefillCloudfront(
     }
   }
 
-  // isPrefilled must be set before warming so that origin can serve
-  // pre-computed bundles on any CloudFront cache miss during the warm requests.
-  await mgr.updatePkgVersion(
-    pkgVersion.pkgId,
-    pkgVersion.version,
-    pkgVersion.branchId,
-    {
-      isPrefilled: true,
-    }
-  );
-
   // Warm CloudFront's versioned cache by GETting each versioned URL through
   // the CDN. This must happen before invalidating the published cache so that
   // when clients follow the published→versioned redirect they get a cache hit.
+  // Warming works here without isPrefilled being set because the versioned
+  // endpoint serves directly from S3 by projectId@version — isPrefilled is
+  // only checked by the published redirect endpoint.
   if (warmingData.length > 0) {
     const baseUrl = getCodegenPublicUrl();
     const warmingResults = await Promise.allSettled(
@@ -181,6 +173,22 @@ export async function prefillCloudfront(
       logger().info(`Warmed CloudFront versioned cache for ${projectId}`);
     }
   }
+
+  // Mark as prefilled immediately before invalidation. Setting it here (after
+  // warming, before invalidation) ensures two things:
+  //   1. The versioned cache is already hot, so cache misses on the published
+  //      redirect are cheap.
+  //   2. The window between "status = ready" and "published cache invalidated"
+  //      is minimised to just the invalidation API call (~100ms), rather than
+  //      the full warming duration (up to 30s × N variants).
+  await mgr.updatePkgVersion(
+    pkgVersion.pkgId,
+    pkgVersion.version,
+    pkgVersion.branchId,
+    {
+      isPrefilled: true,
+    }
+  );
 
   // Invalidate published CDN paths so clients are redirected to the
   // now-warmed versioned entries.

--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -9,11 +9,12 @@ import {
   mkVersionToSync,
 } from "@/wab/server/loader/resolve-projects";
 import { logger } from "@/wab/server/observability";
+import { captureException } from "@/wab/server/observability/datadog";
 import {
   makeGenPublishedLoaderCodeBundleOpts,
   makeCacheableVersionedLoaderQuery,
 } from "@/wab/server/routes/loader";
-import { withSpan } from "@/wab/server/util/apm-util";
+import { withSpan, withTimeSpent } from "@/wab/server/util/apm-util";
 import { PlasmicWorkerPool } from "@/wab/server/workers/pool";
 import { ensureDevFlags } from "@/wab/server/workers/worker-utils";
 import { getCodegenPublicUrl } from "@/wab/shared/urls";
@@ -47,200 +48,268 @@ export async function prefillCloudfront(
     ].join(",")
   );
 
-  logger().info(
-    `Pre-filling ${projectId}@${
-      pkgVersion.version
-    } for combinations ${JSON.stringify(
-      loaderPublishments.map((p) => ({
-        platform: p.platform,
-        loaderVersion: p.loaderVersion,
-        projectIds: p.projectIds,
-        browserOnly: p.browserOnly ?? false,
-        i18nKeyScheme: p.i18nKeyScheme ?? null,
-        i18nTagPrefix: p.i18nTagPrefix ?? null,
-        appDir: p.appDir ?? null,
-      }))
-    )}`
-  );
+  return withSpan(
+    "loader-prefill-cloudfront",
+    async () => {
+      logger().info("loader-prefill-start", {
+        project_id: projectId,
+        pkg_version: pkgVersion.version,
+        pkg_version_id: pkgVersionId,
+        variant_count: loaderPublishments.length,
+        variants: loaderPublishments.map((p) => ({
+          platform: p.platform,
+          loader_version: p.loaderVersion,
+          project_ids: p.projectIds,
+          browser_only: p.browserOnly ?? false,
+          i18n_key_scheme: p.i18nKeyScheme ?? null,
+          i18n_tag_prefix: p.i18nTagPrefix ?? null,
+          app_dir: p.appDir ?? null,
+        })),
+      });
 
-  // Collect resolved specs alongside bundle generation so we can reuse them
-  // for CDN warming without a second DB query.
-  const warmingData: Array<{
-    publishment: (typeof loaderPublishments)[0];
-    resolvedProjectIdSpecs: string[];
-  }> = [];
+      // Collect resolved specs alongside bundle generation so we can reuse them
+      // for CDN warming without a second DB query.
+      const warmingData: Array<{
+        publishment: (typeof loaderPublishments)[0];
+        resolvedProjectIdSpecs: string[];
+      }> = [];
 
-  // Phase 1: resolve all project versions upfront so warmingData is fully
-  // populated before bundle generation starts. This ensures CDN warming and
-  // invalidation cover all variants even if a later bundle generation fails.
-  for (const publishment of loaderPublishments) {
-    const resolvedProjectIdSpecs = await getResolvedProjectVersions(
-      mgr,
-      publishment.projectIds
-    );
-    warmingData.push({ publishment, resolvedProjectIdSpecs });
-  }
+      // Phase 1: resolve all project versions upfront so warmingData is fully
+      // populated before bundle generation starts. This ensures CDN warming and
+      // invalidation cover all variants even if a later bundle generation fails.
+      for (const publishment of loaderPublishments) {
+        const resolvedProjectIdSpecs = await getResolvedProjectVersions(
+          mgr,
+          publishment.projectIds
+        );
+        warmingData.push({ publishment, resolvedProjectIdSpecs });
+      }
 
-  // Phase 2: generate bundles sequentially to bound peak memory usage.
-  // Each variant is wrapped independently so a single failure does not abort
-  // the remaining variants — all are still warmed and invalidated below.
-  for (const { publishment, resolvedProjectIdSpecs } of warmingData) {
-    try {
-      await withSpan(
-        "loader-prefill",
-        async () => {
-          await genPublishedLoaderCodeBundle(
-            mgr,
-            pool,
-            makeGenPublishedLoaderCodeBundleOpts({
-              projectVersions: Object.fromEntries(
-                resolvedProjectIdSpecs.map((spec) => {
-                  const [pid, version] = spec.split("@");
-                  return [pid, mkVersionToSync(version, false)];
+      // Phase 2: generate bundles sequentially to bound peak memory usage.
+      // Each variant is wrapped independently so a single failure does not abort
+      // the remaining variants — all are still warmed and invalidated below.
+      let bundleSuccesses = 0;
+      let bundleFailures = 0;
+      for (const { publishment, resolvedProjectIdSpecs } of warmingData) {
+        try {
+          await withSpan(
+            "loader-prefill-bundle",
+            async () => {
+              await genPublishedLoaderCodeBundle(
+                mgr,
+                pool,
+                makeGenPublishedLoaderCodeBundleOpts({
+                  projectVersions: Object.fromEntries(
+                    resolvedProjectIdSpecs.map((spec) => {
+                      const [pid, version] = spec.split("@");
+                      return [pid, mkVersionToSync(version, false)];
+                    })
+                  ),
+                  platform: publishment.platform,
+                  appDir: publishment.appDir ?? false,
+                  loaderVersion: publishment.loaderVersion,
+                  browserOnly: publishment.browserOnly ?? false,
+                  i18n: {
+                    keyScheme: publishment.i18nKeyScheme ?? undefined,
+                    tagPrefix: publishment.i18nTagPrefix ?? undefined,
+                  },
                 })
-              ),
+              );
+            },
+            undefined,
+            {
+              project_id: projectId,
               platform: publishment.platform,
-              appDir: publishment.appDir ?? false,
-              loaderVersion: publishment.loaderVersion,
-              browserOnly: publishment.browserOnly ?? false,
-              i18n: {
-                keyScheme: publishment.i18nKeyScheme ?? undefined,
-                tagPrefix: publishment.i18nTagPrefix ?? undefined,
-              },
-            })
+              loader_version: publishment.loaderVersion,
+              browser_only: publishment.browserOnly ?? false,
+              app_dir: publishment.appDir ?? false,
+              i18n_key_scheme: publishment.i18nKeyScheme ?? null,
+              i18n_tag_prefix: publishment.i18nTagPrefix ?? null,
+              project_count: publishment.projectIds.length,
+              pkg_version_id: pkgVersionId,
+            }
           );
-        },
-        undefined,
-        {
-          platform: publishment.platform,
-          loader_version: publishment.loaderVersion,
-          browser_only: publishment.browserOnly,
-          app_dir: publishment.appDir,
-          i18n_key_scheme: publishment.i18nKeyScheme,
-          i18n_tag_prefix: publishment.i18nTagPrefix,
-          pkg_version_id: pkgVersionId,
-          project_ids: publishment.projectIds,
-          projects: resolvedProjectIdSpecs,
+          bundleSuccesses++;
+        } catch (err) {
+          // Even if there was an error, we set isPrefilled to true, else it'll
+          // never be pre-filled.
+          bundleFailures++;
+          captureException(err, {
+            project_id: projectId,
+            platform: publishment.platform,
+            pkg_version_id: pkgVersionId,
+          });
         }
-      );
-    } catch (err) {
-      // Even if there was an error, we set isPrefilled to true, else it'll
-      // never be pre-filled.
-      logger().warn(
-        `Bundle generation failed during prefill for ${projectId} (${publishment.platform}): ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
+      }
 
-  // Warm CloudFront's versioned cache by GETting each versioned URL through
-  // the CDN. This must happen before invalidating the published cache so that
-  // when clients follow the published→versioned redirect they get a cache hit.
-  // Warming works here without isPrefilled being set because the versioned
-  // endpoint serves directly from S3 by projectId@version — isPrefilled is
-  // only checked by the published redirect endpoint.
-  if (warmingData.length > 0) {
-    const baseUrl = getCodegenPublicUrl();
-    const warmingResults = await Promise.allSettled(
-      warmingData.map(({ publishment, resolvedProjectIdSpecs }) => {
-        // Use the same query builder as buildPublishedLoaderAssets so the
-        // warming URL is identical to the versioned redirect URL clients follow,
-        // producing the same CloudFront cache key.
-        const query = makeCacheableVersionedLoaderQuery({
-          platform: publishment.platform,
-          nextjsAppDir: publishment.appDir ?? false,
-          loaderVersion: publishment.loaderVersion,
-          resolvedProjectIdSpecs,
-          browserOnly: publishment.browserOnly ?? false,
-          i18nKeyScheme: publishment.i18nKeyScheme ?? undefined,
-          i18nTagPrefix: publishment.i18nTagPrefix ?? undefined,
-        });
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 30_000);
-        return fetch(
-          `${baseUrl}/api/v1/loader/code/versioned?${query}`,
-          { signal: controller.signal }
-        ).finally(() => clearTimeout(timeoutId));
-      })
-    );
-    const warmingFailures = warmingResults.filter(
-      (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok)
-    );
-    if (warmingFailures.length > 0) {
-      logger().warn(
-        `CloudFront versioned cache warming had ${warmingFailures.length}/${warmingResults.length} failures for ${projectId} — invalidation will proceed but some clients may hit origin`
-      );
-    } else {
-      logger().info(`Warmed CloudFront versioned cache for ${projectId}`);
-    }
-  }
+      // Phase 3: warm CloudFront's versioned cache by GETting each versioned
+      // URL through the CDN. This must happen before invalidating the published
+      // cache so that when clients follow the published→versioned redirect they
+      // get a cache hit. Warming works without isPrefilled being set because the
+      // versioned endpoint serves directly from S3 by projectId@version.
+      if (warmingData.length > 0) {
+        const baseUrl = getCodegenPublicUrl();
+        await withSpan(
+          "loader-prefill-warming",
+          async () => {
+            const warmingResults = await Promise.allSettled(
+              warmingData.map(async ({ publishment, resolvedProjectIdSpecs }) => {
+                // Use the same query builder as buildPublishedLoaderAssets so
+                // the warming URL is identical to the versioned redirect URL
+                // clients follow, producing the same CloudFront cache key.
+                const query = makeCacheableVersionedLoaderQuery({
+                  platform: publishment.platform,
+                  nextjsAppDir: publishment.appDir ?? false,
+                  loaderVersion: publishment.loaderVersion,
+                  resolvedProjectIdSpecs,
+                  browserOnly: publishment.browserOnly ?? false,
+                  i18nKeyScheme: publishment.i18nKeyScheme ?? undefined,
+                  i18nTagPrefix: publishment.i18nTagPrefix ?? undefined,
+                });
+                const controller = new AbortController();
+                const timeoutId = setTimeout(() => controller.abort(), 30_000);
+                const { result, spentTime } = await withTimeSpent(() =>
+                  fetch(`${baseUrl}/api/v1/loader/code/versioned?${query}`, {
+                    signal: controller.signal,
+                  }).finally(() => clearTimeout(timeoutId))
+                );
+                logger().info("loader-prefill-warming-url", {
+                  project_id: projectId,
+                  platform: publishment.platform,
+                  loader_version: publishment.loaderVersion,
+                  browser_only: publishment.browserOnly ?? false,
+                  app_dir: publishment.appDir ?? false,
+                  duration_ms: spentTime,
+                  ok: result.ok,
+                  status: result.status,
+                });
+                return result;
+              })
+            );
 
-  // Mark as prefilled immediately before invalidation. Setting it here (after
-  // warming, before invalidation) ensures two things:
-  //   1. The versioned cache is already hot, so cache misses on the published
-  //      redirect are cheap.
-  //   2. The window between "status = ready" and "published cache invalidated"
-  //      is minimised to just the invalidation API call (~100ms), rather than
-  //      the full warming duration (up to 30s × N variants).
-  await mgr.updatePkgVersion(
-    pkgVersion.pkgId,
-    pkgVersion.version,
-    pkgVersion.branchId,
+            const warmingSucceeded = warmingResults.filter(
+              (r) => r.status === "fulfilled" && r.value.ok
+            ).length;
+            const warmingFailed = warmingResults.length - warmingSucceeded;
+            logger().info("loader-prefill-warming-summary", {
+              project_id: projectId,
+              total: warmingResults.length,
+              succeeded: warmingSucceeded,
+              failed: warmingFailed,
+            });
+            if (warmingFailed > 0) {
+              logger().warn(
+                `CloudFront versioned cache warming had ${warmingFailed}/${warmingResults.length} failures for ${projectId} — invalidation will proceed but some clients may hit origin`
+              );
+            }
+          },
+          undefined,
+          { project_id: projectId, variant_count: warmingData.length }
+        );
+      }
+
+      // Mark as prefilled immediately before invalidation. Setting it here
+      // (after warming, before invalidation) ensures:
+      //   1. The versioned cache is already hot for any cache miss on the
+      //      published redirect.
+      //   2. The window between "status = ready" and "published cache
+      //      invalidated" is minimised to just the invalidation API call
+      //      (~100ms), rather than the full warming duration (up to 30s × N).
+      await mgr.updatePkgVersion(
+        pkgVersion.pkgId,
+        pkgVersion.version,
+        pkgVersion.branchId,
+        { isPrefilled: true }
+      );
+
+      // Phase 4: invalidate published CDN paths so clients are redirected to
+      // the now-warmed versioned entries.
+      //
+      // code/published paths are keyed by sorted project IDs embedded in the
+      // URL path by the CloudFront Function (e.g. /published/aaa,zzz*). One
+      // path per unique project-ID combination covers all platform/loaderVersion
+      // variants.
+      //
+      // repr/html published paths already have :projectId in the route, so we
+      // can scope invalidation to just the published project.
+      const distributionId = process.env.CLOUDFRONT_DISTRIBUTION_ID;
+      if (distributionId) {
+        const codePaths = [
+          ...new Set(
+            warmingData.map(
+              ({ publishment }) =>
+                `/api/v1/loader/code/published/${[...publishment.projectIds]
+                  .sort()
+                  .join(",")}*`
+            )
+          ),
+        ];
+        const invalidationPaths = [
+          ...codePaths,
+          `/api/v1/loader/repr-v2/published/${projectId}*`,
+          `/api/v1/loader/repr-v3/published/${projectId}*`,
+          `/api/v1/loader/html/published/${projectId}*`,
+        ];
+        try {
+          await withSpan(
+            "loader-prefill-invalidation",
+            async () => {
+              // CloudFront is a global service; us-east-1 is correct for all CF API calls
+              cloudfrontClient ??= new CloudFrontClient({ region: "us-east-1" });
+              await cloudfrontClient.send(
+                new CreateInvalidationCommand({
+                  DistributionId: distributionId,
+                  InvalidationBatch: {
+                    // Append timestamp so retries of the same pkgVersionId get a
+                    // fresh CallerReference — CF rejects reuse of an in-progress one.
+                    CallerReference: `${pkgVersionId}-${Date.now()}`,
+                    Paths: {
+                      Quantity: invalidationPaths.length,
+                      Items: invalidationPaths,
+                    },
+                  },
+                })
+              );
+              logger().info("loader-prefill-invalidation-success", {
+                project_id: projectId,
+                distribution_id: distributionId,
+                path_count: invalidationPaths.length,
+                paths: invalidationPaths,
+              });
+            },
+            undefined,
+            {
+              project_id: projectId,
+              distribution_id: distributionId,
+              path_count: invalidationPaths.length,
+            }
+          );
+        } catch (err) {
+          captureException(err, {
+            project_id: projectId,
+            distribution_id: distributionId,
+            pkg_version_id: pkgVersionId,
+          });
+        }
+      }
+
+      logger().info("loader-prefill-complete", {
+        project_id: projectId,
+        pkg_version: pkgVersion.version,
+        pkg_version_id: pkgVersionId,
+        variant_count: loaderPublishments.length,
+        bundle_successes: bundleSuccesses,
+        bundle_failures: bundleFailures,
+        warming_variant_count: warmingData.length,
+        invalidation_enabled: !!process.env.CLOUDFRONT_DISTRIBUTION_ID,
+      });
+    },
+    undefined,
     {
-      isPrefilled: true,
+      project_id: projectId,
+      pkg_version: pkgVersion.version,
+      pkg_version_id: pkgVersionId,
+      variant_count: loaderPublishments.length,
     }
   );
-
-  // Invalidate published CDN paths so clients are redirected to the
-  // now-warmed versioned entries.
-  //
-  // code/published paths are keyed by sorted project IDs embedded in the URL
-  // path by the CloudFront Function (e.g. /published/aaa,zzz*). One path per
-  // unique project-ID combination covers all platform/loaderVersion variants.
-  //
-  // repr/html published paths already have :projectId in the route, so we
-  // can scope invalidation to just the published project.
-  const distributionId = process.env.CLOUDFRONT_DISTRIBUTION_ID;
-  if (distributionId) {
-    try {
-      const codePaths = [
-        ...new Set(
-          warmingData.map(
-            ({ publishment }) =>
-              `/api/v1/loader/code/published/${[...publishment.projectIds]
-                .sort()
-                .join(",")}*`
-          )
-        ),
-      ];
-      const invalidationPaths = [
-        ...codePaths,
-        `/api/v1/loader/repr-v2/published/${projectId}*`,
-        `/api/v1/loader/repr-v3/published/${projectId}*`,
-        `/api/v1/loader/html/published/${projectId}*`,
-      ];
-      // CloudFront is a global service; us-east-1 is the correct region for all CF API calls
-      cloudfrontClient ??= new CloudFrontClient({ region: "us-east-1" });
-      await cloudfrontClient.send(
-        new CreateInvalidationCommand({
-          DistributionId: distributionId,
-          InvalidationBatch: {
-            // Append timestamp so retries of the same pkgVersionId get a fresh
-            // CallerReference — CloudFront rejects reuse of an in-progress reference.
-            CallerReference: `${pkgVersionId}-${Date.now()}`,
-            Paths: {
-              Quantity: invalidationPaths.length,
-              Items: invalidationPaths,
-            },
-          },
-        })
-      );
-      logger().info(`CloudFront invalidation triggered for ${projectId}`);
-    } catch (err) {
-      logger().warn(
-        `CloudFront invalidation failed for ${projectId}: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
-
-  logger().info(`Done prefilling cloudfront for ${projectId}`);
 }


### PR DESCRIPTION
## Summary

- **Fix: `isPrefilled` set too early** — previously `isPrefilled: true` was set immediately after bundle generation, before CDN warming or invalidation. The `/status` endpoint returns `\"ready\"` as soon as `isPrefilled` is true, so the perf test (and real clients) would hit CloudFront `/published` before the stale redirect was invalidated — still resolving the old version. Fixed order: **warm versioned cache → `isPrefilled: true` → invalidate published cache**.
- **Fix: `Promise.all` → sequential `for...of`** — bundle generation is now sequential to bound peak memory (one esbuild pipeline at a time instead of N simultaneous).
- **Fix: per-variant error isolation** — a single bundle failure no longer aborts the remaining variants; warming and invalidation still proceed.
- **Fix: CloudFront invalidation** — was silently a no-op because `CLOUDFRONT_DISTRIBUTION_ID` was only set on the codegen service, not WAB where `prefillCloudfront` runs. Now invalidates `code/published`, `repr-v2/published`, `repr-v3/published`, and `html/published` paths after warming.
- **Observability** — four-level span hierarchy in Datadog APM, per-fetch timing logs for warming, structured summary log at completion, failures via `captureException`.

## Changes

- `prefill-cloudfront.ts` — reorder phases (warm → isPrefilled → invalidate), sequential bundle loop, per-variant try/catch, `withSpan` for warming and invalidation phases, structured logging throughout
- `prefill-cloudfront.spec.ts` — refactored into `setupMocks()` helper + `beforeEach`/`afterEach`; added tests for warming ordering, URL construction, invalidation paths, per-variant bundle failure, warming failure resilience, env guard, and invalidation API error

## Span hierarchy in Datadog

```
loader-prefill-cloudfront        (total prefill, tags: project_id, pkg_version, variant_count)
  loader-prefill-bundle          (per variant — platform, loader_version, browser_only, app_dir)
    loader-resolve-deps          (already emitted by gen-code-bundle)
    loader-codegen               (already emitted by gen-code-bundle)
    loader-bundle                (already emitted by gen-code-bundle)
  loader-prefill-warming         (all CDN warm GETs in parallel)
  loader-prefill-invalidation    (single CloudFront API call)
```

## Structured log events

| Event | When | Key fields |
|---|---|---|
| `loader-prefill-start` | Function entry | `variant_count`, full `variants` array |
| `loader-prefill-warming-url` | Per CDN warm GET | `platform`, `loader_version`, `duration_ms`, `ok`, `status` |
| `loader-prefill-warming-summary` | After all GETs | `total`, `succeeded`, `failed` |
| `loader-prefill-invalidation-success` | After CF API call | `distribution_id`, `path_count`, `paths` |
| `loader-prefill-complete` | Function exit | `bundle_successes`, `bundle_failures`, `warming_variant_count` |

## Test plan

- [ ] Run `yarn test platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts`
- [ ] Deploy and run the loader publish-cycle perf test — post-publish versioned URL should advance to the new version on each iteration
- [ ] Check Datadog APM for `loader-prefill-cloudfront` root span with correct child spans
- [ ] Verify `loader-prefill-complete` appears in logs with correct counts after a publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)