### PR TITLE
feat(plasmic-mcp): install, config & auth flow

### DIFF
--- a/packages/plasmic-mcp/.env.example
+++ b/packages/plasmic-mcp/.env.example
@@ -1,0 +1,24 @@
+# Visual Builder MCP Server — Environment Variables
+#
+# All credentials are optional. The server starts in unauthenticated mode
+# if none are provided. Use `npx @elasticpath/plasmic-mcp auth` for
+# interactive setup, or set these variables for scripted/CI use.
+
+# Required: Visual Builder host URL
+# US East: https://useast.storefront.elasticpath.com
+# EU West: https://euwest.storefront.elasticpath.com
+PLASMIC_AUTH_HOST=https://useast.storefront.elasticpath.com
+
+# Required: Your account email
+PLASMIC_AUTH_USER=
+
+# Required: Your API token (from account settings)
+PLASMIC_AUTH_TOKEN=
+
+# Optional: Basic auth for internal/staging environments
+# PLASMIC_BASIC_AUTH_USER=
+# PLASMIC_BASIC_AUTH_PASSWORD=
+
+# Optional: Set to "desktop" when launched from Claude Desktop extension
+# (automatically set by .mcpb manifest — do not set manually)
+# PLASMIC_MCP_CLIENT=desktop

--- a/packages/plasmic-mcp/build-mcpb.mjs
+++ b/packages/plasmic-mcp/build-mcpb.mjs
@@ -1,0 +1,81 @@
+/**
+ * Build .mcpb extension for Claude Desktop.
+ *
+ * Creates a self-contained staging directory with:
+ * - manifest.json
+ * - server/index.cjs (the esbuild bundle)
+ * - node_modules/ (production dependencies only)
+ * - package.json (for npm install --production)
+ *
+ * Then packs it into a .mcpb file using @anthropic-ai/mcpb.
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const staging = path.resolve(__dirname, "dist/mcpb-staging");
+
+// Clean staging directory
+fs.rmSync(staging, { recursive: true, force: true });
+fs.mkdirSync(path.join(staging, "server"), { recursive: true });
+
+// Copy manifest
+fs.copyFileSync(
+  path.resolve(__dirname, "manifest.json"),
+  path.join(staging, "manifest.json")
+);
+
+// Copy built server bundle (without shebang — Claude Desktop runs it via node directly)
+const bundle = fs.readFileSync(path.resolve(__dirname, "dist/index.cjs"), "utf-8");
+const withoutShebang = bundle.replace(/^#!.*\n/, "");
+fs.writeFileSync(path.join(staging, "server/index.cjs"), withoutShebang);
+
+// Copy package.json for dependency installation
+fs.copyFileSync(
+  path.resolve(__dirname, "package.json"),
+  path.join(staging, "package.json")
+);
+
+// Install production dependencies into staging
+console.log("Installing production dependencies...");
+execSync("npm install --omit=dev --ignore-scripts --no-optional --legacy-peer-deps", {
+  cwd: staging,
+  stdio: "pipe",
+});
+
+// Remove devDependencies artifacts and unnecessary files to reduce size
+const nmPath = path.join(staging, "node_modules");
+const cleanPatterns = [
+  "**/.github",
+  "**/test",
+  "**/tests",
+  "**/__tests__",
+  "**/docs",
+  "**/example",
+  "**/examples",
+  "**/*.map",
+  "**/*.ts.map",
+  "**/CHANGELOG.md",
+  "**/HISTORY.md",
+];
+
+// Remove package.json from staging (not needed in final bundle)
+fs.unlinkSync(path.join(staging, "package.json"));
+// Remove package-lock.json if created
+try { fs.unlinkSync(path.join(staging, "package-lock.json")); } catch {}
+
+// Pack into .mcpb
+const output = path.resolve(__dirname, "dist/visual-builder.mcpb");
+console.log("Packing .mcpb...");
+execSync(`npx @anthropic-ai/mcpb pack "${staging}" "${output}"`, {
+  cwd: __dirname,
+  stdio: "inherit",
+});
+
+// Clean staging
+fs.rmSync(staging, { recursive: true, force: true });
+
+console.log(`\n✓ Built ${output}`);

--- a/packages/plasmic-mcp/build.mjs
+++ b/packages/plasmic-mcp/build.mjs
@@ -125,12 +125,15 @@ const result = await esbuild.build({
 const metafilePath = path.resolve(__dirname, "dist/meta.json");
 fs.writeFileSync(metafilePath, JSON.stringify(result.metafile, null, 2));
 
-// Add shebang for npx/bin execution
+// Add shebang and stdout protection.
+// CRITICAL: console.log = console.error MUST be the first executable line
+// (after shebang). Bundled WAB shared code contains console.log() calls that
+// would corrupt the JSON-RPC stdout transport in stdio mode.
 const outfile = path.resolve(__dirname, "dist/index.cjs");
 const built = fs.readFileSync(outfile, "utf-8");
-if (!built.startsWith("#!")) {
-  fs.writeFileSync(outfile, "#!/usr/bin/env node\n" + built);
-}
+const prefix = '#!/usr/bin/env node\nconsole.log = console.error;\n';
+const stripped = built.startsWith("#!") ? built.replace(/^#!.*\n/, "") : built;
+fs.writeFileSync(outfile, prefix + stripped);
 
 // Report
 const stats = fs.statSync(outfile);

--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -13,9 +13,9 @@
       "command": "node",
       "args": ["${__dirname}/server/index.cjs"],
       "env": {
-        "PLASMIC_AUTH_HOST": "{{host}}",
-        "PLASMIC_AUTH_USER": "{{email}}",
-        "PLASMIC_AUTH_TOKEN": "{{api_token}}",
+        "PLASMIC_AUTH_HOST": "${user_config.host}",
+        "PLASMIC_AUTH_USER": "${user_config.email}",
+        "PLASMIC_AUTH_TOKEN": "${user_config.api_token}",
         "PLASMIC_MCP_CLIENT": "desktop"
       }
     }

--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,35 +1,45 @@
 {
-  "manifest_version": "0.4",
+  "manifest_version": "0.2",
   "name": "Visual Builder",
+  "version": "0.1.3",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
-  "icon": "icon.png",
+  "author": {
+    "name": "Elastic Path"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.cjs",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.cjs"],
+      "env": {
+        "PLASMIC_AUTH_HOST": "{{host}}",
+        "PLASMIC_AUTH_USER": "{{email}}",
+        "PLASMIC_AUTH_TOKEN": "{{api_token}}",
+        "PLASMIC_MCP_CLIENT": "desktop"
+      }
+    }
+  },
   "user_config": {
     "host": {
+      "title": "Visual Builder Host",
       "type": "string",
       "description": "Visual Builder host URL. US East: https://useast.storefront.elasticpath.com (default), EU West: https://euwest.storefront.elasticpath.com, or your custom instance URL.",
       "default": "https://useast.storefront.elasticpath.com"
     },
     "email": {
+      "title": "Email Address",
       "type": "string",
       "description": "Your Visual Builder account email address.",
       "required": true
     },
     "api_token": {
+      "title": "API Token",
       "type": "string",
       "description": "Your Visual Builder API token. Found in your account settings.",
       "required": true,
       "sensitive": true
     }
   },
-  "mcp_config": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["-y", "@elasticpath/plasmic-mcp"],
-    "env": {
-      "PLASMIC_AUTH_HOST": "{{host}}",
-      "PLASMIC_AUTH_USER": "{{email}}",
-      "PLASMIC_AUTH_TOKEN": "{{api_token}}",
-      "PLASMIC_MCP_CLIENT": "desktop"
-    }
-  }
+  "license": "MIT"
 }

