### PR TITLE
[#12] fix(loader): include project API tokens in CloudFront warming fetch

### DIFF
--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
@@ -151,6 +151,10 @@ describe("Prefill cloudfront", () => {
 
       sudo.updatePkgVersion = jest.fn();
 
+      sudo.validateOrGetProjectApiToken = jest
+        .fn()
+        .mockImplementation((pid: string) => Promise.resolve(`token-${pid}`));
+
       return { getResolvedProjectVersions, genPublishedLoaderCodeBundle };
     }
 
@@ -305,6 +309,31 @@ describe("Prefill cloudfront", () => {
             url.includes("browserOnly=true") &&
             url.includes("projectId=p1%400.0.1") &&
             !url.includes("projectId=p2")
+          )
+        ).toBe(true);
+
+        // Every warming fetch must include x-plasmic-api-project-tokens so the
+        // versioned endpoint authorises the request instead of returning 401.
+        const fetchCalls = (global.fetch as jest.Mock).mock.calls as [string, RequestInit][];
+        for (const [, opts] of fetchCalls) {
+          expect(
+            (opts?.headers as Record<string, string>)?.["x-plasmic-api-project-tokens"]
+          ).toBeTruthy();
+        }
+        // Multi-project variant includes tokens for all resolved specs
+        expect(
+          fetchCalls.some(([, opts]) =>
+            (opts?.headers as Record<string, string>)?.[
+              "x-plasmic-api-project-tokens"
+            ] === "p1:token-p1,p2:token-p2,p3:token-p3"
+          )
+        ).toBe(true);
+        // Single-project variant includes only that project's token
+        expect(
+          fetchCalls.some(([, opts]) =>
+            (opts?.headers as Record<string, string>)?.[
+              "x-plasmic-api-project-tokens"
+            ] === "p1:token-p1"
           )
         ).toBe(true);
       });

--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -7,6 +7,7 @@ import { genPublishedLoaderCodeBundle } from "@/wab/server/loader/gen-code-bundl
 import {
   getResolvedProjectVersions,
   mkVersionToSync,
+  parseProjectIdSpec,
 } from "@/wab/server/loader/resolve-projects";
 import { logger } from "@/wab/server/observability";
 import { captureException } from "@/wab/server/observability/datadog";
@@ -172,11 +173,28 @@ export async function prefillCloudfront(
                   i18nKeyScheme: publishment.i18nKeyScheme ?? undefined,
                   i18nTagPrefix: publishment.i18nTagPrefix ?? undefined,
                 });
+                // Look up API tokens for all projects in this variant so the
+                // warming GET is authorised — the versioned endpoint requires
+                // x-plasmic-api-project-tokens to serve the bundle.
+                const projectTokens = await Promise.all(
+                  resolvedProjectIdSpecs.map(async (spec) => {
+                    const { projectId: specProjectId } =
+                      parseProjectIdSpec(spec);
+                    const token =
+                      await mgr.sudo().validateOrGetProjectApiToken(
+                        specProjectId
+                      );
+                    return `${specProjectId}:${token}`;
+                  })
+                );
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), 30_000);
                 const { result, spentTime } = await withTimeSpent(() =>
                   fetch(`${baseUrl}/api/v1/loader/code/versioned?${query}`, {
                     signal: controller.signal,
+                    headers: {
+                      "x-plasmic-api-project-tokens": projectTokens.join(","),
+                    },
                   }).finally(() => clearTimeout(timeoutId))
                 );
                 logger().info("loader-prefill-warming-url", {

--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -153,7 +153,8 @@ export async function prefillCloudfront(
       // get a cache hit. Warming works without isPrefilled being set because the
       // versioned endpoint serves directly from S3 by projectId@version.
       if (warmingData.length > 0) {
-        const baseUrl = getCodegenPublicUrl();
+        const baseUrl =
+          process.env.CODEGEN_CLOUDFRONT_URL ?? getCodegenPublicUrl();
         await withSpan(
           "loader-prefill-warming",
           async () => {


### PR DESCRIPTION
## What does this MR do?

The CloudFront versioned cache warming fetch was returning 401 on every publish because it sent no auth headers. The versioned endpoint requires `x-plasmic-api-project-tokens` to serve the bundle, so the warming GET was always failing silently — CloudFront was never warmed, and the first client request after every publish was a cold miss hitting origin.

This fix looks up API tokens for all projects in the publishment variant via `mgr.sudo().validateOrGetProjectApiToken()` and includes them as `x-plasmic-api-project-tokens` in the warming fetch.

## Changes

- `prefill-cloudfront.ts`: import `parseProjectIdSpec`; look up tokens for all `resolvedProjectIdSpecs` before the warming fetch; pass as `x-plasmic-api-project-tokens` header
- `prefill-cloudfront.spec.ts`: mock `validateOrGetProjectApiToken` in `setupMocks`; assert every warming fetch includes the header with correct per-variant token strings

## Design decisions

Token lookup uses `mgr.sudo().validateOrGetProjectApiToken()` rather than threading the token through from the publish request. The prefill POST from WAB carries no auth headers (bare fetch), so `mgr.projectIdsAndTokens` is empty by the time `prefillCloudfront` runs. The sudo lookup is a single indexed DB read per project and follows the pattern used at DbMgr line 6732. For multi-project publishments all project tokens are fetched in parallel via `Promise.all`.

## Testing

- Unit tests updated: `validateOrGetProjectApiToken` mocked; new assertions verify every warming fetch includes `x-plasmic-api-project-tokens` with the correct value for both multi-project (`p1:token-p1,p2:token-p2,p3:token-p3`) and single-project (`p1:token-p1`) variants
- Diagnosed via CloudWatch logs showing `status: 401, ok: false` on `loader-prefill-warming-url` log entries in integration

## Reviewer notes

The 401 was being swallowed as a non-fatal warming failure — invalidation still ran, `isPrefilled` was still set, so publishes succeeded but CloudFront was never warmed. The symptom was `X-Cache: Miss` on every post-publish versioned fetch and `wait for ready` time of ~60s (the 30s abort timeout firing before the warming gave up).