### PR TITLE
feat(loader): add Server-Timing headers to versioned loader endpoint

### DIFF
--- a/platform/wab/src/wab/server/routes/loader.ts
+++ b/platform/wab/src/wab/server/routes/loader.ts
@@ -26,6 +26,11 @@ import {
 import { logger } from "@/wab/server/observability";
 import { superDbMgr, userDbMgr } from "@/wab/server/routes/util";
 import { withSpan } from "@/wab/server/util/apm-util";
+import {
+  getServerTimingHeader,
+  runWithServerTiming,
+  timedProxy,
+} from "@/wab/server/util/server-timing";
 import { prefillCloudfront } from "@/wab/server/workers/prefill-cloudfront";
 import { BadRequestError, NotFoundError } from "@/wab/shared/ApiErrors/errors";
 import { ProjectId } from "@/wab/shared/ApiSchema";
@@ -220,84 +225,94 @@ export function makeCacheableVersionedLoaderQuery({
 }
 
 export async function buildVersionedLoaderAssets(req: Request, res: Response) {
-  const mgr = userDbMgr(req);
-  const {
-    platform,
-    nextjsAppDir,
-    browserOnly,
-    projectIdSpecs,
-    loaderVersion,
-    i18nKeyScheme,
-    i18nTagPrefix,
-    skipHead,
-  } = getLoaderOptions(req);
-
-  const projectVersions = projectIdSpecs.map(parseProjectIdSpec);
-
-  for (const { projectId, version } of projectVersions) {
-    if (!version) {
-      throw new BadRequestError(
-        `Project ${projectId} does not have a specified version`
-      );
-    }
-  }
-
-  await Promise.all(
-    projectVersions.map(({ projectId }) =>
-      mgr.checkProjectPerms(projectId, "viewer", "get")
-    )
-  );
-
-  const projects = await Promise.all(
-    projectVersions.map(
-      async ({ projectId }) => await mgr.getProjectById(projectId)
-    )
-  );
-  trackLoaderCodegenEvent(req, projects, {
-    versionType: "versioned",
-    platform,
-  });
-
-  req.promLabels.projectId = projects.map((p) => p.id).join(",");
-
-  const result = await genPublishedLoaderCodeBundle(
-    mgr,
-    req.workerpool,
-    makeGenPublishedLoaderCodeBundleOpts({
+  return runWithServerTiming(async () => {
+    const mgr = userDbMgr(req);
+    const {
       platform,
-      appDir: nextjsAppDir,
-      projectVersions: Object.fromEntries(
-        projectVersions.map(({ projectId, version }) => [
-          projectId,
-          mkVersionToSync(
-            ensure(version, "Unexpected nullish version in projectVersions")
-          ),
-        ])
-      ),
-      i18n: {
-        keyScheme: i18nKeyScheme,
-        tagPrefix: i18nTagPrefix,
-      },
+      nextjsAppDir,
+      browserOnly,
+      projectIdSpecs,
+      loaderVersion,
+      i18nKeyScheme,
+      i18nTagPrefix,
+      skipHead,
+    } = getLoaderOptions(req);
+
+    const projectVersions = projectIdSpecs.map(parseProjectIdSpec);
+
+    for (const { projectId, version } of projectVersions) {
+      if (!version) {
+        throw new BadRequestError(
+          `Project ${projectId} does not have a specified version`
+        );
+      }
+    }
+
+    const timedMgr = timedProxy(mgr, "db");
+
+    await Promise.all(
+      projectVersions.map(({ projectId }) =>
+        timedMgr.checkProjectPerms(projectId, "viewer", "get")
+      )
+    );
+
+    const projects = await Promise.all(
+      projectVersions.map(
+        async ({ projectId }) => await timedMgr.getProjectById(projectId)
+      )
+    );
+    trackLoaderCodegenEvent(req, projects, {
+      versionType: "versioned",
+      platform,
+    });
+
+    req.promLabels.projectId = projects.map((p) => p.id).join(",");
+
+    const result = await genPublishedLoaderCodeBundle(
+      timedMgr,
+      req.workerpool,
+      makeGenPublishedLoaderCodeBundleOpts({
+        platform,
+        appDir: nextjsAppDir,
+        projectVersions: Object.fromEntries(
+          projectVersions.map(({ projectId, version }) => [
+            projectId,
+            mkVersionToSync(
+              ensure(version, "Unexpected nullish version in projectVersions")
+            ),
+          ])
+        ),
+        i18n: {
+          keyScheme: i18nKeyScheme,
+          tagPrefix: i18nTagPrefix,
+        },
+        loaderVersion,
+        browserOnly,
+        skipHead,
+      })
+    );
+
+    const projectIds = projectVersions.map(({ projectId }) => projectId);
+
+    await timedMgr.upsertLoaderPublishmentEntities({
+      projectIds,
+      platform,
       loaderVersion,
       browserOnly,
-      skipHead,
-    })
-  );
+      i18nKeyScheme,
+      i18nTagPrefix,
+      appDir: nextjsAppDir,
+    });
 
-  const projectIds = projectVersions.map(({ projectId }) => projectId);
-
-  await mgr.upsertLoaderPublishmentEntities({
-    projectIds,
-    platform,
-    loaderVersion,
-    browserOnly,
-    i18nKeyScheme,
-    i18nTagPrefix,
-    appDir: nextjsAppDir,
+    if (process.env.NODE_ENV !== "production") {
+      const timingHeader = getServerTimingHeader();
+      if (timingHeader) {
+        res.setHeader("Server-Timing", timingHeader);
+      }
+    }
+    setAsCacheableResource(res);
+    res.json(result);
   });
-
-  setAsCacheableResource(res);
-  res.json(result);
 }
 
 /**

--- a/platform/wab/src/wab/server/util/apm-util.ts
+++ b/platform/wab/src/wab/server/util/apm-util.ts
@@ -1,5 +1,6 @@
 import { logger } from "@/wab/server/observability";
 import { WabPromTimer } from "@/wab/server/promstats";
+import { recordTiming } from "@/wab/server/util/server-timing";
 import { Properties } from "@/wab/shared/observability/Properties";
 import { trace } from "@opentelemetry/api";
 
@@ -27,6 +28,7 @@ export async function withSpan<T>(
         duration_ms: durationMs,
         ...payload,
       });
+      recordTiming(name, durationMs);
       promTimer.end();
       span.end();
     }

--- a/platform/wab/src/wab/server/util/s3-util.ts
+++ b/platform/wab/src/wab/server/util/s3-util.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/wab/server/observability";
+import { withTiming } from "@/wab/server/util/server-timing";
 import { ensureInstance } from "@/wab/shared/common";
 import S3 from "aws-sdk/clients/s3";
 import path from "path";
@@ -12,21 +13,21 @@ export async function upsertS3CacheEntry<T>(opts: {
 }) {
   const { bucket, key, compute: f, serialize, deserialize } = opts;
   const s3 = new S3({ endpoint: process.env.S3_ENDPOINT });
+  const shortKey = key.split("/").slice(-1)[0].slice(0, 24);
 
   try {
-    const obj = await s3
-      .getObject({
-        Bucket: bucket,
-        Key: key,
-      })
-      .promise();
+    const obj = await withTiming(`s3-get-${shortKey}`, () =>
+      s3.getObject({ Bucket: bucket, Key: key }).promise()
+    );
     const serialized = ensureInstance(obj.Body, Buffer).toString("utf8");
     logger().info(`S3 cache hit for ${bucket} ${key}`, {
       s3CacheResult: "hit",
       bucket,
       key,
     });
-    const data = deserialize(serialized);
+    const data = await withTiming(`s3-deserialize-${shortKey}`, async () =>
+      deserialize(serialized)
+    );
     return data;
   } catch (err) {
     if (err.code === "TimeoutError") {
@@ -37,16 +38,12 @@ export async function upsertS3CacheEntry<T>(opts: {
       bucket,
       key,
     });
-    const content = await f();
+    const content = await withTiming(`s3-compute-${shortKey}`, f);
     const serialized = serialize(content);
     try {
-      await s3
-        .putObject({
-          Bucket: bucket,
-          Key: key,
-          Body: serialized,
-        })
-        .promise();
+      await withTiming(`s3-put-${shortKey}`, () =>
+        s3.putObject({ Bucket: bucket, Key: key, Body: serialized }).promise()
+      );
     } catch (e) {
       if (process.env.NODE_ENV === "production") {
         throw e;

--- a/platform/wab/src/wab/server/util/server-timing.ts
+++ b/platform/wab/src/wab/server/util/server-timing.ts
@@ -1,0 +1,63 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+interface TimingEntry {
+  name: string;
+  dur: number;
+  desc?: string;
+}
+
+const storage = new AsyncLocalStorage<TimingEntry[]>();
+
+export function runWithServerTiming<T>(fn: () => Promise<T>): Promise<T> {
+  return storage.run([], fn);
+}
+
+export function recordTiming(name: string, dur: number, desc?: string) {
+  storage.getStore()?.push({ name, dur, desc });
+}
+
+export async function withTiming<T>(
+  name: string,
+  fn: () => Promise<T>,
+  desc?: string
+): Promise<T> {
+  const start = Date.now();
+  try {
+    return await fn();
+  } finally {
+    recordTiming(name, Date.now() - start, desc);
+  }
+}
+
+export function timedProxy<T extends object>(target: T, prefix = ""): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const val = Reflect.get(obj, prop, receiver);
+      if (typeof val !== "function") return val;
+      const name = prefix ? `${prefix}-${String(prop)}` : String(prop);
+      return function (this: unknown, ...args: unknown[]) {
+        const result = (val as Function).apply(this ?? obj, args);
+        if (result instanceof Promise) {
+          const start = Date.now();
+          return result.finally(() => {
+            recordTiming(name, Date.now() - start);
+          });
+        }
+        return result;
+      };
+    },
+  });
+}
+
+export function getServerTimingHeader(): string | undefined {
+  const store = storage.getStore();
+  if (!store || store.length === 0) return undefined;
+  return store
+    .map(({ name, dur, desc }) => {
+      const safeName = name.replace(/[^a-zA-Z0-9_\-]/g, "-");
+      return desc
+        ? `${safeName};dur=${dur.toFixed(1)};desc="${desc}"`
+        : `${safeName};dur=${dur.toFixed(1)}`;
+    })
+    .join(", ");
+}


### PR DESCRIPTION
Adds per-request Server-Timing headers to /api/v1/loader/code/versioned to expose function-by-function breakdown of where time is spent on warm S3 requests. Captures DB method calls via timedProxy on DbMgr, S3 get/ compute/put/deserialize timings in upsertS3CacheEntry, and existing withSpan phases (loader-resolve-deps, loader-codegen, loader-bundle).

Headers are only emitted outside of production to avoid leaking internal S3 key patterns and DB method names to external callers.