### PR TITLE
feat(loader): add ENABLE_SERVER_TIMING env var to control Server-Timing headers

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -583,7 +583,8 @@ function addMiddlewares(
     if (
       isAdminTeamEmail(req.user?.email, DEVFLAGS) ||
       req.path.includes("/server-data") ||
-      ROUTES_WITH_TIMING.some((route) => req.path.includes(route))
+      ROUTES_WITH_TIMING.some((route) => req.path.includes(route)) ||
+      process.env.ENABLE_SERVER_TIMING === "true"
     ) {
       const timingStore = { calls: [], cur: undefined };
       req.timingStore = timingStore;

--- a/platform/wab/src/wab/server/routes/loader.ts
+++ b/platform/wab/src/wab/server/routes/loader.ts
@@ -304,7 +304,7 @@ export async function buildVersionedLoaderAssets(req: Request, res: Response) {
       appDir: nextjsAppDir,
     });
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.ENABLE_SERVER_TIMING === "true") {
       const timingHeader = getServerTimingHeader();
       if (timingHeader) {
         res.setHeader("Server-Timing", timingHeader);


### PR DESCRIPTION
## What does this MR do?

Adds an `ENABLE_SERVER_TIMING` environment variable to control emission of `Server-Timing` headers on loader responses. Previously the guard was `NODE_ENV !== "production"`, which meant headers were never emitted on ECS (which always runs `NODE_ENV=production`). This change decouples timing visibility from `NODE_ENV`.

## Changes

- `loader.ts`: Replace `NODE_ENV !== "production"` guard with `ENABLE_SERVER_TIMING === "true"` on the versioned endpoint Server-Timing emission
- `AppServer.ts`: Add `ENABLE_SERVER_TIMING === "true"` as an additional condition in the timing middleware, so the timing store is populated even when the caller is not an admin-team user

## Design decisions

The env var approach lets us enable Server-Timing per environment (integration only) without forking on `NODE_ENV`. The middleware condition is an OR, so admin-team users and configured routes continue to get timing regardless of the env var.

## Testing

Manually verified via curl against integration with `ENABLE_SERVER_TIMING=true` set — `Server-Timing` header appears on `/api/v1/loader/code/versioned` responses. The corresponding terraservices MR enables the flag for integration.

## Reviewer notes

Companion to the terraservices MR that wires `ENABLE_SERVER_TIMING=true` into the integration ECS task definition. The two should be merged together.