--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": "0.4",
+  "name": "Visual Builder",
+  "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
+  "icon": "icon.png",
+  "user_config": {
+    "host": {
+      "type": "string",
+      "description": "Visual Builder host URL. US East: https://useast.storefront.elasticpath.com (default), EU West: https://euwest.storefront.elasticpath.com, or your custom instance URL.",
+      "default": "https://useast.storefront.elasticpath.com"
+    },
+    "email": {
+      "type": "string",
+      "description": "Your Visual Builder account email address.",
+      "required": true
+    },
+    "api_token": {
+      "type": "string",
+      "description": "Your Visual Builder API token. Found in your account settings.",
+      "required": true,
+      "sensitive": true
+    }
+  },
+  "mcp_config": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["-y", "@elasticpath/plasmic-mcp"],
+    "env": {
+      "PLASMIC_AUTH_HOST": "{{host}}",
+      "PLASMIC_AUTH_USER": "{{email}}",
+      "PLASMIC_AUTH_TOKEN": "{{api_token}}",
+      "PLASMIC_MCP_CLIENT": "desktop"
+    }
+  }
+}

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -9,6 +9,7 @@
   "main": "./dist/index.cjs",
   "scripts": {
     "build": "node build.mjs",
+    "build:mcpb": "node build.mjs && rm -rf dist/mcpb-staging && mkdir -p dist/mcpb-staging/server && cp manifest.json dist/mcpb-staging/ && cp dist/index.cjs dist/mcpb-staging/server/ && npx @anthropic-ai/mcpb pack dist/mcpb-staging dist/visual-builder.mcpb && rm -rf dist/mcpb-staging",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -9,7 +9,7 @@
   "main": "./dist/index.cjs",
   "scripts": {
     "build": "node build.mjs",
-    "build:mcpb": "node build.mjs && rm -rf dist/mcpb-staging && mkdir -p dist/mcpb-staging/server && cp manifest.json dist/mcpb-staging/ && cp dist/index.cjs dist/mcpb-staging/server/ && npx @anthropic-ai/mcpb pack dist/mcpb-staging dist/visual-builder.mcpb && rm -rf dist/mcpb-staging",
+    "build:mcpb": "node build.mjs && node build-mcpb.mjs",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
@@ -23,6 +23,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@xmldom/xmldom": "^0.8.0",
+    "@plasmicapp/host": "*",
+    "@plasmicapp/loader-react": "*",
+    "@plasmicapp/react-web": "*",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "acorn": "^8.0.0",
     "acorn-walk": "^8.0.0",
     "class-validator": "^0.14.0",

--- a/packages/plasmic-mcp/src/__tests__/auth-flow.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/auth-flow.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for auth-flow.ts — browser init-token authentication.
+ *
+ * Mocks browser opening and socket.io to test the orchestration logic
+ * without requiring a real Plasmic server.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Shared mock holders for dynamic imports
+const _mocks = {
+  openFn: null as any,
+  socketConnect: null as any,
+  socketOn: null as any,
+  socketClose: null as any,
+  promptsFn: null as any,
+};
+
+async function loadAuthFlow() {
+  vi.resetModules();
+
+  vi.doMock("open", () => ({
+    default: (...args: any[]) => _mocks.openFn(...args),
+  }));
+
+  // Mock socket.io-client
+  vi.doMock("socket.io-client", () => ({
+    io: (...args: any[]) => {
+      _mocks.socketConnect(...args);
+      return {
+        on: (...onArgs: any[]) => _mocks.socketOn(...onArgs),
+        close: () => _mocks.socketClose(),
+      };
+    },
+  }));
+
+  vi.doMock("prompts", () => ({
+    default: (...args: any[]) => _mocks.promptsFn(...args),
+  }));
+
+  return await import("../auth-flow.js");
+}
+
+describe("acquireAuth", () => {
+  beforeEach(() => {
+    _mocks.openFn = vi.fn();
+    _mocks.socketConnect = vi.fn();
+    _mocks.socketOn = vi.fn();
+    _mocks.socketClose = vi.fn();
+    _mocks.promptsFn = vi.fn();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("opens browser with correct init-token URL", async () => {
+    // Socket.io mock that immediately emits "token" event
+    _mocks.socketOn = vi.fn((event: string, cb: Function) => {
+      if (event === "token") {
+        setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
+      }
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com");
+
+    expect(_mocks.openFn).toHaveBeenCalledOnce();
+    const url = _mocks.openFn.mock.calls[0][0] as string;
+    expect(url).toMatch(/^https:\/\/useast\.storefront\.elasticpath\.com\/auth\/plasmic-init\//);
+    // URL should contain a UUID-like init token
+    expect(url).toMatch(/\/[0-9a-f-]{36}$/);
+  });
+
+  it("returns AuthConfig on successful token callback", async () => {
+    _mocks.socketOn = vi.fn((event: string, cb: Function) => {
+      if (event === "token") {
+        setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
+      }
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com");
+
+    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
+    expect(result.user).toBe("u@test.com");
+    expect(result.token).toBe("tok123");
+  });
+
+  it("closes socket after receiving token", async () => {
+    _mocks.socketOn = vi.fn((event: string, cb: Function) => {
+      if (event === "token") {
+        setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
+      }
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    await acquireAuth("https://useast.storefront.elasticpath.com");
+
+    expect(_mocks.socketClose).toHaveBeenCalled();
+  });
+
+  it("falls back to manual entry on timeout", async () => {
+    // Socket never emits "token" — will timeout
+    _mocks.socketOn = vi.fn();
+
+    // Manual prompt returns credentials
+    _mocks.promptsFn = vi.fn().mockResolvedValue({
+      user: "manual@test.com",
+      token: "manual_tok",
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    // Use short timeout for testing
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com", { timeoutMs: 50 });
+
+    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
+    expect(result.user).toBe("manual@test.com");
+    expect(result.token).toBe("manual_tok");
+  });
+
+  it("strips trailing slash from host", async () => {
+    _mocks.socketOn = vi.fn((event: string, cb: Function) => {
+      if (event === "token") {
+        setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
+      }
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com/");
+
+    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/auth-flow.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/auth-flow.test.ts
@@ -1,13 +1,12 @@
 /**
- * Unit tests for auth-flow.ts — browser init-token authentication.
+ * Unit tests for auth-flow.ts — interactive and browser-based authentication.
  *
- * Mocks browser opening and socket.io to test the orchestration logic
- * without requiring a real Plasmic server.
+ * Default flow uses terminal prompts. Browser init-token flow is available
+ * via { browser: true } option (deferred until CM supports the route).
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-// Shared mock holders for dynamic imports
 const _mocks = {
   openFn: null as any,
   socketConnect: null as any,
@@ -23,7 +22,6 @@ async function loadAuthFlow() {
     default: (...args: any[]) => _mocks.openFn(...args),
   }));
 
-  // Mock socket.io-client
   vi.doMock("socket.io-client", () => ({
     io: (...args: any[]) => {
       _mocks.socketConnect(...args);
@@ -41,7 +39,70 @@ async function loadAuthFlow() {
   return await import("../auth-flow.js");
 }
 
-describe("acquireAuth", () => {
+describe("acquireAuth — prompt flow (default)", () => {
+  beforeEach(() => {
+    _mocks.openFn = vi.fn();
+    _mocks.socketConnect = vi.fn();
+    _mocks.socketOn = vi.fn();
+    _mocks.socketClose = vi.fn();
+    _mocks.promptsFn = vi.fn();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns AuthConfig from prompted credentials", async () => {
+    _mocks.promptsFn = vi.fn().mockResolvedValue({
+      user: "user@example.com",
+      token: "tok_abc123",
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com");
+
+    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
+    expect(result.user).toBe("user@example.com");
+    expect(result.token).toBe("tok_abc123");
+  });
+
+  it("strips trailing slash from host", async () => {
+    _mocks.promptsFn = vi.fn().mockResolvedValue({
+      user: "user@example.com",
+      token: "tok_abc123",
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com/");
+
+    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
+  });
+
+  it("throws when user cancels prompts", async () => {
+    _mocks.promptsFn = vi.fn().mockResolvedValue({});
+
+    const { acquireAuth } = await loadAuthFlow();
+    await expect(acquireAuth("https://useast.storefront.elasticpath.com")).rejects.toThrow(
+      "Authentication cancelled"
+    );
+  });
+
+  it("does not open browser", async () => {
+    _mocks.promptsFn = vi.fn().mockResolvedValue({
+      user: "user@example.com",
+      token: "tok_abc123",
+    });
+
+    const { acquireAuth } = await loadAuthFlow();
+    await acquireAuth("https://useast.storefront.elasticpath.com");
+
+    expect(_mocks.openFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("acquireAuth — browser flow ({ browser: true })", () => {
   beforeEach(() => {
     _mocks.openFn = vi.fn();
     _mocks.socketConnect = vi.fn();
@@ -57,7 +118,6 @@ describe("acquireAuth", () => {
   });
 
   it("opens browser with correct init-token URL", async () => {
-    // Socket.io mock that immediately emits "token" event
     _mocks.socketOn = vi.fn((event: string, cb: Function) => {
       if (event === "token") {
         setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
@@ -65,12 +125,11 @@ describe("acquireAuth", () => {
     });
 
     const { acquireAuth } = await loadAuthFlow();
-    const result = await acquireAuth("https://useast.storefront.elasticpath.com");
+    await acquireAuth("https://useast.storefront.elasticpath.com", { browser: true });
 
     expect(_mocks.openFn).toHaveBeenCalledOnce();
     const url = _mocks.openFn.mock.calls[0][0] as string;
     expect(url).toMatch(/^https:\/\/useast\.storefront\.elasticpath\.com\/auth\/plasmic-init\//);
-    // URL should contain a UUID-like init token
     expect(url).toMatch(/\/[0-9a-f-]{36}$/);
   });
 
@@ -82,7 +141,7 @@ describe("acquireAuth", () => {
     });
 
     const { acquireAuth } = await loadAuthFlow();
-    const result = await acquireAuth("https://useast.storefront.elasticpath.com");
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com", { browser: true });
 
     expect(result.host).toBe("https://useast.storefront.elasticpath.com");
     expect(result.user).toBe("u@test.com");
@@ -97,40 +156,26 @@ describe("acquireAuth", () => {
     });
 
     const { acquireAuth } = await loadAuthFlow();
-    await acquireAuth("https://useast.storefront.elasticpath.com");
+    await acquireAuth("https://useast.storefront.elasticpath.com", { browser: true });
 
     expect(_mocks.socketClose).toHaveBeenCalled();
   });
 
   it("falls back to manual entry on timeout", async () => {
-    // Socket never emits "token" — will timeout
     _mocks.socketOn = vi.fn();
-
-    // Manual prompt returns credentials
     _mocks.promptsFn = vi.fn().mockResolvedValue({
       user: "manual@test.com",
       token: "manual_tok",
     });
 
     const { acquireAuth } = await loadAuthFlow();
-    // Use short timeout for testing
-    const result = await acquireAuth("https://useast.storefront.elasticpath.com", { timeoutMs: 50 });
+    const result = await acquireAuth("https://useast.storefront.elasticpath.com", {
+      browser: true,
+      timeoutMs: 50,
+    });
 
     expect(result.host).toBe("https://useast.storefront.elasticpath.com");
     expect(result.user).toBe("manual@test.com");
     expect(result.token).toBe("manual_tok");
-  });
-
-  it("strips trailing slash from host", async () => {
-    _mocks.socketOn = vi.fn((event: string, cb: Function) => {
-      if (event === "token") {
-        setTimeout(() => cb({ user: "u@test.com", token: "tok123" }), 10);
-      }
-    });
-
-    const { acquireAuth } = await loadAuthFlow();
-    const result = await acquireAuth("https://useast.storefront.elasticpath.com/");
-
-    expect(result.host).toBe("https://useast.storefront.elasticpath.com");
   });
 });

--- a/packages/plasmic-mcp/src/__tests__/auth-guard.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/auth-guard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for auth-guard.ts — auth enforcement with context-aware messages.
+ *
+ * The auth guard is called by tool handlers to ensure the API client is
+ * authenticated before making API calls. Returns the client if authenticated,
+ * throws a descriptive error with client-specific instructions if not.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { requireAuth, getAuthErrorMessage } from "../auth-guard.js";
+
+describe("requireAuth", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...savedEnv };
+    delete process.env.PLASMIC_MCP_CLIENT;
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it("returns the client when non-null", () => {
+    const fakeClient = { getAuth: () => ({ host: "h", user: "u", token: "t" }) };
+    const result = requireAuth(fakeClient as any);
+    expect(result).toBe(fakeClient);
+  });
+
+  it("throws with CLI-specific message when null and no PLASMIC_MCP_CLIENT", () => {
+    expect(() => requireAuth(null)).toThrow("plasmic-mcp auth");
+  });
+
+  it("throws with Desktop-specific message when PLASMIC_MCP_CLIENT=desktop", () => {
+    process.env.PLASMIC_MCP_CLIENT = "desktop";
+    expect(() => requireAuth(null)).toThrow("extension settings");
+  });
+});
+
+describe("getAuthErrorMessage", () => {
+  it("returns CLI instructions by default", () => {
+    const msg = getAuthErrorMessage();
+    expect(msg).toContain("plasmic-mcp auth");
+    expect(msg).toContain("PLASMIC_AUTH");
+  });
+
+  it("returns Desktop instructions for desktop client", () => {
+    const msg = getAuthErrorMessage("desktop");
+    expect(msg).toContain("extension settings");
+    expect(msg).not.toContain("plasmic-mcp auth");
+  });
+
+  it("includes actionable steps", () => {
+    const msg = getAuthErrorMessage();
+    expect(msg).toContain("Visual Builder");
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/auth.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/auth.test.ts
@@ -14,37 +14,56 @@ import { vi, describe, it, expect, beforeEach, afterEach, afterAll } from "vites
 // via the module-level object so closures are not needed.
 const _authMocks = {
   fsReadFileSync: null as any,
+  fsWriteFileSync: null as any,
+  fsChmodSync: null as any,
+  osMkdirSync: null as any,
   osHomedir: null as any,
 };
 
+/**
+ * Load auth module with mocked fs and os modules.
+ * Uses vi.resetModules() to ensure the auth module picks up fresh mocks.
+ */
+async function loadAuthWithMocks(opts: {
+  fsReadFileSync: ReturnType<typeof vi.fn>;
+  osHomedir: ReturnType<typeof vi.fn>;
+  fsWriteFileSync?: ReturnType<typeof vi.fn>;
+  fsChmodSync?: ReturnType<typeof vi.fn>;
+}) {
+  _authMocks.fsReadFileSync = opts.fsReadFileSync;
+  _authMocks.fsWriteFileSync = opts.fsWriteFileSync ?? vi.fn();
+  _authMocks.fsChmodSync = opts.fsChmodSync ?? vi.fn();
+  _authMocks.osHomedir = opts.osHomedir;
+  vi.resetModules();
+  vi.doMock("fs", () => ({
+    readFileSync: (...args: any[]) => _authMocks.fsReadFileSync(...args),
+    writeFileSync: (...args: any[]) => _authMocks.fsWriteFileSync(...args),
+    chmodSync: (...args: any[]) => _authMocks.fsChmodSync(...args),
+    mkdirSync: (...args: any[]) => (_authMocks.osMkdirSync ?? vi.fn())(...args),
+  }));
+  vi.doMock("path", async () => await vi.importActual("path"));
+  vi.doMock("os", () => ({
+    homedir: () => _authMocks.osHomedir(),
+  }));
+  return await import("../auth");
+}
+
+/** Shorthand for tests that only need getAuth. */
+async function loadGetAuthWithMocks(fsReadFileSync: ReturnType<typeof vi.fn>, osHomedir: ReturnType<typeof vi.fn>) {
+  const mod = await loadAuthWithMocks({ fsReadFileSync, osHomedir });
+  return mod.getAuth;
+}
+
+function clearAuthEnv() {
+  delete process.env.PLASMIC_AUTH_HOST;
+  delete process.env.PLASMIC_AUTH_USER;
+  delete process.env.PLASMIC_AUTH_TOKEN;
+  delete process.env.PLASMIC_BASIC_AUTH_USER;
+  delete process.env.PLASMIC_BASIC_AUTH_PASSWORD;
+}
+
 describe("getAuth", () => {
   const savedEnv = { ...process.env };
-
-  function clearAuthEnv() {
-    delete process.env.PLASMIC_AUTH_HOST;
-    delete process.env.PLASMIC_AUTH_USER;
-    delete process.env.PLASMIC_AUTH_TOKEN;
-    delete process.env.PLASMIC_BASIC_AUTH_USER;
-    delete process.env.PLASMIC_BASIC_AUTH_PASSWORD;
-  }
-
-  /**
-   * Load getAuth with mocked fs and os modules.
-   * Uses vi.resetModules() to ensure the auth module picks up fresh mocks.
-   */
-  async function loadGetAuthWithMocks(fsReadFileSync: ReturnType<typeof vi.fn>, osHomedir: ReturnType<typeof vi.fn>) {
-    _authMocks.fsReadFileSync = fsReadFileSync;
-    _authMocks.osHomedir = osHomedir;
-    vi.resetModules();
-    vi.doMock("fs", () => ({
-      readFileSync: (...args: any[]) => _authMocks.fsReadFileSync(...args),
-    }));
-    vi.doMock("path", async () => await vi.importActual("path"));
-    vi.doMock("os", () => ({
-      homedir: () => _authMocks.osHomedir(),
-    }));
-    return (await import("../auth")).getAuth as typeof import("../auth")["getAuth"];
-  }
 
   beforeEach(() => {
     process.env = { ...savedEnv };
@@ -129,7 +148,8 @@ describe("getAuth", () => {
       vi.fn(() => { throw new Error("ENOENT"); }),
       vi.fn(() => "/mock/home")
     );
-    expect(() => getAuth()).toThrow("Plasmic authentication required");
+    const auth = getAuth();
+    expect(auth).toBeNull();
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Partial Plasmic auth env vars")
     );
@@ -177,7 +197,7 @@ describe("getAuth", () => {
     expect(auth.host).toBe("https://file-host.example.com");
   });
 
-  it("skips auth file with incomplete fields", async () => {
+  it("skips auth file with incomplete fields and returns null", async () => {
     const mockReadFileSync = vi.fn((filePath: any) => {
       if (String(filePath).endsWith(".plasmic.auth")) {
         // Missing token field
@@ -190,7 +210,7 @@ describe("getAuth", () => {
       mockReadFileSync,
       vi.fn(() => "/mock/home")
     );
-    expect(() => getAuth()).toThrow("Plasmic authentication required");
+    expect(getAuth()).toBeNull();
   });
 
   it("warns when auth file has invalid JSON instead of silently ignoring", async () => {
@@ -205,8 +225,8 @@ describe("getAuth", () => {
       mockReadFileSync,
       vi.fn(() => "/mock/home")
     );
-    // Should still throw because no valid auth is found
-    expect(() => getAuth()).toThrow("Plasmic authentication required");
+    // Should return null because no valid auth is found
+    expect(getAuth()).toBeNull();
     // But should warn about the malformed file
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("could not read it")
@@ -221,7 +241,7 @@ describe("getAuth", () => {
       mockReadFileSync,
       vi.fn(() => "/mock/home")
     );
-    expect(() => getAuth()).toThrow("Plasmic authentication required");
+    expect(getAuth()).toBeNull();
     // Should NOT warn about missing files (expected case)
     const errorCalls = (console.error as ReturnType<typeof vi.fn>).mock.calls;
     const warningCalls = errorCalls.filter(
@@ -230,14 +250,135 @@ describe("getAuth", () => {
     expect(warningCalls).toHaveLength(0);
   });
 
-  it("throws descriptive error when no auth source available", async () => {
+  it("returns null when no auth source available", async () => {
     const getAuth = await loadGetAuthWithMocks(
       vi.fn(() => { throw new Error("ENOENT"); }),
       vi.fn(() => "/mock/home")
     );
-    expect(() => getAuth()).toThrow("Plasmic authentication required");
-    expect(() => getAuth()).toThrow("PLASMIC_AUTH_HOST");
-    expect(() => getAuth()).toThrow("PLASMIC_AUTH_USER");
-    expect(() => getAuth()).toThrow("PLASMIC_AUTH_TOKEN");
+    expect(getAuth()).toBeNull();
+  });
+});
+
+describe("writeAuth", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...savedEnv };
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  afterAll(() => {
+    process.env = savedEnv;
+  });
+
+  it("writes JSON credentials to ~/.plasmic.auth", async () => {
+    const mockWriteFileSync = vi.fn();
+    const mockChmodSync = vi.fn();
+
+    const { writeAuth } = await loadAuthWithMocks({
+      fsReadFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+      osHomedir: vi.fn(() => "/mock/home"),
+      fsWriteFileSync: mockWriteFileSync,
+      fsChmodSync: mockChmodSync,
+    });
+
+    writeAuth({
+      host: "https://useast.storefront.elasticpath.com",
+      user: "user@example.com",
+      token: "tok_abc123",
+    });
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const [filePath, content] = mockWriteFileSync.mock.calls[0];
+    expect(filePath).toContain(".plasmic.auth");
+    const parsed = JSON.parse(content);
+    expect(parsed.host).toBe("https://useast.storefront.elasticpath.com");
+    expect(parsed.user).toBe("user@example.com");
+    expect(parsed.token).toBe("tok_abc123");
+  });
+
+  it("sets file permissions to 0600", async () => {
+    const mockWriteFileSync = vi.fn();
+    const mockChmodSync = vi.fn();
+
+    const { writeAuth } = await loadAuthWithMocks({
+      fsReadFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+      osHomedir: vi.fn(() => "/mock/home"),
+      fsWriteFileSync: mockWriteFileSync,
+      fsChmodSync: mockChmodSync,
+    });
+
+    writeAuth({
+      host: "https://useast.storefront.elasticpath.com",
+      user: "user@example.com",
+      token: "tok_abc123",
+    });
+
+    expect(mockChmodSync).toHaveBeenCalledOnce();
+    const [filePath, mode] = mockChmodSync.mock.calls[0];
+    expect(filePath).toContain(".plasmic.auth");
+    expect(mode).toBe(0o600);
+  });
+
+  it("writes to custom path when provided", async () => {
+    const mockWriteFileSync = vi.fn();
+    const mockChmodSync = vi.fn();
+
+    const { writeAuth } = await loadAuthWithMocks({
+      fsReadFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+      osHomedir: vi.fn(() => "/mock/home"),
+      fsWriteFileSync: mockWriteFileSync,
+      fsChmodSync: mockChmodSync,
+    });
+
+    writeAuth(
+      {
+        host: "https://euwest.storefront.elasticpath.com",
+        user: "user@example.com",
+        token: "tok_xyz789",
+      },
+      "/custom/path/.plasmic.auth"
+    );
+
+    const [filePath] = mockWriteFileSync.mock.calls[0];
+    expect(filePath).toBe("/custom/path/.plasmic.auth");
+  });
+
+  it("round-trips: writeAuth then getAuth returns same credentials", async () => {
+    // In-memory file store
+    const fileStore: Record<string, string> = {};
+
+    const mockWriteFileSync = vi.fn((filePath: string, content: string) => {
+      fileStore[filePath] = content;
+    });
+    const mockReadFileSync = vi.fn((filePath: string) => {
+      if (fileStore[filePath]) return fileStore[filePath];
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const { writeAuth, getAuth } = await loadAuthWithMocks({
+      fsReadFileSync: mockReadFileSync,
+      osHomedir: vi.fn(() => "/mock/home"),
+      fsWriteFileSync: mockWriteFileSync,
+      fsChmodSync: vi.fn(),
+    });
+
+    const config = {
+      host: "https://useast.storefront.elasticpath.com",
+      user: "roundtrip@example.com",
+      token: "tok_roundtrip",
+    };
+
+    writeAuth(config, "/mock/home/.plasmic.auth");
+    const readBack = getAuth();
+    expect(readBack).not.toBeNull();
+    expect(readBack!.host).toBe(config.host);
+    expect(readBack!.user).toBe(config.user);
+    expect(readBack!.token).toBe(config.token);
   });
 });

--- a/packages/plasmic-mcp/src/__tests__/cli.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/cli.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for cli.ts — CLI argument parser.
+ *
+ * The CLI router parses process.argv to determine which command to run:
+ * - No args → serve (start MCP server)
+ * - "auth" → authenticate
+ * - "--version" → print version
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../cli.js";
+
+describe("parseArgs", () => {
+  // argv[0] = node, argv[1] = script path, argv[2+] = user args
+  const base = ["/usr/bin/node", "/path/to/plasmic-mcp"];
+
+  it("defaults to serve when no args", () => {
+    const result = parseArgs([...base]);
+    expect(result.command).toBe("serve");
+  });
+
+  it("parses auth command", () => {
+    const result = parseArgs([...base, "auth"]);
+    expect(result.command).toBe("auth");
+  });
+
+  it("parses auth --host flag", () => {
+    const result = parseArgs([...base, "auth", "--host", "https://useast.storefront.elasticpath.com"]);
+    expect(result.command).toBe("auth");
+    expect(result.options.host).toBe("https://useast.storefront.elasticpath.com");
+  });
+
+  it("parses --version flag", () => {
+    const result = parseArgs([...base, "--version"]);
+    expect(result.command).toBe("version");
+  });
+
+  it("defaults to serve on unknown command", () => {
+    const result = parseArgs([...base, "unknown-thing"]);
+    expect(result.command).toBe("serve");
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/entry-point.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/entry-point.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the entry point wiring (index.ts).
+ *
+ * Verifies that the CLI router correctly dispatches to:
+ * - serve → starts the MCP server
+ * - auth → runs the auth flow and writes credentials
+ * - version → prints version and exits
+ *
+ * Since index.ts is the process entry point, we test via the runCli() function
+ * that will be extracted from main().
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { parseArgs } from "../cli.js";
+
+describe("CLI dispatch via parseArgs", () => {
+  it("routes no-args to serve", () => {
+    const result = parseArgs(["/usr/bin/node", "/path/to/plasmic-mcp"]);
+    expect(result.command).toBe("serve");
+  });
+
+  it("routes auth to auth command", () => {
+    const result = parseArgs(["/usr/bin/node", "/path/to/plasmic-mcp", "auth"]);
+    expect(result.command).toBe("auth");
+  });
+
+  it("routes --version to version command", () => {
+    const result = parseArgs(["/usr/bin/node", "/path/to/plasmic-mcp", "--version"]);
+    expect(result.command).toBe("version");
+  });
+
+  it("passes --host to auth options", () => {
+    const result = parseArgs([
+      "/usr/bin/node", "/path/to/plasmic-mcp",
+      "auth", "--host", "https://euwest.storefront.elasticpath.com"
+    ]);
+    expect(result.command).toBe("auth");
+    expect(result.options.host).toBe("https://euwest.storefront.elasticpath.com");
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/health-check.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/health-check.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the health-check tool.
+ *
+ * The health check returns server version and auth status without requiring
+ * authentication, making it the one tool that works in unauthenticated mode.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
+
+describe("health-check tool", () => {
+  const savedEnv = { ...process.env };
+  let client: any;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    process.env = { ...savedEnv };
+  });
+
+  afterAll(() => {
+    process.env = savedEnv;
+  });
+
+  async function setupServer(withAuth: boolean) {
+    if (withAuth) {
+      process.env.PLASMIC_AUTH_HOST = "https://useast.storefront.elasticpath.com";
+      process.env.PLASMIC_AUTH_USER = "test@example.com";
+      process.env.PLASMIC_AUTH_TOKEN = "test-token";
+    } else {
+      delete process.env.PLASMIC_AUTH_HOST;
+      delete process.env.PLASMIC_AUTH_USER;
+      delete process.env.PLASMIC_AUTH_TOKEN;
+    }
+
+    vi.resetModules();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.doMock("mobx", () => {
+      const mock = { configure: vi.fn() };
+      return { ...mock, default: mock };
+    });
+    vi.doMock("fs", () => {
+      const mock = {
+        readFileSync: () => { throw new Error("ENOENT"); },
+        writeFileSync: vi.fn(),
+      };
+      return { ...mock, default: mock };
+    });
+    vi.doMock("os", () => {
+      const mock = { homedir: () => "/mock/home", tmpdir: () => "/tmp" };
+      return { ...mock, default: mock };
+    });
+
+    const { createServer } = await import("../server");
+    const mcpServer = createServer();
+
+    const { InMemoryTransport } = await import("@modelcontextprotocol/sdk/inMemory.js");
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mcpServer.connect(serverTransport);
+    client = new Client({ name: "test-client", version: "1.0" });
+    await client.connect(clientTransport);
+  }
+
+  it("returns version and authenticated status when auth is present", async () => {
+    await setupServer(true);
+
+    const result = await client.callTool({
+      name: "project",
+      arguments: { action: "health-check" },
+    });
+
+    const text = (result.content as any[])[0]?.text;
+    const parsed = JSON.parse(text);
+    expect(parsed.status).toBe("ok");
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.host).toBe("https://useast.storefront.elasticpath.com");
+    expect(parsed.version).toBeDefined();
+
+    await client.close();
+  });
+
+  it("returns version and unauthenticated status when no auth", async () => {
+    await setupServer(false);
+
+    const result = await client.callTool({
+      name: "project",
+      arguments: { action: "health-check" },
+    });
+
+    const text = (result.content as any[])[0]?.text;
+    const parsed = JSON.parse(text);
+    expect(parsed.status).toBe("ok");
+    expect(parsed.authenticated).toBe(false);
+    expect(parsed.host).toBeUndefined();
+    expect(parsed.version).toBeDefined();
+
+    await client.close();
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/manifest.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/manifest.test.ts
@@ -50,9 +50,9 @@ describe("mcpb manifest", () => {
 
   it("maps env vars correctly in server.mcp_config", () => {
     const env = manifest.server.mcp_config.env;
-    expect(env.PLASMIC_AUTH_HOST).toBe("{{host}}");
-    expect(env.PLASMIC_AUTH_USER).toBe("{{email}}");
-    expect(env.PLASMIC_AUTH_TOKEN).toBe("{{api_token}}");
+    expect(env.PLASMIC_AUTH_HOST).toBe("${user_config.host}");
+    expect(env.PLASMIC_AUTH_USER).toBe("${user_config.email}");
+    expect(env.PLASMIC_AUTH_TOKEN).toBe("${user_config.api_token}");
     expect(env.PLASMIC_MCP_CLIENT).toBe("desktop");
   });
 

--- a/packages/plasmic-mcp/src/__tests__/manifest.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/manifest.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Structural validation tests for the .mcpb manifest.
+ *
+ * Ensures the Claude Desktop extension manifest has the correct v0.4 format,
+ * required user_config fields, sensitive marking on api_token, and proper
+ * environment variable mapping.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const MANIFEST_PATH = path.resolve(__dirname, "../../manifest.json");
+
+describe("mcpb manifest", () => {
+  let manifest: any;
+
+  // Read manifest once for all tests
+  try {
+    manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf-8"));
+  } catch {
+    manifest = null;
+  }
+
+  it("exists and is valid JSON", () => {
+    expect(manifest).not.toBeNull();
+  });
+
+  it("has v0.4 manifest version", () => {
+    expect(manifest.manifest_version).toBe("0.4");
+  });
+
+  it("has required user_config fields: host, email, api_token", () => {
+    const fields = manifest.user_config;
+    expect(fields).toBeDefined();
+    expect(fields.host).toBeDefined();
+    expect(fields.email).toBeDefined();
+    expect(fields.api_token).toBeDefined();
+  });
+
+  it("marks api_token as sensitive", () => {
+    expect(manifest.user_config.api_token.sensitive).toBe(true);
+  });
+
+  it("host has a default value pointing to US East", () => {
+    expect(manifest.user_config.host.default).toBe(
+      "https://useast.storefront.elasticpath.com"
+    );
+  });
+
+  it("maps env vars correctly in mcp_config", () => {
+    const env = manifest.mcp_config.env;
+    expect(env.PLASMIC_AUTH_HOST).toBe("{{host}}");
+    expect(env.PLASMIC_AUTH_USER).toBe("{{email}}");
+    expect(env.PLASMIC_AUTH_TOKEN).toBe("{{api_token}}");
+    expect(env.PLASMIC_MCP_CLIENT).toBe("desktop");
+  });
+
+  it("uses stdio transport", () => {
+    expect(manifest.mcp_config.transport).toBe("stdio");
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/manifest.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/manifest.test.ts
@@ -1,7 +1,7 @@
 /**
  * Structural validation tests for the .mcpb manifest.
  *
- * Ensures the Claude Desktop extension manifest has the correct v0.4 format,
+ * Ensures the Claude Desktop extension manifest has the correct format,
  * required user_config fields, sensitive marking on api_token, and proper
  * environment variable mapping.
  */
@@ -26,8 +26,8 @@ describe("mcpb manifest", () => {
     expect(manifest).not.toBeNull();
   });
 
-  it("has v0.4 manifest version", () => {
-    expect(manifest.manifest_version).toBe("0.4");
+  it("has manifest_version", () => {
+    expect(manifest.manifest_version).toBeDefined();
   });
 
   it("has required user_config fields: host, email, api_token", () => {
@@ -48,15 +48,15 @@ describe("mcpb manifest", () => {
     );
   });
 
-  it("maps env vars correctly in mcp_config", () => {
-    const env = manifest.mcp_config.env;
+  it("maps env vars correctly in server.mcp_config", () => {
+    const env = manifest.server.mcp_config.env;
     expect(env.PLASMIC_AUTH_HOST).toBe("{{host}}");
     expect(env.PLASMIC_AUTH_USER).toBe("{{email}}");
     expect(env.PLASMIC_AUTH_TOKEN).toBe("{{api_token}}");
     expect(env.PLASMIC_MCP_CLIENT).toBe("desktop");
   });
 
-  it("uses stdio transport", () => {
-    expect(manifest.mcp_config.transport).toBe("stdio");
+  it("uses node server type", () => {
+    expect(manifest.server.type).toBe("node");
   });
 });

--- a/packages/plasmic-mcp/src/__tests__/server.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/server.test.ts
@@ -63,7 +63,7 @@ describe("createServer", () => {
     expect(server).toBeDefined();
   });
 
-  it("throws when auth is not configured", async () => {
+  it("starts without auth (graceful unauthenticated mode)", async () => {
     delete process.env.PLASMIC_AUTH_HOST;
     delete process.env.PLASMIC_AUTH_USER;
     delete process.env.PLASMIC_AUTH_TOKEN;
@@ -86,7 +86,50 @@ describe("createServer", () => {
     });
 
     const { createServer } = await import("../server");
-    expect(() => createServer()).toThrow("Plasmic authentication required");
+    const server = createServer();
+    expect(server).toBeDefined();
+  });
+
+  it("returns content-level auth error when tool called without credentials", async () => {
+    delete process.env.PLASMIC_AUTH_HOST;
+    delete process.env.PLASMIC_AUTH_USER;
+    delete process.env.PLASMIC_AUTH_TOKEN;
+
+    vi.resetModules();
+    vi.doMock("mobx", () => {
+      const mock = { configure: vi.fn() };
+      return { ...mock, default: mock };
+    });
+    vi.doMock("fs", () => {
+      const mock = {
+        readFileSync: () => { throw new Error("ENOENT"); },
+        writeFileSync: vi.fn(),
+      };
+      return { ...mock, default: mock };
+    });
+    vi.doMock("os", () => {
+      const mock = { homedir: () => "/mock/home", tmpdir: () => "/tmp" };
+      return { ...mock, default: mock };
+    });
+
+    const { createServer } = await import("../server");
+    const mcpServer = createServer();
+
+    const { InMemoryTransport } = await import("@modelcontextprotocol/sdk/inMemory.js");
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mcpServer.connect(serverTransport);
+    const client = new Client({ name: "test-client", version: "1.0" });
+    await client.connect(clientTransport);
+
+    // Call project.list — should get a content-level auth error, not a protocol error
+    const result = await client.callTool({ name: "project", arguments: { action: "list" } });
+    expect(result.content).toBeDefined();
+    const text = (result.content as any[])[0]?.text;
+    expect(text).toContain("authentication required");
+
+    await client.close();
   });
 });
 

--- a/packages/plasmic-mcp/src/auth-flow.ts
+++ b/packages/plasmic-mcp/src/auth-flow.ts
@@ -1,13 +1,14 @@
 /**
- * Browser-based init-token authentication flow.
+ * Authentication flow for the MCP server.
  *
- * Replicates the Plasmic CLI's auth pattern:
- * 1. Generate a UUID init token
- * 2. Open browser to {host}/auth/plasmic-init/{initToken}
- * 3. Listen via socket.io on /api/v1/init-token for the token callback
- * 4. Write credentials to ~/.plasmic.auth
+ * Default: interactive credential entry via terminal prompts.
  *
- * Falls back to manual credential entry if the browser flow times out.
+ * Browser-based init-token flow (deferred): replicates the Plasmic CLI's
+ * auth pattern — generate UUID init token, open browser to
+ * {host}/auth/plasmic-init/{initToken}, listen via socket.io for callback.
+ * Currently disabled because EP-hosted environments redirect unauthenticated
+ * users to Commerce Manager, which doesn't yet support the init-token route.
+ * Enable with `{ browser: true }` once a CM route is available.
  *
  * Reference: packages/cli/src/utils/auth-utils.ts
  */
@@ -19,6 +20,8 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 
 export interface AcquireAuthOptions {
   timeoutMs?: number;
+  /** Use browser-based init-token flow instead of terminal prompts. */
+  browser?: boolean;
 }
 
 export async function acquireAuth(
@@ -26,24 +29,39 @@ export async function acquireAuth(
   options?: AcquireAuthOptions
 ): Promise<AuthConfig> {
   const cleanHost = host.replace(/\/+$/, "");
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
+  if (options?.browser) {
+    return browserFlow(cleanHost, options?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  }
+
+  console.error("[plasmic-mcp] Visual Builder authentication");
+  console.error(`[plasmic-mcp] Host: ${cleanHost}`);
+  console.error("[plasmic-mcp] Enter your credentials (from your account settings):\n");
+
+  return manualEntry(cleanHost);
+}
+
+// ---------------------------------------------------------------------------
+// Browser init-token flow (deferred — enable when CM supports the route)
+// ---------------------------------------------------------------------------
+
+async function browserFlow(
+  host: string,
+  timeoutMs: number
+): Promise<AuthConfig> {
   const initToken = randomUUID();
-  const authUrl = `${cleanHost}/auth/plasmic-init/${initToken}`;
+  const authUrl = `${host}/auth/plasmic-init/${initToken}`;
 
-  // Open browser
   const open = (await import("open")).default;
   await open(authUrl);
   console.error(`[plasmic-mcp] Opened browser for authentication: ${authUrl}`);
 
-  // Try socket.io polling for the token
   try {
-    const authData = await pollForToken(cleanHost, initToken, timeoutMs);
-    return { host: cleanHost, user: authData.user, token: authData.token };
+    const authData = await pollForToken(host, initToken, timeoutMs);
+    return { host, user: authData.user, token: authData.token };
   } catch {
-    // Timeout — fall back to manual entry
     console.error("[plasmic-mcp] Browser auth timed out, falling back to manual entry");
-    return manualEntry(cleanHost);
+    return manualEntry(host);
   }
 }
 
@@ -89,6 +107,10 @@ function pollForToken(
     });
   });
 }
+
+// ---------------------------------------------------------------------------
+// Manual credential entry (current default)
+// ---------------------------------------------------------------------------
 
 async function manualEntry(host: string): Promise<AuthConfig> {
   const prompts = (await import("prompts")).default;

--- a/packages/plasmic-mcp/src/auth-flow.ts
+++ b/packages/plasmic-mcp/src/auth-flow.ts
@@ -1,0 +1,114 @@
+/**
+ * Browser-based init-token authentication flow.
+ *
+ * Replicates the Plasmic CLI's auth pattern:
+ * 1. Generate a UUID init token
+ * 2. Open browser to {host}/auth/plasmic-init/{initToken}
+ * 3. Listen via socket.io on /api/v1/init-token for the token callback
+ * 4. Write credentials to ~/.plasmic.auth
+ *
+ * Falls back to manual credential entry if the browser flow times out.
+ *
+ * Reference: packages/cli/src/utils/auth-utils.ts
+ */
+
+import { randomUUID } from "crypto";
+import type { AuthConfig } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface AcquireAuthOptions {
+  timeoutMs?: number;
+}
+
+export async function acquireAuth(
+  host: string,
+  options?: AcquireAuthOptions
+): Promise<AuthConfig> {
+  const cleanHost = host.replace(/\/+$/, "");
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const initToken = randomUUID();
+  const authUrl = `${cleanHost}/auth/plasmic-init/${initToken}`;
+
+  // Open browser
+  const open = (await import("open")).default;
+  await open(authUrl);
+  console.error(`[plasmic-mcp] Opened browser for authentication: ${authUrl}`);
+
+  // Try socket.io polling for the token
+  try {
+    const authData = await pollForToken(cleanHost, initToken, timeoutMs);
+    return { host: cleanHost, user: authData.user, token: authData.token };
+  } catch {
+    // Timeout — fall back to manual entry
+    console.error("[plasmic-mcp] Browser auth timed out, falling back to manual entry");
+    return manualEntry(cleanHost);
+  }
+}
+
+interface AuthData {
+  user: string;
+  token: string;
+}
+
+function pollForToken(
+  host: string,
+  initToken: string,
+  timeoutMs: number
+): Promise<AuthData> {
+  return new Promise(async (resolve, reject) => {
+    const { io } = await import("socket.io-client");
+
+    const socket = io(host, {
+      path: "/api/v1/init-token",
+      transportOptions: {
+        polling: {
+          extraHeaders: {
+            "x-plasmic-init-token": initToken,
+          },
+        },
+      },
+    });
+
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error("Auth polling timed out"));
+    }, timeoutMs);
+
+    socket.on("token", (data: AuthData) => {
+      clearTimeout(timer);
+      socket.close();
+      resolve(data);
+    });
+
+    socket.on("error", (err: Error) => {
+      clearTimeout(timer);
+      socket.close();
+      reject(err);
+    });
+  });
+}
+
+async function manualEntry(host: string): Promise<AuthConfig> {
+  const prompts = (await import("prompts")).default;
+
+  const response = await prompts([
+    {
+      type: "text",
+      name: "user",
+      message: "Email address:",
+    },
+    {
+      type: "password",
+      name: "token",
+      message: "API token:",
+    },
+  ]);
+
+  if (!response.user || !response.token) {
+    throw new Error("Authentication cancelled — no credentials provided");
+  }
+
+  return { host, user: response.user, token: response.token };
+}

--- a/packages/plasmic-mcp/src/auth-guard.ts
+++ b/packages/plasmic-mcp/src/auth-guard.ts
@@ -1,0 +1,39 @@
+/**
+ * Auth guard for MCP tool handlers.
+ *
+ * Ensures the API client is authenticated before tool execution.
+ * Returns context-aware error messages depending on whether the server
+ * was launched by Claude Desktop (.mcpb) or Claude Code / other CLI clients.
+ */
+
+import type { PlasmicApiClient } from "./api-client.js";
+
+export function requireAuth(apiClient: PlasmicApiClient | null): PlasmicApiClient {
+  if (apiClient) {
+    return apiClient;
+  }
+  const client = process.env.PLASMIC_MCP_CLIENT;
+  throw new Error(getAuthErrorMessage(client));
+}
+
+export function getAuthErrorMessage(client?: string): string {
+  if (client === "desktop") {
+    return (
+      "Visual Builder authentication required.\n\n" +
+      "Open your extension settings and enter your credentials:\n" +
+      "  1. Open Claude Desktop Settings > Extensions\n" +
+      "  2. Find the Visual Builder extension\n" +
+      "  3. Enter your host URL, email, and API token"
+    );
+  }
+
+  return (
+    "Visual Builder authentication required.\n\n" +
+    "Run the auth command:\n" +
+    "  npx @elasticpath/plasmic-mcp auth\n\n" +
+    "Or set environment variables:\n" +
+    "  PLASMIC_AUTH_HOST=https://useast.storefront.elasticpath.com\n" +
+    "  PLASMIC_AUTH_USER=<your-email>\n" +
+    "  PLASMIC_AUTH_TOKEN=<your-api-token>"
+  );
+}

--- a/packages/plasmic-mcp/src/auth.ts
+++ b/packages/plasmic-mcp/src/auth.ts
@@ -1,9 +1,11 @@
 /**
  * Authentication for the Plasmic API.
  *
- * Reads credentials from environment variables (same as @plasmicapp/cli) or
- * from a .plasmic.auth JSON file. The MCP server requires auth to be present
- * at startup — interactive flows are not supported.
+ * Reads credentials from environment variables or from a .plasmic.auth JSON
+ * file. Returns null when no credentials are found (graceful unauthenticated
+ * startup). Writes credentials to ~/.plasmic.auth with 0600 permissions.
+ *
+ * Resolution order: env vars → .plasmic.auth file → null
  *
  * Reference: packages/cli/src/utils/auth-utils.ts
  */
@@ -18,7 +20,7 @@ const ENV_AUTH_USER = "PLASMIC_AUTH_USER";
 const ENV_AUTH_TOKEN = "PLASMIC_AUTH_TOKEN";
 const AUTH_FILE_NAME = ".plasmic.auth";
 
-export function getAuth(): AuthConfig {
+export function getAuth(): AuthConfig | null {
   // Priority 1: environment variables
   const host = process.env[ENV_AUTH_HOST];
   const user = process.env[ENV_AUTH_USER];
@@ -28,7 +30,7 @@ export function getAuth(): AuthConfig {
     if (!host) {
       throw new Error(
         "PLASMIC_AUTH_HOST is required when PLASMIC_AUTH_USER and PLASMIC_AUTH_TOKEN are set. " +
-          "Set it to your self-hosted Plasmic instance URL (e.g., https://studio.plasmic.app)."
+          "Set it to your Visual Builder instance URL (e.g., https://useast.storefront.elasticpath.com)."
       );
     }
     return {
@@ -54,14 +56,19 @@ export function getAuth(): AuthConfig {
     return authFromFile;
   }
 
-  throw new Error(
-    "Plasmic authentication required. Set environment variables:\n" +
-      "  PLASMIC_AUTH_HOST=https://your-plasmic-instance.example.com\n" +
-      "  PLASMIC_AUTH_USER=<your-api-user-id>\n" +
-      "  PLASMIC_AUTH_TOKEN=<your-api-token>\n\n" +
-      "Or create a .plasmic.auth file with:\n" +
-      '  { "host": "...", "user": "...", "token": "..." }'
+  return null;
+}
+
+export function writeAuth(config: AuthConfig, filePath?: string): void {
+  const target = filePath ?? path.join(os.homedir(), AUTH_FILE_NAME);
+  const content = JSON.stringify(
+    { host: config.host, user: config.user, token: config.token },
+    null,
+    2
   );
+  fs.writeFileSync(target, content, "utf-8");
+  fs.chmodSync(target, 0o600);
+  console.error(`[plasmic-mcp] Credentials written to ${target}`);
 }
 
 function readAuthFile(): AuthConfig | null {

--- a/packages/plasmic-mcp/src/cli.ts
+++ b/packages/plasmic-mcp/src/cli.ts
@@ -1,0 +1,41 @@
+/**
+ * CLI argument parser for plasmic-mcp.
+ *
+ * Routes process.argv to the appropriate command:
+ * - (no args)      → serve: start MCP server over stdio
+ * - auth           → authenticate via browser init-token flow
+ * - auth --host    → authenticate against a specific host
+ * - --version      → print version and exit
+ */
+
+export interface ParsedArgs {
+  command: "serve" | "auth" | "version";
+  options: {
+    host?: string;
+  };
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  // argv[0] = node, argv[1] = script, argv[2+] = user args
+  const args = argv.slice(2);
+
+  if (args.length === 0) {
+    return { command: "serve", options: {} };
+  }
+
+  if (args[0] === "--version" || args[0] === "-v") {
+    return { command: "version", options: {} };
+  }
+
+  if (args[0] === "auth") {
+    const options: ParsedArgs["options"] = {};
+    const hostIdx = args.indexOf("--host");
+    if (hostIdx !== -1 && args[hostIdx + 1]) {
+      options.host = args[hostIdx + 1];
+    }
+    return { command: "auth", options };
+  }
+
+  // Unknown command — default to serve
+  return { command: "serve", options: {} };
+}

--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -41,8 +41,6 @@ process.on("uncaughtException", (err) => {
 });
 
 // Graceful shutdown: disconnect socket so Studio removes the player avatar immediately.
-// Claude Code closes stdin (not SIGTERM) when restarting the MCP server,
-// so we also listen for stdin end and process beforeExit.
 let shuttingDown = false;
 function shutdown() {
   if (shuttingDown) return;
@@ -51,10 +49,8 @@ function shutdown() {
   stopLiveSync();
   stopPreviewServer().catch(() => {});
 }
-process.on("SIGTERM", () => { shutdown(); process.exit(0); });
-process.on("SIGINT", () => { shutdown(); process.exit(0); });
-process.on("beforeExit", shutdown);
-process.stdin.on("close", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
 
 async function startServer() {
   console.error("[plasmic-mcp] Starting Plasmic MCP server...");

--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -14,6 +14,12 @@
  * All logging uses console.error().
  */
 
+// CRITICAL: Redirect console.log to stderr BEFORE any imports.
+// Bundled WAB shared code contains console.log() calls that would write to
+// stdout, corrupting the JSON-RPC transport. This must be the very first
+// thing that executes.
+console.log = console.error;
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { stopLiveSync } from "./live-sync.js";
@@ -21,6 +27,7 @@ import { stopPreviewServer } from "./preview-server.js";
 import { parseArgs } from "./cli.js";
 import { getAuth, writeAuth } from "./auth.js";
 import { acquireAuth } from "./auth-flow.js";
+import * as logger from "./logger.js";
 
 const VERSION = "0.1.3";
 
@@ -34,10 +41,10 @@ const KNOWN_HOSTS: Record<string, string> = {
 
 // Prevent silent crashes from unhandled rejections (e.g. socket.io failures)
 process.on("unhandledRejection", (reason) => {
-  console.error("[plasmic-mcp] Unhandled rejection:", reason);
+  logger.error(`Unhandled rejection: ${reason}`);
 });
 process.on("uncaughtException", (err) => {
-  console.error("[plasmic-mcp] Uncaught exception:", err);
+  logger.error(`Uncaught exception: ${err?.stack ?? err}`);
 });
 
 // Graceful shutdown: disconnect socket so Studio removes the player avatar immediately.
@@ -45,7 +52,7 @@ let shuttingDown = false;
 function shutdown() {
   if (shuttingDown) return;
   shuttingDown = true;
-  console.error("[plasmic-mcp] Shutting down...");
+  logger.info("Shutting down...");
   stopLiveSync();
   stopPreviewServer().catch(() => {});
 }
@@ -53,15 +60,16 @@ process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
 
 async function startServer() {
-  console.error("[plasmic-mcp] Starting Plasmic MCP server...");
+  logger.info("Starting Plasmic MCP server...");
 
   try {
     const server = createServer();
+    logger.setMcpServer(server);
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error("[plasmic-mcp] Server connected via stdio");
+    logger.info("Server connected via stdio");
   } catch (error) {
-    console.error("[plasmic-mcp] Failed to start:", error);
+    logger.error(`Failed to start: ${error}`);
     process.exit(1);
   }
 }

--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -1,20 +1,36 @@
 /**
  * Entry point for the Plasmic MCP server.
  *
- * Starts a stdio-based MCP server using the STRAP architecture:
- * 8 domain tools (project, inspect, component, node, variant, design,
- * data, interaction) consolidating 108 actions total.
+ * Routes through the CLI parser:
+ * - (no args) → start stdio MCP server
+ * - auth      → browser init-token auth flow
+ * - --version → print version and exit
  *
  * Usage (development): tsx packages/plasmic-mcp/src/index.ts
  * Usage (production):  npx @elasticpath/plasmic-mcp
+ * Usage (auth):        npx @elasticpath/plasmic-mcp auth
  *
- * CRITICAL: stdout is the JSON-RPC transport. All logging uses console.error().
+ * CRITICAL: stdout is the JSON-RPC transport in serve mode.
+ * All logging uses console.error().
  */
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { stopLiveSync } from "./live-sync.js";
 import { stopPreviewServer } from "./preview-server.js";
+import { parseArgs } from "./cli.js";
+import { getAuth, writeAuth } from "./auth.js";
+import { acquireAuth } from "./auth-flow.js";
+
+const VERSION = "0.1.3";
+
+const US_EAST_HOST = "https://useast.storefront.elasticpath.com";
+const EU_WEST_HOST = "https://euwest.storefront.elasticpath.com";
+
+const KNOWN_HOSTS: Record<string, string> = {
+  useast: US_EAST_HOST,
+  euwest: EU_WEST_HOST,
+};
 
 // Prevent silent crashes from unhandled rejections (e.g. socket.io failures)
 process.on("unhandledRejection", (reason) => {
@@ -40,7 +56,7 @@ process.on("SIGINT", () => { shutdown(); process.exit(0); });
 process.on("beforeExit", shutdown);
 process.stdin.on("close", shutdown);
 
-async function main() {
+async function startServer() {
   console.error("[plasmic-mcp] Starting Plasmic MCP server...");
 
   try {
@@ -51,6 +67,52 @@ async function main() {
   } catch (error) {
     console.error("[plasmic-mcp] Failed to start:", error);
     process.exit(1);
+  }
+}
+
+async function runAuth(hostOption?: string) {
+  // Resolve host: --host flag → existing auth host → prompt for selection
+  let host = hostOption;
+
+  if (!host) {
+    const existingAuth = getAuth();
+    if (existingAuth) {
+      console.error(`[plasmic-mcp] Existing credentials found for ${existingAuth.host}`);
+      host = existingAuth.host;
+    }
+  }
+
+  if (!host) {
+    // Default to US East — interactive host selection deferred to future iteration
+    host = US_EAST_HOST;
+    console.error(`[plasmic-mcp] Using default host: ${host}`);
+  }
+
+  // Resolve shorthand names
+  if (KNOWN_HOSTS[host]) {
+    host = KNOWN_HOSTS[host];
+  }
+
+  const config = await acquireAuth(host);
+  writeAuth(config);
+  console.error(`[plasmic-mcp] Authentication successful! Credentials saved for ${config.user}`);
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv);
+
+  switch (command) {
+    case "serve":
+      await startServer();
+      break;
+    case "auth":
+      await runAuth(options.host);
+      break;
+    case "version":
+      // Version goes to stdout (not stderr) since this is a user-facing command, not stdio transport
+      console.log(`@elasticpath/plasmic-mcp v${VERSION}`);
+      process.exit(0);
+      break;
   }
 }
 

--- a/packages/plasmic-mcp/src/logger.ts
+++ b/packages/plasmic-mcp/src/logger.ts
@@ -1,0 +1,67 @@
+/**
+ * Logging for the MCP server.
+ *
+ * Three output channels:
+ * 1. stderr (console.error) — captured by Claude Code and terminal stdio clients
+ * 2. MCP logging notifications — captured by Claude Desktop and any MCP client
+ * 3. File log — always available at ~/.plasmic-mcp.log for debugging
+ *
+ * stderr alone is NOT captured by Claude Desktop's built-in Node.js runner
+ * for mcpb extensions. The MCP notification channel and file log ensure
+ * observability regardless of how the server is launched.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const LOG_FILE = path.join(os.homedir(), ".plasmic-mcp.log");
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB — rotate when exceeded
+
+type LogLevel = "debug" | "info" | "warning" | "error";
+
+/** MCP server reference — set after server is created. */
+let mcpServer: { sendLoggingMessage: (params: { level: string; logger?: string; data: unknown }) => Promise<void> } | null = null;
+
+export function setMcpServer(server: typeof mcpServer): void {
+  mcpServer = server;
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function rotateIfNeeded(): void {
+  try {
+    const stats = fs.statSync(LOG_FILE);
+    if (stats.size > MAX_LOG_SIZE) {
+      const backup = LOG_FILE + ".old";
+      try { fs.unlinkSync(backup); } catch {}
+      fs.renameSync(LOG_FILE, backup);
+    }
+  } catch {}
+}
+
+function writeToFile(level: LogLevel, message: string): void {
+  try {
+    rotateIfNeeded();
+    fs.appendFileSync(LOG_FILE, `${timestamp()} [${level}] ${message}\n`);
+  } catch {}
+}
+
+function sendToMcp(level: LogLevel, message: string): void {
+  if (!mcpServer) return;
+  mcpServer.sendLoggingMessage({ level, logger: "plasmic-mcp", data: message }).catch(() => {});
+}
+
+export function log(level: LogLevel, message: string): void {
+  const formatted = `[plasmic-mcp] ${message}`;
+  console.error(formatted);
+  writeToFile(level, message);
+  sendToMcp(level, message);
+}
+
+export function info(message: string): void { log("info", message); }
+export function warn(message: string): void { log("warning", message); }
+export function error(message: string): void { log("error", message); }
+export function debug(message: string): void { log("debug", message); }

--- a/packages/plasmic-mcp/src/logger.ts
+++ b/packages/plasmic-mcp/src/logger.ts
@@ -21,7 +21,7 @@ const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB — rotate when exceeded
 type LogLevel = "debug" | "info" | "warning" | "error";
 
 /** MCP server reference — set after server is created. */
-let mcpServer: { sendLoggingMessage: (params: { level: string; logger?: string; data: unknown }) => Promise<void> } | null = null;
+let mcpServer: { sendLoggingMessage: (params: { level: LogLevel; logger?: string; data: unknown }) => Promise<void> } | null = null;
 
 export function setMcpServer(server: typeof mcpServer): void {
   mcpServer = server;

--- a/packages/plasmic-mcp/src/preview-server.ts
+++ b/packages/plasmic-mcp/src/preview-server.ts
@@ -151,6 +151,9 @@ export async function stopPreviewServer(): Promise<void> {
 /** Get the Studio origin URL (for getlibs.js loading). */
 function getStudioOrigin(): string {
   const auth = getAuth();
+  if (!auth) {
+    throw new Error("Cannot determine Studio origin: no authentication configured");
+  }
   return auth.host.replace(/\/$/, "");
 }
 

--- a/packages/plasmic-mcp/src/prompts.d.ts
+++ b/packages/plasmic-mcp/src/prompts.d.ts
@@ -1,0 +1,10 @@
+declare module "prompts" {
+  interface PromptObject {
+    type: string;
+    name: string;
+    message: string;
+  }
+
+  function prompts(questions: PromptObject | PromptObject[]): Promise<Record<string, any>>;
+  export default prompts;
+}

--- a/packages/plasmic-mcp/src/server.ts
+++ b/packages/plasmic-mcp/src/server.ts
@@ -310,6 +310,10 @@ export function createServer(): McpServer {
   const server = new McpServer({
     name: "plasmic",
     version: "0.1.0",
+  }, {
+    capabilities: {
+      logging: {},
+    },
   });
 
   const auth = getAuth();

--- a/packages/plasmic-mcp/src/server.ts
+++ b/packages/plasmic-mcp/src/server.ts
@@ -282,9 +282,65 @@ async function withDryRun<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Extract a human-readable message from an unknown thrown value. */
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Walks the error cause chain (following Sentry MCP's pattern) and handles:
+ * - PlasmicApiError (statusCode + errorType)
+ * - Standard Error with message
+ * - Errors with cause chains
+ * - HTML error responses (server returning error pages instead of JSON)
+ * - Non-Error thrown values
+ *
+ * Never returns an empty string.
+ *
+ * Reference: getsentry/sentry-mcp packages/mcp-core/src/api-client/client.ts
+ */
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (err == null) return "Unknown error (null)";
+
+  // Walk the cause chain to find the root cause (Sentry pattern)
+  let rootCause: unknown = err;
+  while (rootCause instanceof Error && (rootCause as any).cause) {
+    rootCause = (rootCause as any).cause;
+  }
+
+  // PlasmicApiError — include status code and error type
+  if (err instanceof Error && "statusCode" in err) {
+    const apiErr = err as Error & { statusCode: number; errorType?: string };
+    const parts: string[] = [];
+    if (apiErr.statusCode) parts.push(`HTTP ${apiErr.statusCode}`);
+    if (apiErr.errorType) parts.push(apiErr.errorType);
+    if (apiErr.message) {
+      // Detect HTML error pages (server returning error page instead of JSON)
+      if (apiErr.message.includes("<!doctype") || apiErr.message.includes("<html")) {
+        parts.push("Server returned HTML instead of JSON. The host URL may be incorrect or the server may be down.");
+      } else {
+        parts.push(apiErr.message);
+      }
+    }
+    return parts.join(": ") || `API error (status ${apiErr.statusCode})`;
+  }
+
+  // Standard Error — prefer root cause message if original is empty
+  if (err instanceof Error) {
+    const msg = err.message || (rootCause instanceof Error ? rootCause.message : "");
+    if (msg) {
+      // Detect HTML in error message
+      if (msg.includes("<!doctype") || msg.includes("<html")) {
+        return "Server returned HTML instead of JSON. Check the host URL is correct and the server is reachable.";
+      }
+      return msg;
+    }
+    return `${err.name || "Error"} (no message)`;
+  }
+
+  // Non-Error thrown value
+  const str = String(err);
+  if (!str || str === "[object Object]") {
+    try { return JSON.stringify(err).slice(0, 500); } catch { return "Unknown error (unserializable)"; }
+  }
+  return str;
 }
 
 /**

--- a/packages/plasmic-mcp/src/server.ts
+++ b/packages/plasmic-mcp/src/server.ts
@@ -30,6 +30,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { PlasmicApiClient } from "./api-client.js";
 import { getAuth } from "./auth.js";
+import { requireAuth } from "./auth-guard.js";
 import { requireSession, setSession } from "./session.js";
 import { loadProject } from "./model-loader.js";
 import { listPackages, addPackage, removePackage, upgradePackage, listAvailablePackages, listPackageComponents } from "./package-manager.js";
@@ -312,9 +313,18 @@ export function createServer(): McpServer {
   });
 
   const auth = getAuth();
-  const apiClient = new PlasmicApiClient(auth);
+  const apiClient = auth ? new PlasmicApiClient(auth) : null;
 
-  console.error(`[plasmic-mcp] Authenticated as ${auth.user} against ${auth.host}`);
+  if (auth) {
+    console.error(`[plasmic-mcp] Authenticated as ${auth.user} against ${auth.host}`);
+  } else {
+    console.error("[plasmic-mcp] Starting without authentication — tool calls will require auth");
+  }
+
+  /** Get the authenticated API client or throw a descriptive auth error. */
+  function getClient(): PlasmicApiClient {
+    return requireAuth(apiClient);
+  }
 
   // ========================================================================
   // DOMAIN 1: project (8 actions)
@@ -338,9 +348,10 @@ export function createServer(): McpServer {
         "- list-package-components: List components from installed hostless packages\n" +
         "- add-package: Add a hostless package by its source projectId\n" +
         "- remove-package: Remove an installed package by pkgId or name\n" +
-        "- upgrade-package: Upgrade one or all packages to latest version",
+        "- upgrade-package: Upgrade one or all packages to latest version\n" +
+        "- health-check: Check server status, version, and authentication state (works without auth)",
       inputSchema: {
-        action: z.enum(["set", "list", "get-meta", "save", "refresh", "begin-batch", "end-batch", "undo", "list-packages", "list-available-packages", "list-package-components", "add-package", "remove-package", "upgrade-package"]),
+        action: z.enum(["set", "list", "get-meta", "save", "refresh", "begin-batch", "end-batch", "undo", "list-packages", "list-available-packages", "list-package-components", "add-package", "remove-package", "upgrade-package", "health-check"]),
         projectId: z.string().optional().describe("The Plasmic project ID (required for 'set' and 'add-package')"),
         branchId: z.string().optional().describe("Branch ID to load (omit for main branch). Use branch.list to get available branch IDs."),
         batchId: z.string().optional().describe("Optional batch ID for verification (used by 'end-batch')"),
@@ -357,7 +368,7 @@ export function createServer(): McpServer {
             // Clean up previous session state before loading new project
             stopLiveSync();
             stopPreviewServer().catch(() => {});
-            apiClient.clearSessionState();
+            getClient().clearSessionState();
             cancelBatch();
             clearUndoStack();
             disposeChangeTracker();
@@ -373,7 +384,7 @@ export function createServer(): McpServer {
               hostUrl,
               bundleVersion,
               projectApiToken,
-            } = await loadProject(apiClient, pid, branchId);
+            } = await loadProject(getClient(), pid, branchId);
 
             // Sync code component variants from the dev host (non-fatal)
             const syncResult = await syncFromDevHost(site, hostUrl);
@@ -411,7 +422,7 @@ export function createServer(): McpServer {
                   recordVariantMetadataSync(site, variantComponents);
                 });
                 if (changes.changes.length > 0) {
-                  const saveManager = new SaveManager(apiClient);
+                  const saveManager = new SaveManager(getClient());
                   await saveManager.saveChanges(changes);
                   console.error("[plasmic-mcp] Persisted variant metadata to server");
                 }
@@ -419,7 +430,7 @@ export function createServer(): McpServer {
             }
 
             // Start live sync (non-blocking — continues in HTTP-only mode if socket fails)
-            startLiveSync(apiClient, pid).catch((err) => {
+            startLiveSync(getClient(), pid).catch((err) => {
               console.error(
                 `[plasmic-mcp] LiveSync start failed (non-fatal): ${
                   err instanceof Error ? err.message : String(err)
@@ -428,7 +439,7 @@ export function createServer(): McpServer {
             });
 
             // Start preview server (non-blocking — continues if it fails)
-            startPreviewServer(apiClient).catch((err) => {
+            startPreviewServer(getClient()).catch((err) => {
               console.error(
                 `[plasmic-mcp] Preview server start failed (non-fatal): ${
                   err instanceof Error ? err.message : String(err)
@@ -471,7 +482,7 @@ export function createServer(): McpServer {
           }
 
           case "list": {
-            const response = await apiClient.listProjects();
+            const response = await getClient().listProjects();
             const projects = response.projects.map((p) => ({
               id: p.id,
               name: p.name,
@@ -561,7 +572,7 @@ export function createServer(): McpServer {
 
           case "save": {
             requireSession();
-            const saveManager = new SaveManager(apiClient);
+            const saveManager = new SaveManager(getClient());
             const save = await saveManager.saveFullBundle();
 
             return {
@@ -609,7 +620,7 @@ export function createServer(): McpServer {
               hostUrl,
               bundleVersion,
               projectApiToken: refreshedToken,
-            } = await loadProject(apiClient, session.projectId, session.activeBranchId ?? undefined);
+            } = await loadProject(getClient(), session.projectId, session.activeBranchId ?? undefined);
 
             // Clear registry cache to force fresh fetch on explicit refresh
             clearRegistryCache(hostUrl);
@@ -649,7 +660,7 @@ export function createServer(): McpServer {
                   recordVariantMetadataSync(site, variantComponents);
                 });
                 if (changes.changes.length > 0) {
-                  const saveManager = new SaveManager(apiClient);
+                  const saveManager = new SaveManager(getClient());
                   await saveManager.saveChanges(changes);
                   console.error("[plasmic-mcp] Persisted variant metadata to server");
                 }
@@ -657,7 +668,7 @@ export function createServer(): McpServer {
             }
 
             // Restart live sync after reload (non-blocking)
-            startLiveSync(apiClient, session.projectId).catch((err) => {
+            startLiveSync(getClient(), session.projectId).catch((err) => {
               console.error(
                 `[plasmic-mcp] LiveSync restart failed (non-fatal): ${
                   err instanceof Error ? err.message : String(err)
@@ -721,7 +732,7 @@ export function createServer(): McpServer {
 
           case "end-batch": {
             requireSession();
-            const result = await endBatch(apiClient, batchId);
+            const result = await endBatch(getClient(), batchId);
             const batchRevision = result.save?.revisionNum ?? null;
             return {
               content: [
@@ -749,7 +760,7 @@ export function createServer(): McpServer {
                 "Cannot undo during a batch session. Call end-batch first, then undo."
               );
             }
-            const result = await undoOperation(apiClient);
+            const result = await undoOperation(getClient());
             const undoRevision = result.save?.revisionNum ?? null;
             return {
               content: [
@@ -771,7 +782,7 @@ export function createServer(): McpServer {
 
           case "list-packages": {
             requireSession();
-            const packages = await listPackages(apiClient);
+            const packages = await listPackages(getClient());
             return {
               content: [
                 {
@@ -790,7 +801,7 @@ export function createServer(): McpServer {
 
           case "list-available-packages": {
             requireSession();
-            const packages = await listAvailablePackages(apiClient);
+            const packages = await listAvailablePackages(getClient());
             return {
               content: [
                 {
@@ -809,7 +820,7 @@ export function createServer(): McpServer {
 
           case "list-package-components": {
             requireSession();
-            const components = await listPackageComponents(apiClient, packageName);
+            const components = await listPackageComponents(getClient(), packageName);
             return {
               content: [
                 {
@@ -834,12 +845,12 @@ export function createServer(): McpServer {
                   "End the current batch first, then add the package."
               );
             }
-            const addPkgResult = await addPackage(apiClient, pid);
+            const addPkgResult = await addPackage(getClient(), pid);
             // Package ops are structural (async fetch + sync mutation) so they
             // can't use the synchronous change tracker for incremental saves.
             // Full bundle save persists all model state — mirrors Studio which
             // records the sync mutation separately and lets auto-save handle it.
-            const addPkgSave = new SaveManager(apiClient);
+            const addPkgSave = new SaveManager(getClient());
             const addPkgRevision = await addPkgSave.saveFullBundle();
             return {
               content: [
@@ -864,8 +875,8 @@ export function createServer(): McpServer {
                   "End the current batch first, then remove the package."
               );
             }
-            const rmPkgResult = await removePackage(apiClient, pkgIdOrName);
-            const rmPkgSave = new SaveManager(apiClient);
+            const rmPkgResult = await removePackage(getClient(), pkgIdOrName);
+            const rmPkgSave = new SaveManager(getClient());
             const rmPkgRevision = await rmPkgSave.saveFullBundle();
             return {
               content: [
@@ -889,7 +900,7 @@ export function createServer(): McpServer {
                   "End the current batch first, then upgrade packages."
               );
             }
-            const upgResults = await upgradePackage(apiClient, pkgId);
+            const upgResults = await upgradePackage(getClient(), pkgId);
             if (upgResults.length === 0) {
               return {
                 content: [
@@ -904,7 +915,7 @@ export function createServer(): McpServer {
                 ],
               };
             }
-            const upgPkgSave = new SaveManager(apiClient);
+            const upgPkgSave = new SaveManager(getClient());
             const upgPkgRevision = await upgPkgSave.saveFullBundle();
             return {
               content: [
@@ -921,8 +932,23 @@ export function createServer(): McpServer {
             };
           }
 
+          case "health-check": {
+            const healthResult: Record<string, unknown> = {
+              status: "ok",
+              version: "0.1.0",
+              authenticated: apiClient !== null,
+            };
+            if (auth) {
+              healthResult.host = auth.host;
+              healthResult.user = auth.user;
+            }
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify(healthResult, null, 2) }],
+            };
+          }
+
           default:
-            throw new Error(`Unknown action '${action}' for project tool. Available: set, list, get-meta, save, refresh, begin-batch, end-batch, undo, list-packages, list-available-packages, list-package-components, add-package, remove-package, upgrade-package`);
+            throw new Error(`Unknown action '${action}' for project tool. Available: set, list, get-meta, save, refresh, begin-batch, end-batch, undo, list-packages, list-available-packages, list-package-components, add-package, remove-package, upgrade-package, health-check`);
         }
       } catch (err: unknown) {
         return {
@@ -1335,7 +1361,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const host = auth.host.replace(/\/$/, ""); // Normalize trailing slash
+            const host = auth?.host.replace(/\/$/, "") ?? ""; // Normalize trailing slash
             const studioUrl = `${host}/projects/${session.projectId}`;
             const studioComponentUrl = `${studioUrl}?arena_type=component&arena=${encodeURIComponent(cuuid)}`;
             const isPage = !!component.pageMeta?.path;
@@ -1637,7 +1663,7 @@ export function createServer(): McpServer {
             const pagePath = requireParam(params.path, "path", "component.create-page");
             const session = requireSession();
 
-            const apiResponse = await apiClient.updateProject(session.projectId, {
+            const apiResponse = await getClient().updateProject(session.projectId, {
               newComponents: [{ name: pageName, path: pagePath, body: params.body }],
             });
 
@@ -1659,7 +1685,7 @@ export function createServer(): McpServer {
                 hostUrl: reloadedHostUrl,
                 bundleVersion: newBundleVersion,
                 projectApiToken: reloadedToken,
-              } = await loadProject(apiClient, session.projectId, session.activeBranchId ?? undefined);
+              } = await loadProject(getClient(), session.projectId, session.activeBranchId ?? undefined);
 
               // Re-sync code component variants from the dev host (non-fatal)
               const syncResult = await syncFromDevHost(site, reloadedHostUrl);
@@ -1737,7 +1763,7 @@ export function createServer(): McpServer {
             if (compName.length < 1) throw new Error("Component name is required");
             const session = requireSession();
 
-            const apiResponse = await apiClient.updateProject(session.projectId, {
+            const apiResponse = await getClient().updateProject(session.projectId, {
               newComponents: [{ name: compName, body: params.body }],
             });
 
@@ -1759,7 +1785,7 @@ export function createServer(): McpServer {
                 hostUrl: reloadedHostUrl,
                 bundleVersion: newBundleVersion,
                 projectApiToken: reloadedToken,
-              } = await loadProject(apiClient, session.projectId, session.activeBranchId ?? undefined);
+              } = await loadProject(getClient(), session.projectId, session.activeBranchId ?? undefined);
 
               // Re-sync code component variants from the dev host (non-fatal)
               const syncResult = await syncFromDevHost(site, reloadedHostUrl);
@@ -1862,7 +1888,7 @@ export function createServer(): McpServer {
               req.path = params.path;
             }
 
-            const apiResponse = await apiClient.updateProject(session.projectId, {
+            const apiResponse = await getClient().updateProject(session.projectId, {
               newComponents: [req],
             });
 
@@ -1884,7 +1910,7 @@ export function createServer(): McpServer {
                 hostUrl: reloadedHostUrl,
                 bundleVersion: newBundleVersion,
                 projectApiToken: reloadedToken,
-              } = await loadProject(apiClient, session.projectId, session.activeBranchId ?? undefined);
+              } = await loadProject(getClient(), session.projectId, session.activeBranchId ?? undefined);
 
               // Re-sync code component variants from the dev host (non-fatal)
               const syncResult = await syncFromDevHost(site, reloadedHostUrl);
@@ -1960,7 +1986,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                renameComponent(apiClient, cuuid, nn, params.newPath)
+                renameComponent(getClient(), cuuid, nn, params.newPath)
               );
               return {
                 content: [
@@ -1981,7 +2007,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await renameComponent(apiClient, cuuid, nn, params.newPath);
+            const result = await renameComponent(getClient(), cuuid, nn, params.newPath);
             return {
               content: [
                 {
@@ -2007,7 +2033,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                deleteComponent(apiClient, cuuid, params.force)
+                deleteComponent(getClient(), cuuid, params.force)
               );
               return {
                 content: [
@@ -2026,7 +2052,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await deleteComponent(apiClient, cuuid, params.force);
+            const result = await deleteComponent(getClient(), cuuid, params.force);
             return {
               content: [
                 {
@@ -2053,7 +2079,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                extractToComponent(apiClient, cuuid, nRef, eName)
+                extractToComponent(getClient(), cuuid, nRef, eName)
               );
               return {
                 content: [
@@ -2074,7 +2100,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await extractToComponent(apiClient, cuuid, nRef, eName);
+            const result = await extractToComponent(getClient(), cuuid, nRef, eName);
             clearNodeCache();
             return {
               content: [
@@ -2101,7 +2127,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                convertToPage(apiClient, cuuid, params.path)
+                convertToPage(getClient(), cuuid, params.path)
               );
               return {
                 content: [
@@ -2120,7 +2146,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await convertToPage(apiClient, cuuid, params.path);
+            const result = await convertToPage(getClient(), cuuid, params.path);
             return {
               content: [
                 {
@@ -2144,7 +2170,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                convertToComponent(apiClient, cuuid)
+                convertToComponent(getClient(), cuuid)
               );
               return {
                 content: [
@@ -2162,7 +2188,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await convertToComponent(apiClient, cuuid);
+            const result = await convertToComponent(getClient(), cuuid);
             return {
               content: [
                 {
@@ -2192,7 +2218,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updatePageMeta(apiClient, cuuid, meta)
+                updatePageMeta(getClient(), cuuid, meta)
               );
               return {
                 content: [
@@ -2212,7 +2238,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updatePageMeta(apiClient, cuuid, meta);
+            const result = await updatePageMeta(getClient(), cuuid, meta);
             return {
               content: [
                 {
@@ -2276,7 +2302,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addProp(apiClient, cuuid, propName, propType, params.defaultValue, params.description)
+                addProp(getClient(), cuuid, propName, propType, params.defaultValue, params.description)
               );
               return {
                 content: [
@@ -2297,7 +2323,7 @@ export function createServer(): McpServer {
             }
 
             const result = await addProp(
-              apiClient, cuuid, propName, propType, params.defaultValue, params.description
+              getClient(), cuuid, propName, propType, params.defaultValue, params.description
             );
             return {
               content: [
@@ -2341,7 +2367,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateProp(apiClient, cuuid, pRef, params.name, params.defaultValue, params.description)
+                updateProp(getClient(), cuuid, pRef, params.name, params.defaultValue, params.description)
               );
               return {
                 content: [
@@ -2363,7 +2389,7 @@ export function createServer(): McpServer {
             }
 
             const result = await updateProp(
-              apiClient, cuuid, pRef, params.name, params.defaultValue, params.description
+              getClient(), cuuid, pRef, params.name, params.defaultValue, params.description
             );
             return {
               content: [
@@ -2390,7 +2416,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeProp(apiClient, cuuid, pRef)
+                removeProp(getClient(), cuuid, pRef)
               );
               return {
                 content: [
@@ -2410,7 +2436,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeProp(apiClient, cuuid, pRef);
+            const result = await removeProp(getClient(), cuuid, pRef);
             return {
               content: [
                 {
@@ -2474,7 +2500,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addState(apiClient, cuuid, stateName, varType, accType, params.initialValue)
+                addState(getClient(), cuuid, stateName, varType, accType, params.initialValue)
               );
               return {
                 content: [
@@ -2497,7 +2523,7 @@ export function createServer(): McpServer {
             }
 
             const result = await addState(
-              apiClient, cuuid, stateName, varType, accType, params.initialValue
+              getClient(), cuuid, stateName, varType, accType, params.initialValue
             );
             return {
               content: [
@@ -2543,7 +2569,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateState(apiClient, cuuid, sRef, params.name, params.accessType, params.initialValue)
+                updateState(getClient(), cuuid, sRef, params.name, params.accessType, params.initialValue)
               );
               return {
                 content: [
@@ -2565,7 +2591,7 @@ export function createServer(): McpServer {
             }
 
             const result = await updateState(
-              apiClient, cuuid, sRef, params.name, params.accessType, params.initialValue
+              getClient(), cuuid, sRef, params.name, params.accessType, params.initialValue
             );
             return {
               content: [
@@ -2592,7 +2618,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeState(apiClient, cuuid, sRef)
+                removeState(getClient(), cuuid, sRef)
               );
               return {
                 content: [
@@ -2612,7 +2638,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeState(apiClient, cuuid, sRef);
+            const result = await removeState(getClient(), cuuid, sRef);
             return {
               content: [
                 {
@@ -2746,7 +2772,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addChild(apiClient, cuuid, pRef, childBody, params.position, params.slot)
+                addChild(getClient(), cuuid, pRef, childBody, params.position, params.slot)
               );
               return {
                 content: [
@@ -2770,7 +2796,7 @@ export function createServer(): McpServer {
             }
 
             const result = await addChild(
-              apiClient, cuuid, pRef, childBody, params.position, params.slot
+              getClient(), cuuid, pRef, childBody, params.position, params.slot
             );
             // Structural edit: invalidate node resolver cache for this component
             invalidateNodeCache(cuuid);
@@ -2801,7 +2827,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeChild(apiClient, cuuid, nref)
+                removeChild(getClient(), cuuid, nref)
               );
               return {
                 content: [
@@ -2819,7 +2845,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeChild(apiClient, cuuid, nref);
+            const result = await removeChild(getClient(), cuuid, nref);
             invalidateNodeCache(cuuid);
             return {
               content: [
@@ -2844,7 +2870,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                moveChild(apiClient, cuuid, nref, npRef, params.position, params.slot)
+                moveChild(getClient(), cuuid, nref, npRef, params.position, params.slot)
               );
               return {
                 content: [
@@ -2866,7 +2892,7 @@ export function createServer(): McpServer {
             }
 
             const result = await moveChild(
-              apiClient, cuuid, nref, npRef, params.position, params.slot
+              getClient(), cuuid, nref, npRef, params.position, params.slot
             );
             invalidateNodeCache(cuuid);
             return {
@@ -2894,7 +2920,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                cloneChild(apiClient, cuuid, nref, params.newName, params.parentRef, params.position, params.slot)
+                cloneChild(getClient(), cuuid, nref, params.newName, params.parentRef, params.position, params.slot)
               );
               return {
                 content: [
@@ -2916,7 +2942,7 @@ export function createServer(): McpServer {
             }
 
             const result = await cloneChild(
-              apiClient, cuuid, nref, params.newName, params.parentRef, params.position, params.slot
+              getClient(), cuuid, nref, params.newName, params.parentRef, params.position, params.slot
             );
             invalidateNodeCache(cuuid);
             return {
@@ -2945,7 +2971,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                reorderChildren(apiClient, cuuid, pRef, cRefs)
+                reorderChildren(getClient(), cuuid, pRef, cRefs)
               );
               return {
                 content: [
@@ -2963,7 +2989,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await reorderChildren(apiClient, cuuid, pRef, cRefs);
+            const result = await reorderChildren(getClient(), cuuid, pRef, cRefs);
             invalidateNodeCache(cuuid);
             return {
               content: [
@@ -2990,7 +3016,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateStyles(apiClient, cuuid, nref, sty, params.variant)
+                updateStyles(getClient(), cuuid, nref, sty, params.variant)
               );
               return {
                 content: [
@@ -3011,7 +3037,7 @@ export function createServer(): McpServer {
             }
 
             const result = await updateStyles(
-              apiClient, cuuid, nref, sty, params.variant
+              getClient(), cuuid, nref, sty, params.variant
             );
             return {
               content: [
@@ -3038,7 +3064,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateText(apiClient, cuuid, nref, txt, params.variant, params.dynamic, params.fallback, params.html)
+                updateText(getClient(), cuuid, nref, txt, params.variant, params.dynamic, params.fallback, params.html)
               );
               return {
                 content: [
@@ -3060,7 +3086,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateText(apiClient, cuuid, nref, txt, params.variant, params.dynamic, params.fallback, params.html);
+            const result = await updateText(getClient(), cuuid, nref, txt, params.variant, params.dynamic, params.fallback, params.html);
             return {
               content: [
                 {
@@ -3089,7 +3115,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateRichText(apiClient, cuuid, nref, txt, mrks, params.variant)
+                updateRichText(getClient(), cuuid, nref, txt, mrks, params.variant)
               );
               return {
                 content: [
@@ -3110,7 +3136,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateRichText(apiClient, cuuid, nref, txt, mrks, params.variant);
+            const result = await updateRichText(getClient(), cuuid, nref, txt, mrks, params.variant);
             return {
               content: [
                 {
@@ -3137,7 +3163,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateAttrs(apiClient, cuuid, nref, at, params.variant)
+                updateAttrs(getClient(), cuuid, nref, at, params.variant)
               );
               return {
                 content: [
@@ -3159,7 +3185,7 @@ export function createServer(): McpServer {
             }
 
             const result = await updateAttrs(
-              apiClient, cuuid, nref, at, params.variant
+              getClient(), cuuid, nref, at, params.variant
             );
             return {
               content: [
@@ -3187,7 +3213,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateProps(apiClient, cuuid, nref, pr, params.variant)
+                updateProps(getClient(), cuuid, nref, pr, params.variant)
               );
               return {
                 content: [
@@ -3209,7 +3235,7 @@ export function createServer(): McpServer {
             }
 
             const result = await updateProps(
-              apiClient, cuuid, nref, pr, params.variant
+              getClient(), cuuid, nref, pr, params.variant
             );
             return {
               content: [
@@ -3237,7 +3263,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                setVisibility(apiClient, cuuid, nref, vis, params.variant)
+                setVisibility(getClient(), cuuid, nref, vis, params.variant)
               );
               return {
                 content: [
@@ -3259,7 +3285,7 @@ export function createServer(): McpServer {
             }
 
             const result = await setVisibility(
-              apiClient, cuuid, nref, vis, params.variant
+              getClient(), cuuid, nref, vis, params.variant
             );
             return {
               content: [
@@ -3304,7 +3330,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                setImage(apiClient, cuuid, nref, { assetRef: params.assetRef, src: params.src }, params.variant)
+                setImage(getClient(), cuuid, nref, { assetRef: params.assetRef, src: params.src }, params.variant)
               );
               return {
                 content: [
@@ -3324,7 +3350,7 @@ export function createServer(): McpServer {
             }
 
             const result = await setImage(
-              apiClient, cuuid, nref,
+              getClient(), cuuid, nref,
               { assetRef: params.assetRef, src: params.src },
               params.variant
             );
@@ -3352,7 +3378,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                applyMixin(apiClient, cuuid, nref, mref)
+                applyMixin(getClient(), cuuid, nref, mref)
               );
               return {
                 content: [
@@ -3371,7 +3397,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await applyMixin(apiClient, cuuid, nref, mref);
+            const result = await applyMixin(getClient(), cuuid, nref, mref);
             return {
               content: [
                 {
@@ -3396,7 +3422,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                detachMixin(apiClient, cuuid, nref, mref)
+                detachMixin(getClient(), cuuid, nref, mref)
               );
               return {
                 content: [
@@ -3415,7 +3441,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await detachMixin(apiClient, cuuid, nref, mref);
+            const result = await detachMixin(getClient(), cuuid, nref, mref);
             return {
               content: [
                 {
@@ -3440,7 +3466,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addNodeAnimation(apiClient, cuuid, nref, sref,
+                addNodeAnimation(getClient(), cuuid, nref, sref,
                   params.duration, params.delay, params.timingFunction,
                   params.iterationCount, params.direction, params.fillMode, params.playState)
               );
@@ -3462,7 +3488,7 @@ export function createServer(): McpServer {
             }
 
             const result = await addNodeAnimation(
-              apiClient, cuuid, nref, sref,
+              getClient(), cuuid, nref, sref,
               params.duration, params.delay, params.timingFunction,
               params.iterationCount, params.direction, params.fillMode, params.playState
             );
@@ -3489,7 +3515,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeNodeAnimation(apiClient, cuuid, nref, params.seqRef, params.animationIndex)
+                removeNodeAnimation(getClient(), cuuid, nref, params.seqRef, params.animationIndex)
               );
               return {
                 content: [
@@ -3508,7 +3534,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeNodeAnimation(apiClient, cuuid, nref, params.seqRef, params.animationIndex);
+            const result = await removeNodeAnimation(getClient(), cuuid, nref, params.seqRef, params.animationIndex);
             return {
               content: [
                 {
@@ -3532,7 +3558,7 @@ export function createServer(): McpServer {
             const pName = requireParam(params.patternName, "patternName", "node.apply-pattern");
 
             const result = await applyPattern(
-              apiClient, cuuid, pRef, pName, params.customisations, params.position
+              getClient(), cuuid, pRef, pName, params.customisations, params.position
             );
 
             if (result.error) {
@@ -3678,7 +3704,7 @@ export function createServer(): McpServer {
             const sel = requireParam(params.selector, "selector", "variant.create-style");
 
             const result = await createStyleVariant(
-              apiClient, cuuid, sel, params.nodeRef
+              getClient(), cuuid, sel, params.nodeRef
             );
             return {
               content: [
@@ -3711,7 +3737,7 @@ export function createServer(): McpServer {
             if (gname.length < 1) throw new Error("Group name is required");
 
             const result = await createVariantGroup(
-              apiClient, cuuid, gname, params.type, params.initialVariants
+              getClient(), cuuid, gname, params.type, params.initialVariants
             );
             return {
               content: [
@@ -3755,7 +3781,7 @@ export function createServer(): McpServer {
                 `Invalid type "toggle" for variant.create-global-group. Global variant groups support "single" or "multi" only.`
               );
             }
-            const result = await createGlobalVariantGroup(apiClient, gname, params.type, params.initialVariants);
+            const result = await createGlobalVariantGroup(getClient(), gname, params.type, params.initialVariants);
             return {
               content: [
                 {
@@ -3775,7 +3801,7 @@ export function createServer(): McpServer {
           case "add-global": {
             const gref = requireParam(params.groupRef, "groupRef", "variant.add-global");
             const vname = requireParam(params.name, "name", "variant.add-global");
-            const result = await addGlobalVariant(apiClient, gref, vname);
+            const result = await addGlobalVariant(getClient(), gref, vname);
             return {
               content: [
                 {
@@ -3794,7 +3820,7 @@ export function createServer(): McpServer {
 
           case "remove-global-group": {
             const gref = requireParam(params.groupRef, "groupRef", "variant.remove-global-group");
-            const result = await removeGlobalVariantGroup(apiClient, gref);
+            const result = await removeGlobalVariantGroup(getClient(), gref);
             return {
               content: [
                 {
@@ -3815,7 +3841,7 @@ export function createServer(): McpServer {
           case "rename-global": {
             const vref = requireParam(params.variantRef, "variantRef", "variant.rename-global");
             const nn = requireParam(params.newName, "newName", "variant.rename-global");
-            const result = await renameGlobalVariant(apiClient, vref, nn);
+            const result = await renameGlobalVariant(getClient(), vref, nn);
             return {
               content: [
                 {
@@ -3836,7 +3862,7 @@ export function createServer(): McpServer {
           case "create-screen": {
             const screenName = requireParam(params.name, "name", "variant.create-screen");
             const result = await createScreenVariantAction(
-              apiClient, screenName, params.minWidth, params.maxWidth
+              getClient(), screenName, params.minWidth, params.maxWidth
             );
             return {
               content: [
@@ -3859,7 +3885,7 @@ export function createServer(): McpServer {
 
           case "update-screen": {
             const vref = requireParam(params.variantRef, "variantRef", "variant.update-screen");
-            const result = await updateScreenVariant(apiClient, vref, params.minWidth, params.maxWidth);
+            const result = await updateScreenVariant(getClient(), vref, params.minWidth, params.maxWidth);
             return {
               content: [
                 {
@@ -3882,7 +3908,7 @@ export function createServer(): McpServer {
           case "rename": {
             const vref = requireParam(params.variantRef, "variantRef", "variant.rename");
             const nn = requireParam(params.newName, "newName", "variant.rename");
-            const result = await renameVariantAction(apiClient, vref, nn, params.componentUuid);
+            const result = await renameVariantAction(getClient(), vref, nn, params.componentUuid);
             return {
               content: [
                 {
@@ -3903,7 +3929,7 @@ export function createServer(): McpServer {
 
           case "remove": {
             const vref = requireParam(params.variantRef, "variantRef", "variant.remove");
-            const result = await removeVariantAction(apiClient, vref, params.componentUuid);
+            const result = await removeVariantAction(getClient(), vref, params.componentUuid);
             return {
               content: [
                 {
@@ -4060,7 +4086,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createToken(apiClient, tName, tType, tValue)
+                createToken(getClient(), tName, tType, tValue)
               );
               return {
                 content: [
@@ -4080,7 +4106,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createToken(apiClient, tName, tType, tValue);
+            const result = await createToken(getClient(), tName, tType, tValue);
             return {
               content: [
                 {
@@ -4123,7 +4149,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateToken(apiClient, tRef, params.value, params.name)
+                updateToken(getClient(), tRef, params.value, params.name)
               );
               return {
                 content: [
@@ -4145,7 +4171,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateToken(apiClient, tRef, params.value, params.name);
+            const result = await updateToken(getClient(), tRef, params.value, params.name);
             return {
               content: [
                 {
@@ -4171,7 +4197,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeToken(apiClient, tRef)
+                removeToken(getClient(), tRef)
               );
               return {
                 content: [
@@ -4191,7 +4217,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeToken(apiClient, tRef);
+            const result = await removeToken(getClient(), tRef);
             return {
               content: [
                 {
@@ -4215,7 +4241,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                duplicateToken(apiClient, tRef, params.newName)
+                duplicateToken(getClient(), tRef, params.newName)
               );
               return {
                 content: [
@@ -4237,7 +4263,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await duplicateToken(apiClient, tRef, params.newName);
+            const result = await duplicateToken(getClient(), tRef, params.newName);
             return {
               content: [
                 {
@@ -4279,7 +4305,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createMixin(apiClient, mName, params.styles)
+                createMixin(getClient(), mName, params.styles)
               );
               return {
                 content: [
@@ -4298,7 +4324,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createMixin(apiClient, mName, params.styles);
+            const result = await createMixin(getClient(), mName, params.styles);
             return {
               content: [
                 {
@@ -4324,7 +4350,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateMixin(apiClient, mRef, params.newName, params.styles)
+                updateMixin(getClient(), mRef, params.newName, params.styles)
               );
               return {
                 content: [
@@ -4344,7 +4370,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateMixin(apiClient, mRef, params.newName, params.styles);
+            const result = await updateMixin(getClient(), mRef, params.newName, params.styles);
             return {
               content: [
                 {
@@ -4368,7 +4394,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeMixin(apiClient, mRef)
+                removeMixin(getClient(), mRef)
               );
               return {
                 content: [
@@ -4387,7 +4413,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeMixin(apiClient, mRef);
+            const result = await removeMixin(getClient(), mRef);
             return {
               content: [
                 {
@@ -4426,7 +4452,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createAnimationSequence(apiClient, aName, params.keyframes)
+                createAnimationSequence(getClient(), aName, params.keyframes)
               );
               return {
                 content: [
@@ -4445,7 +4471,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createAnimationSequence(apiClient, aName, params.keyframes);
+            const result = await createAnimationSequence(getClient(), aName, params.keyframes);
             return {
               content: [
                 {
@@ -4471,7 +4497,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateAnimationSequence(apiClient, sRef, params.newName, params.keyframes)
+                updateAnimationSequence(getClient(), sRef, params.newName, params.keyframes)
               );
               return {
                 content: [
@@ -4491,7 +4517,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateAnimationSequence(apiClient, sRef, params.newName, params.keyframes);
+            const result = await updateAnimationSequence(getClient(), sRef, params.newName, params.keyframes);
             return {
               content: [
                 {
@@ -4515,7 +4541,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeAnimationSequence(apiClient, sRef)
+                removeAnimationSequence(getClient(), sRef)
               );
               return {
                 content: [
@@ -4534,7 +4560,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeAnimationSequence(apiClient, sRef);
+            const result = await removeAnimationSequence(getClient(), sRef);
             return {
               content: [
                 {
@@ -4571,7 +4597,7 @@ export function createServer(): McpServer {
           case "create-theme": {
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createTheme(apiClient, params.defaultStyles, params.themeStyles, params.setActive)
+                createTheme(getClient(), params.defaultStyles, params.themeStyles, params.setActive)
               );
               return {
                 content: [
@@ -4589,7 +4615,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createTheme(apiClient, params.defaultStyles, params.themeStyles, params.setActive);
+            const result = await createTheme(getClient(), params.defaultStyles, params.themeStyles, params.setActive);
             return {
               content: [
                 {
@@ -4611,7 +4637,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateTheme(apiClient, tIdx as number, params.defaultStyles, params.themeStyles)
+                updateTheme(getClient(), tIdx as number, params.defaultStyles, params.themeStyles)
               );
               return {
                 content: [
@@ -4630,7 +4656,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateTheme(apiClient, tIdx as number, params.defaultStyles, params.themeStyles);
+            const result = await updateTheme(getClient(), tIdx as number, params.defaultStyles, params.themeStyles);
             return {
               content: [
                 {
@@ -4653,7 +4679,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeTheme(apiClient, tIdx as number)
+                removeTheme(getClient(), tIdx as number)
               );
               return {
                 content: [
@@ -4671,7 +4697,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeTheme(apiClient, tIdx as number);
+            const result = await removeTheme(getClient(), tIdx as number);
             return {
               content: [
                 {
@@ -4696,7 +4722,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                setActiveTheme(apiClient, params.themeIndex as number | null)
+                setActiveTheme(getClient(), params.themeIndex as number | null)
               );
               return {
                 content: [
@@ -4714,7 +4740,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await setActiveTheme(apiClient, params.themeIndex as number | null);
+            const result = await setActiveTheme(getClient(), params.themeIndex as number | null);
             return {
               content: [
                 {
@@ -4748,7 +4774,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                uploadAsset(apiClient, aName, aType, { url: params.url, dataUri: params.dataUri, width: params.width, height: params.height })
+                uploadAsset(getClient(), aName, aType, { url: params.url, dataUri: params.dataUri, width: params.width, height: params.height })
               );
               return {
                 content: [
@@ -4767,7 +4793,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await uploadAsset(apiClient, aName, aType, { url: params.url, dataUri: params.dataUri, width: params.width, height: params.height });
+            const result = await uploadAsset(getClient(), aName, aType, { url: params.url, dataUri: params.dataUri, width: params.width, height: params.height });
             return {
               content: [
                 {
@@ -4792,7 +4818,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                renameAsset(apiClient, aRef, nn)
+                renameAsset(getClient(), aRef, nn)
               );
               return {
                 content: [
@@ -4811,7 +4837,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await renameAsset(apiClient, aRef, nn);
+            const result = await renameAsset(getClient(), aRef, nn);
             return {
               content: [
                 {
@@ -4835,7 +4861,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeAsset(apiClient, aRef)
+                removeAsset(getClient(), aRef)
               );
               return {
                 content: [
@@ -4854,7 +4880,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeAsset(apiClient, aRef);
+            const result = await removeAsset(getClient(), aRef);
             return {
               content: [
                 {
@@ -4961,7 +4987,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                setDataCond(apiClient, cuuid, nref, params.condition!, params.variant)
+                setDataCond(getClient(), cuuid, nref, params.condition!, params.variant)
               );
               return {
                 content: [
@@ -4982,7 +5008,7 @@ export function createServer(): McpServer {
             }
 
             const result = await setDataCond(
-              apiClient, cuuid, nref, params.condition!, params.variant
+              getClient(), cuuid, nref, params.condition!, params.variant
             );
             return {
               content: [
@@ -5013,7 +5039,7 @@ export function createServer(): McpServer {
             if (params.dryRun) {
               const result = await withDryRun(() =>
                 setDataRep(
-                  apiClient, cuuid, nref, params.collection!,
+                  getClient(), cuuid, nref, params.collection!,
                   params.elementVariable, params.indexVariable, params.variant
                 )
               );
@@ -5036,7 +5062,7 @@ export function createServer(): McpServer {
             }
 
             const result = await setDataRep(
-              apiClient, cuuid, nref, params.collection!,
+              getClient(), cuuid, nref, params.collection!,
               params.elementVariable, params.indexVariable, params.variant
             );
             return {
@@ -5100,7 +5126,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addQuery(apiClient, cuuid, qName, qType)
+                addQuery(getClient(), cuuid, qName, qType)
               );
               return {
                 content: [
@@ -5120,7 +5146,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await addQuery(apiClient, cuuid, qName, qType);
+            const result = await addQuery(getClient(), cuuid, qName, qType);
             return {
               content: [
                 {
@@ -5146,7 +5172,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateQuery(apiClient, cuuid, qRef, qName)
+                updateQuery(getClient(), cuuid, qRef, qName)
               );
               return {
                 content: [
@@ -5166,7 +5192,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateQuery(apiClient, cuuid, qRef, qName);
+            const result = await updateQuery(getClient(), cuuid, qRef, qName);
             return {
               content: [
                 {
@@ -5191,7 +5217,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeQuery(apiClient, cuuid, qRef)
+                removeQuery(getClient(), cuuid, qRef)
               );
               return {
                 content: [
@@ -5211,7 +5237,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeQuery(apiClient, cuuid, qRef);
+            const result = await removeQuery(getClient(), cuuid, qRef);
             return {
               content: [
                 {
@@ -5244,7 +5270,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createDataToken(apiClient, dtName, params.value)
+                createDataToken(getClient(), dtName, params.value)
               );
               return {
                 content: [
@@ -5262,7 +5288,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createDataToken(apiClient, dtName, params.value);
+            const result = await createDataToken(getClient(), dtName, params.value);
             return {
               content: [
                 {
@@ -5287,7 +5313,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateDataToken(apiClient, dtRef, params.name, params.value)
+                updateDataToken(getClient(), dtRef, params.name, params.value)
               );
               return {
                 content: [
@@ -5305,7 +5331,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateDataToken(apiClient, dtRef, params.name, params.value);
+            const result = await updateDataToken(getClient(), dtRef, params.name, params.value);
             return {
               content: [
                 {
@@ -5327,7 +5353,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeDataToken(apiClient, dtRef)
+                removeDataToken(getClient(), dtRef)
               );
               return {
                 content: [
@@ -5346,7 +5372,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeDataToken(apiClient, dtRef);
+            const result = await removeDataToken(getClient(), dtRef);
             return {
               content: [
                 {
@@ -5380,7 +5406,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                createSplit(apiClient, sName, sType, sSlices)
+                createSplit(getClient(), sName, sType, sSlices)
               );
               return {
                 content: [
@@ -5398,7 +5424,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await createSplit(apiClient, sName, sType, sSlices);
+            const result = await createSplit(getClient(), sName, sType, sSlices);
             return {
               content: [
                 {
@@ -5423,7 +5449,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateSplit(apiClient, sRef, params.name, params.status, params.slices)
+                updateSplit(getClient(), sRef, params.name, params.status, params.slices)
               );
               return {
                 content: [
@@ -5441,7 +5467,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateSplit(apiClient, sRef, params.name, params.status, params.slices);
+            const result = await updateSplit(getClient(), sRef, params.name, params.status, params.slices);
             return {
               content: [
                 {
@@ -5463,7 +5489,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeSplit(apiClient, sRef)
+                removeSplit(getClient(), sRef)
               );
               return {
                 content: [
@@ -5482,7 +5508,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await removeSplit(apiClient, sRef);
+            const result = await removeSplit(getClient(), sRef);
             return {
               content: [
                 {
@@ -5672,7 +5698,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                addInteraction(apiClient, cuuid, nref, evt, actName, argz, params.interactionName, params.condition)
+                addInteraction(getClient(), cuuid, nref, evt, actName, argz, params.interactionName, params.condition)
               );
               return {
                 content: [
@@ -5694,7 +5720,7 @@ export function createServer(): McpServer {
             }
 
             const result = await addInteraction(
-              apiClient, cuuid, nref, evt, actName, argz, params.interactionName, params.condition
+              getClient(), cuuid, nref, evt, actName, argz, params.interactionName, params.condition
             );
             return {
               content: [
@@ -5734,7 +5760,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateInteraction(apiClient, cuuid, nref, evt, idx, updates)
+                updateInteraction(getClient(), cuuid, nref, evt, idx, updates)
               );
               return {
                 content: [
@@ -5755,7 +5781,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateInteraction(apiClient, cuuid, nref, evt, idx, updates);
+            const result = await updateInteraction(getClient(), cuuid, nref, evt, idx, updates);
             return {
               content: [
                 {
@@ -5782,7 +5808,7 @@ export function createServer(): McpServer {
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                removeInteraction(apiClient, cuuid, nref, evt, params.interactionIndex)
+                removeInteraction(getClient(), cuuid, nref, evt, params.interactionIndex)
               );
               return {
                 content: [
@@ -5802,7 +5828,7 @@ export function createServer(): McpServer {
             }
 
             const result = await removeInteraction(
-              apiClient, cuuid, nref, evt, params.interactionIndex
+              getClient(), cuuid, nref, evt, params.interactionIndex
             );
             return {
               content: [
@@ -5877,7 +5903,7 @@ export function createServer(): McpServer {
 
         switch (action) {
           case "list": {
-            const result = await apiClient.listBranches(projectId);
+            const result = await getClient().listBranches(projectId);
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 branches: result.branches ?? [],
@@ -5891,14 +5917,14 @@ export function createServer(): McpServer {
             if (!name) throw new Error("branch.create requires a name");
             // Branching requires at least one published version (commit).
             // Check early to give a clear error instead of a server 500.
-            const pkgCheck = await apiClient.getPkgByProjectId(projectId);
+            const pkgCheck = await getClient().getPkgByProjectId(projectId);
             if (!pkgCheck.pkg) {
               throw new Error(
                 "Cannot create branches: this project has never been published. " +
                 "Publish the project first (via Studio > Publish) to enable branching."
               );
             }
-            const result = await apiClient.createBranch(projectId, {
+            const result = await getClient().createBranch(projectId, {
               name,
               ...(params.sourceBranchId ? { sourceBranchId: params.sourceBranchId } : {}),
               ...(params.base ? { base: params.base } : {}),
@@ -5918,7 +5944,7 @@ export function createServer(): McpServer {
             const data: Record<string, string> = {};
             if (params.name) data.name = params.name;
             if (params.status) data.status = params.status;
-            await apiClient.updateBranch(projectId, branchId, data);
+            await getClient().updateBranch(projectId, branchId, data);
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 success: true,
@@ -5930,7 +5956,7 @@ export function createServer(): McpServer {
           case "delete": {
             const branchId = params.branchId;
             if (!branchId) throw new Error("branch.delete requires a branchId");
-            await apiClient.deleteBranch(projectId, branchId);
+            await getClient().deleteBranch(projectId, branchId);
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 success: true,
@@ -5945,7 +5971,7 @@ export function createServer(): McpServer {
             if (!fromBranchId || !toBranchId) {
               throw new Error("branch.merge requires fromBranchId and toBranchId");
             }
-            const result = await apiClient.tryMergeBranch(projectId, {
+            const result = await getClient().tryMergeBranch(projectId, {
               subject: { fromBranchId, toBranchId },
               pretend: params.pretend ?? false,
               ...(params.description ? { description: params.description } : {}),
@@ -5970,7 +5996,7 @@ export function createServer(): McpServer {
                 disposeChangeTracker();
                 clearUndoStack();
                 clearNodeCache();
-                const loaded = await loadProject(apiClient, session.projectId, session.activeBranchId ?? undefined);
+                const loaded = await loadProject(getClient(), session.projectId, session.activeBranchId ?? undefined);
                 clearRegistryCache(loaded.hostUrl);
                 const syncResult = await syncFromDevHost(loaded.site, loaded.hostUrl);
                 setSession({
@@ -5991,7 +6017,7 @@ export function createServer(): McpServer {
                   projectApiToken: loaded.projectApiToken,
                 });
                 initChangeTracker(loaded.site);
-                startLiveSync(apiClient, session.projectId).catch(() => {});
+                startLiveSync(getClient(), session.projectId).catch(() => {});
                 reloaded = true;
               }
             }
@@ -6014,7 +6040,7 @@ export function createServer(): McpServer {
             if (params.protected === undefined) {
               throw new Error("branch.protect requires protected: true or false");
             }
-            await apiClient.setMainBranchProtection(projectId, params.protected);
+            await getClient().setMainBranchProtection(projectId, params.protected);
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 success: true,
@@ -6027,7 +6053,7 @@ export function createServer(): McpServer {
           }
 
           case "revision-info": {
-            const result = await apiClient.getRevisionInfo(
+            const result = await getClient().getRevisionInfo(
               projectId,
               params.revisionId,
               params.branchId
@@ -6084,7 +6110,7 @@ export function createServer(): McpServer {
 
         switch (action) {
           case "list": {
-            const result = await apiClient.getComments(projectId, branchId);
+            const result = await getClient().getComments(projectId, branchId);
             const threads = result.threads ?? [];
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
@@ -6132,7 +6158,7 @@ export function createServer(): McpServer {
 
             const commentThreadId = randomUUID();
             const commentId = randomUUID();
-            await apiClient.postRootComment(projectId, branchId, {
+            await getClient().postRootComment(projectId, branchId, {
               commentThreadId,
               commentId,
               body,
@@ -6159,7 +6185,7 @@ export function createServer(): McpServer {
             if (!threadId) throw new Error("comment.reply requires threadId");
             if (!body) throw new Error("comment.reply requires body text");
             const commentId = randomUUID();
-            await apiClient.postThreadComment(projectId, branchId, threadId, {
+            await getClient().postThreadComment(projectId, branchId, threadId, {
               id: commentId,
               body,
             });
@@ -6178,7 +6204,7 @@ export function createServer(): McpServer {
             const body = params.body;
             if (!commentId) throw new Error("comment.edit requires commentId");
             if (!body) throw new Error("comment.edit requires body text");
-            await apiClient.editComment(projectId, branchId, commentId, { body });
+            await getClient().editComment(projectId, branchId, commentId, { body });
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 success: true,
@@ -6191,7 +6217,7 @@ export function createServer(): McpServer {
           case "delete": {
             const commentId = params.commentId;
             if (!commentId) throw new Error("comment.delete requires commentId");
-            await apiClient.deleteComment(projectId, branchId, commentId);
+            await getClient().deleteComment(projectId, branchId, commentId);
             return {
               content: [{ type: "text" as const, text: JSON.stringify({
                 success: true,
@@ -6205,7 +6231,7 @@ export function createServer(): McpServer {
             const threadId = params.threadId;
             if (!threadId) throw new Error("comment.resolve requires threadId");
             const resolved = params.resolved ?? true;
-            await apiClient.resolveThread(projectId, branchId, threadId, {
+            await getClient().resolveThread(projectId, branchId, threadId, {
               id: randomUUID(),
               resolved,
             });
@@ -6225,7 +6251,7 @@ export function createServer(): McpServer {
             const reactionId = params.reactionId;
             if (reactionId) {
               // Remove reaction
-              await apiClient.removeReaction(projectId, branchId, reactionId);
+              await getClient().removeReaction(projectId, branchId, reactionId);
               return {
                 content: [{ type: "text" as const, text: JSON.stringify({
                   success: true,
@@ -6238,7 +6264,7 @@ export function createServer(): McpServer {
               throw new Error("comment.react requires commentId + emoji (to add) or reactionId (to remove)");
             }
             const newReactionId = randomUUID();
-            await apiClient.addReaction(projectId, branchId, commentId, {
+            await getClient().addReaction(projectId, branchId, commentId, {
               id: newReactionId,
               data: { emojiName: emoji },
             });

--- a/packages/plasmic-mcp/src/session.ts
+++ b/packages/plasmic-mcp/src/session.ts
@@ -64,6 +64,16 @@ export function getSession(): Session | null {
 
 export function requireSession(): Session {
   if (!currentSession) {
+    // Log to file for debugging — stderr may not be captured in all environments
+    try {
+      const fs = require("fs");
+      const os = require("os");
+      const path = require("path");
+      fs.appendFileSync(
+        path.join(os.homedir(), ".plasmic-mcp.log"),
+        `${new Date().toISOString()} [error] requireSession failed — currentSession is null (pid=${process.pid})\n`
+      );
+    } catch {}
     throw new Error("No active project. Use project tool with action 'set' first.");
   }
   return currentSession;
@@ -71,8 +81,26 @@ export function requireSession(): Session {
 
 export function setSession(session: Session): void {
   currentSession = session;
+  try {
+    const fs = require("fs");
+    const os = require("os");
+    const path = require("path");
+    fs.appendFileSync(
+      path.join(os.homedir(), ".plasmic-mcp.log"),
+      `${new Date().toISOString()} [info] setSession projectId=${session.projectId} name=${session.projectName} (pid=${process.pid})\n`
+    );
+  } catch {}
 }
 
 export function clearSession(): void {
   currentSession = null;
+  try {
+    const fs = require("fs");
+    const os = require("os");
+    const path = require("path");
+    fs.appendFileSync(
+      path.join(os.homedir(), ".plasmic-mcp.log"),
+      `${new Date().toISOString()} [info] clearSession (pid=${process.pid})\n`
+    );
+  } catch {}
 }

--- a/platform/wab/src/wab/client/components/root-view.tsx
+++ b/platform/wab/src/wab/client/components/root-view.tsx
@@ -142,6 +142,16 @@ function LoggedInContainer(props: LoggedInContainerProps) {
         // Not logged in users
         <Switch>
           {projectRoute()}
+          {routerRoute({
+            exact: true,
+            path: APP_ROUTES.plasmicInit,
+            render: ({ match }) => (
+              <InitTokenPage
+                appCtx={appCtx}
+                initToken={match.params.initToken}
+              />
+            ),
+          })}
           {isDashboardRestricted(
             appCtx.appConfig,
             currentLocation.search

--- a/platform/wab/src/wab/client/components/root-view.tsx
+++ b/platform/wab/src/wab/client/components/root-view.tsx
@@ -142,16 +142,6 @@ function LoggedInContainer(props: LoggedInContainerProps) {
         // Not logged in users
         <Switch>
           {projectRoute()}
-          {routerRoute({
-            exact: true,
-            path: APP_ROUTES.plasmicInit,
-            render: ({ match }) => (
-              <InitTokenPage
-                appCtx={appCtx}
-                initToken={match.params.initToken}
-              />
-            ),
-          })}
           {isDashboardRestricted(
             appCtx.appConfig,
             currentLocation.search


### PR DESCRIPTION
## Summary

Implements [PRD #240](https://github.com/elasticpath/plasmic/issues/240) — MCP server installation, configuration, and authentication flow.

- **Graceful unauthenticated startup**: `getAuth()` returns `null` instead of throwing; server starts and registers all tools without credentials
- **Auth guard**: Tool calls return content-level errors with context-aware instructions (Desktop vs CLI messages via `PLASMIC_MCP_CLIENT` env var)
- **CLI router**: `npx @elasticpath/plasmic-mcp` (serve) | `auth` (prompt-based credential entry) | `--version`
- **Prompt-based auth**: Interactive terminal prompts for email + API token. Browser init-token flow preserved behind `{ browser: true }` option for future use when Commerce Manager supports the init-token route.
- **Health check**: `project.health-check` action works without auth — returns version, auth status, host
- **MCPB manifest & build**: v0.2 manifest with `${user_config.*}` env var substitution, `build:mcpb` script that bundles server + node_modules into a self-contained `.mcpb` file
- **`.env.example`**: Documents all supported environment variables

### Why prompt-based auth (not browser)?
EP environments redirect unauthenticated users to Commerce Manager, which doesn't support the Plasmic `/auth/plasmic-init/` route. The browser init-token flow code is preserved and can be enabled via `{ browser: true }` once a CM route is added (tracked as follow-up).

### New modules
| Module | File | Tests |
|---|---|---|
| Auth reader/writer | `src/auth.ts` (refactored) | 15 |
| CLI router | `src/cli.ts` | 5 |
| Auth guard | `src/auth-guard.ts` | 6 |
| Auth flow | `src/auth-flow.ts` | 8 |
| Health check | `src/server.ts` (new action) | 2 |
| MCPB manifest & build | `manifest.json`, `build-mcpb.mjs` | 7 |
| Entry point | `src/index.ts` (refactored) | 4 |

### Installation channels
- **Claude Desktop**: `.mcpb` extension (double-click install, keychain credentials)
- **Claude Code**: `claude mcp add plasmic -- npx -y @elasticpath/plasmic-mcp`
- **Cursor**: Manual `mcp.json` with same npx command

### Known limitation: Claude Desktop session persistence
Claude Desktop's mcpb runner restarts the server process between tool calls, so in-memory session state (`project.set`) does not persist. Stateless tools (`project.list`, `project.health-check`) work correctly. Session-based workflows require Claude Code or Cursor where the server process stays alive. This is a Claude Desktop platform limitation, not a server issue.

## Test plan

- [x] `getAuth()` returns `null` when no credentials (was: throws)
- [x] `writeAuth()` writes JSON with 0600 permissions, round-trips with `getAuth()`
- [x] CLI parses `auth`, `auth --host <url>`, `--version`, and defaults to `serve`
- [x] Auth guard returns client when present, throws Desktop/CLI-specific messages when null
- [x] Prompt-based auth flow collects credentials and writes `~/.plasmic.auth`
- [x] Browser auth flow (behind `{ browser: true }`) opens correct URL, returns config on callback, falls back on timeout
- [x] Health check returns version + auth status in both authenticated and unauthenticated modes
- [x] Manifest is valid with correct user_config fields, sensitive marking, and `${user_config.*}` env mapping
- [x] Server starts without credentials and returns content-level auth error on tool calls
- [x] All unit tests pass, zero regressions
- [x] TypeScript type check clean
- [x] esbuild bundle succeeds

### Manual verification
- [x] `--version` prints version and exits
- [x] Unauthenticated startup, health-check, and auth error messages (CLI + Desktop)
- [x] `auth --host` prompt flow writes `~/.plasmic.auth` with 0600 permissions
- [x] Switching between localhost and integration credentials works correctly
- [x] `project.list` returns correct projects for each host (19 localhost vs 47 integration)
- [x] Claude Code: full end-to-end with MCP server registered and working
- [x] Claude Desktop: `.mcpb` installs, connects, tools register, `project.list` returns projects
- [x] Claude Desktop: session persistence limitation documented (process restarts between calls)

Closes #240