### PR TITLE
fix(wab): enable splits tab for restricted/white-label users

### DIFF
--- a/platform/wab/src/wab/client/components/studio/LeftTabStrip.tsx
+++ b/platform/wab/src/wab/client/components/studio/LeftTabStrip.tsx
@@ -233,11 +233,10 @@ Help
           tabKey: "splits",
           icon: <IconIcon />,
           label: "Split content",
-          cond:
-            isLoggedIn &&
-            DEVFLAGS.splits &&
-            canViewTab("splits") &&
-            !isRestrictedUser,
+          // Splits is a core editing feature — not gated by isRestrictedUser.
+          // Access is controlled by DEVFLAGS.splits, canViewTab, and the
+          // splitContent feature tier (checked at publish time).
+          cond: isLoggedIn && DEVFLAGS.splits && canViewTab("splits"),
         },
         imports: {
           type: "item",


### PR DESCRIPTION
## Summary

- Remove the `!isRestrictedUser` guard from the Splits tab in `LeftTabStrip.tsx`
- Splits is a core Studio editing feature needed for segmentation — it was incorrectly grouped with Plasmic community links (Slack, Forum, Docs, Help) that are correctly hidden in white-label contexts
- Access remains controlled by `DEVFLAGS.splits`, `canViewTab("splits")`, and the `splitContent` feature tier at publish time

Closes #254

## Test plan

- [x] Restricted/white-label user opens Studio → "Split content" tab is visible under "More" in the left sidebar
- [x] User can create Segment and A/B test splits
- [x] Non-restricted user experience is unchanged
- [x] Slack, Forum, Docs, Help links remain hidden for restricted users