### PR TITLE
chore(plasmic-mcp): bump to v0.1.4, add files field

### DIFF
--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Visual Builder",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
   "author": {
     "name": "Elastic Path"

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,12 +1,17 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {
     "plasmic-mcp": "./dist/index.cjs"
   },
   "main": "./dist/index.cjs",
+  "files": [
+    "dist/index.cjs",
+    "dist/index.cjs.map",
+    "manifest.json"
+  ],
   "scripts": {
     "build": "node build.mjs",
     "build:mcpb": "node build.mjs && node build-mcpb.mjs",

--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -29,7 +29,7 @@ import { getAuth, writeAuth } from "./auth.js";
 import { acquireAuth } from "./auth-flow.js";
 import * as logger from "./logger.js";
 
-const VERSION = "0.1.3";
+const VERSION = "0.1.4";
 
 const US_EAST_HOST = "https://useast.storefront.elasticpath.com";
 const EU_WEST_HOST = "https://euwest.storefront.elasticpath.com";


### PR DESCRIPTION
## Summary

- Bump version to 0.1.4 across `package.json`, `src/index.ts`, and `manifest.json`
- Add `files` field to `package.json` — reduces npm package from 68.7 MB to 11.4 MB

Already published to npm. This PR commits the source changes.

Closes #244

## Test plan

- [x] All 2,152 unit tests pass
- [x] Verified from clean `npm install` of tarball: `--version`, MCP handshake, `tools/list`, `health-check` all succeed
- [x] `npm pack --dry-run` shows 5 files / 1.9 MB tarball