### PR TITLE
fix(wab): use CODEGEN_CLOUDFRONT_URL for CloudFront cache warming

### DIFF
--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -153,7 +153,8 @@ export async function prefillCloudfront(
       // get a cache hit. Warming works without isPrefilled being set because the
       // versioned endpoint serves directly from S3 by projectId@version.
       if (warmingData.length > 0) {
-        const baseUrl = getCodegenPublicUrl();
+        const baseUrl =
+          process.env.CODEGEN_CLOUDFRONT_URL ?? getCodegenPublicUrl();
         await withSpan(
           "loader-prefill-warming",
           async () => {


### PR DESCRIPTION
## Summary

- Warming GET requests in `prefill-cloudfront.ts` were using `getCodegenPublicUrl()`, which resolves to `CODEGEN_HOST` — going directly to origin and bypassing CloudFront entirely
- Now uses `process.env.CODEGEN_CLOUDFRONT_URL` (injected by terraservices [!115](https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/plasmic-terraservices/-/merge_requests/115)) so warming flows through the public CloudFront URL (NAT Gateway → CloudFront → Origin Shield → origin)
- Falls back to `getCodegenPublicUrl()` when env var is absent (local dev)

## Test plan

- [ ] Verify `CODEGEN_CLOUDFRONT_URL` is present in the WAB ECS task definition after terraservices !115 is deployed
- [ ] After a publish, confirm warming logs (`loader-prefill-warming-url`) show the CloudFront domain in the URL rather than the internal host
- [ ] Confirm post-publish versioned URL first-request latency drops from ~866ms to ~50ms (Origin Shield hit)