### PR TITLE
refactor(loader): remove CloudFront versioned cache warming from prefill

### DIFF
--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.spec.ts
@@ -54,7 +54,6 @@ describe("Prefill cloudfront", () => {
   });
 
   describe("prefillCloudfront", () => {
-    const CODEGEN_HOST = "http://cghost";
     const PROJECT_ID = "P1";
     const PKG_ID = "p1-pkgId-1";
     const PKG_VERSION = "0.0.1";
@@ -71,11 +70,9 @@ describe("Prefill cloudfront", () => {
       (cf.CreateInvalidationCommand as jest.Mock).mockImplementation(
         (input: any) => input
       );
-      global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
     });
 
     afterEach(() => {
-      delete process.env.CODEGEN_HOST;
       delete process.env.CLOUDFRONT_DISTRIBUTION_ID;
     });
 
@@ -150,10 +147,6 @@ describe("Prefill cloudfront", () => {
       }));
 
       sudo.updatePkgVersion = jest.fn();
-
-      sudo.validateOrGetProjectApiToken = jest
-        .fn()
-        .mockImplementation((pid: string) => Promise.resolve(`token-${pid}`));
 
       return { getResolvedProjectVersions, genPublishedLoaderCodeBundle };
     }
@@ -256,105 +249,14 @@ describe("Prefill cloudfront", () => {
       });
     });
 
-    it("should warm CloudFront versioned cache before setting isPrefilled", async () => {
+    it("should invalidate published CloudFront paths after bundle generation", async () => {
       await withDb(async (sudo) => {
         setupMocks(sudo);
-        process.env.CODEGEN_HOST = CODEGEN_HOST;
-
-        const pool: any = {};
-        const updatePkgVersionMock = sudo.updatePkgVersion as jest.Mock;
-
-        await prefillCloudfront(sudo, pool, PKG_VERSION_ID);
-
-        // Warming fetches must complete before isPrefilled is set so that
-        // status only becomes "ready" once the CDN is actually primed.
-        const updateCallOrder = updatePkgVersionMock.mock.invocationCallOrder[0];
-        const lastFetchCallOrder = (global.fetch as jest.Mock).mock
-          .invocationCallOrder.at(-1);
-        expect(lastFetchCallOrder).toBeLessThan(updateCallOrder);
-
-        // One warming GET per unique publishment. All 4 mock publishments have
-        // distinct uniqBy keys (react/8/false, nextjs/8/false+i18n, react/8/true,
-        // react/1/true) so all 4 survive dedup and each gets a warming fetch.
-        expect(global.fetch).toHaveBeenCalledTimes(4);
-
-        // Verify URL construction for a known publishment
-        const fetchedUrls = (global.fetch as jest.Mock).mock.calls.map(
-          (c: any[]) => c[0]
-        );
-        expect(
-          fetchedUrls.some((url: string) =>
-            url.includes("/api/v1/loader/code/versioned") &&
-            url.includes("platform=react") &&
-            url.includes("loaderVersion=8") &&
-            url.includes("projectId=p1%400.0.1") &&
-            url.includes("projectId=p2%400.0.2") &&
-            url.includes("projectId=p3%400.0.3") &&
-            !url.includes("browserOnly")
-          )
-        ).toBe(true);
-
-        expect(
-          fetchedUrls.some((url: string) =>
-            url.includes("platform=nextjs") &&
-            url.includes("nextjsAppDir=true") &&
-            url.includes("i18nKeyScheme=hash") &&
-            url.includes("i18nTagPrefix=n")
-          )
-        ).toBe(true);
-
-        expect(
-          fetchedUrls.some((url: string) =>
-            url.includes("platform=react") &&
-            url.includes("browserOnly=true") &&
-            url.includes("projectId=p1%400.0.1") &&
-            !url.includes("projectId=p2")
-          )
-        ).toBe(true);
-
-        // Every warming fetch must include x-plasmic-api-project-tokens so the
-        // versioned endpoint authorises the request instead of returning 401.
-        const fetchCalls = (global.fetch as jest.Mock).mock.calls as [string, RequestInit][];
-        for (const [, opts] of fetchCalls) {
-          expect(
-            (opts?.headers as Record<string, string>)?.["x-plasmic-api-project-tokens"]
-          ).toBeTruthy();
-        }
-        // Multi-project variant includes tokens for all resolved specs
-        expect(
-          fetchCalls.some(([, opts]) =>
-            (opts?.headers as Record<string, string>)?.[
-              "x-plasmic-api-project-tokens"
-            ] === "p1:token-p1,p2:token-p2,p3:token-p3"
-          )
-        ).toBe(true);
-        // Single-project variant includes only that project's token
-        expect(
-          fetchCalls.some(([, opts]) =>
-            (opts?.headers as Record<string, string>)?.[
-              "x-plasmic-api-project-tokens"
-            ] === "p1:token-p1"
-          )
-        ).toBe(true);
-      });
-    });
-
-    it("should invalidate published CloudFront paths after warming", async () => {
-      await withDb(async (sudo) => {
-        setupMocks(sudo);
-        process.env.CODEGEN_HOST = CODEGEN_HOST;
         process.env.CLOUDFRONT_DISTRIBUTION_ID = "EDFDVBD6EXAMPLE";
 
         const pool: any = {};
 
         await prefillCloudfront(sudo, pool, PKG_VERSION_ID);
-
-        // Warming must complete before isPrefilled is set and before invalidation,
-        // so that "status=ready" is only signalled once the CDN is primed.
-        const firstFetchOrder = (global.fetch as jest.Mock).mock
-          .invocationCallOrder[0];
-        const invalidationOrder = mockSend.mock.invocationCallOrder[0];
-        expect(firstFetchOrder).toBeLessThan(invalidationOrder);
 
         // codePaths deduplicates on sorted projectId strings (not on all
         // platform/loaderVersion fields), so publishments sharing the same
@@ -386,7 +288,6 @@ describe("Prefill cloudfront", () => {
     it("should continue generating remaining variants if one bundle fails", async () => {
       await withDb(async (sudo) => {
         const { genPublishedLoaderCodeBundle } = setupMocks(sudo);
-        process.env.CODEGEN_HOST = CODEGEN_HOST;
         process.env.CLOUDFRONT_DISTRIBUTION_ID = "EDFDVBD6EXAMPLE";
 
         // Fail only the second variant
@@ -400,26 +301,7 @@ describe("Prefill cloudfront", () => {
         // Should not throw — per-variant errors are non-fatal
         await expect(prefillCloudfront(sudo, pool, PKG_VERSION_ID)).resolves.not.toThrow();
 
-        // All 4 variants still get warming fetches and invalidation proceeds
-        expect(global.fetch).toHaveBeenCalledTimes(4);
-        expect(mockSend).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    it("should warn and continue if warming fetches fail", async () => {
-      await withDb(async (sudo) => {
-        setupMocks(sudo);
-        process.env.CODEGEN_HOST = CODEGEN_HOST;
-        process.env.CLOUDFRONT_DISTRIBUTION_ID = "EDFDVBD6EXAMPLE";
-        // All warming fetches return 500
-        (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 } as Response);
-
-        const pool: any = {};
-
-        // Should not throw — warming failures are non-fatal
-        await expect(prefillCloudfront(sudo, pool, PKG_VERSION_ID)).resolves.not.toThrow();
-
-        // Invalidation should still be attempted after warming failures
+        // Invalidation still proceeds despite one bundle failure
         expect(mockSend).toHaveBeenCalledTimes(1);
       });
     });

--- a/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
+++ b/platform/wab/src/wab/server/workers/prefill-cloudfront.ts
@@ -7,18 +7,13 @@ import { genPublishedLoaderCodeBundle } from "@/wab/server/loader/gen-code-bundl
 import {
   getResolvedProjectVersions,
   mkVersionToSync,
-  parseProjectIdSpec,
 } from "@/wab/server/loader/resolve-projects";
 import { logger } from "@/wab/server/observability";
 import { captureException } from "@/wab/server/observability/datadog";
-import {
-  makeGenPublishedLoaderCodeBundleOpts,
-  makeCacheableVersionedLoaderQuery,
-} from "@/wab/server/routes/loader";
-import { withSpan, withTimeSpent } from "@/wab/server/util/apm-util";
+import { makeGenPublishedLoaderCodeBundleOpts } from "@/wab/server/routes/loader";
+import { withSpan } from "@/wab/server/util/apm-util";
 import { PlasmicWorkerPool } from "@/wab/server/workers/pool";
 import { ensureDevFlags } from "@/wab/server/workers/worker-utils";
-import { getCodegenPublicUrl } from "@/wab/shared/urls";
 import { uniqBy } from "lodash";
 
 // Reuse a single client instance across publishes — the AWS SDK client is
@@ -73,30 +68,30 @@ export async function prefillCloudfront(
         })),
       });
 
-      // Collect resolved specs alongside bundle generation so we can reuse them
-      // for CDN warming without a second DB query.
-      const warmingData: Array<{
+      // Collect resolved specs alongside bundle generation so they can be
+      // reused for CloudFront invalidation without a second DB query.
+      const prefillData: Array<{
         publishment: (typeof loaderPublishments)[0];
         resolvedProjectIdSpecs: string[];
       }> = [];
 
-      // Phase 1: resolve all project versions upfront so warmingData is fully
-      // populated before bundle generation starts. This ensures CDN warming and
-      // invalidation cover all variants even if a later bundle generation fails.
+      // Phase 1: resolve all project versions upfront so prefillData is fully
+      // populated before bundle generation starts. This ensures invalidation
+      // covers all variants even if a later bundle generation fails.
       for (const publishment of loaderPublishments) {
         const resolvedProjectIdSpecs = await getResolvedProjectVersions(
           mgr,
           publishment.projectIds
         );
-        warmingData.push({ publishment, resolvedProjectIdSpecs });
+        prefillData.push({ publishment, resolvedProjectIdSpecs });
       }
 
       // Phase 2: generate bundles sequentially to bound peak memory usage.
       // Each variant is wrapped independently so a single failure does not abort
-      // the remaining variants — all are still warmed and invalidated below.
+      // the remaining variants — all are still invalidated below.
       let bundleSuccesses = 0;
       let bundleFailures = 0;
-      for (const { publishment, resolvedProjectIdSpecs } of warmingData) {
+      for (const { publishment, resolvedProjectIdSpecs } of prefillData) {
         try {
           await withSpan(
             "loader-prefill-bundle",
@@ -148,98 +143,9 @@ export async function prefillCloudfront(
         }
       }
 
-      // Phase 3: warm CloudFront's versioned cache by GETting each versioned
-      // URL through the CDN. This must happen before invalidating the published
-      // cache so that when clients follow the published→versioned redirect they
-      // get a cache hit. Warming works without isPrefilled being set because the
-      // versioned endpoint serves directly from S3 by projectId@version.
-      if (warmingData.length > 0) {
-        const baseUrl =
-          process.env.CODEGEN_CLOUDFRONT_URL ?? getCodegenPublicUrl();
-        await withSpan(
-          "loader-prefill-warming",
-          async () => {
-            const warmingResults = await Promise.allSettled(
-              warmingData.map(async ({ publishment, resolvedProjectIdSpecs }) => {
-                // Use the same query builder as buildPublishedLoaderAssets so
-                // the warming URL is identical to the versioned redirect URL
-                // clients follow, producing the same CloudFront cache key.
-                const query = makeCacheableVersionedLoaderQuery({
-                  platform: publishment.platform,
-                  nextjsAppDir: publishment.appDir ?? false,
-                  loaderVersion: publishment.loaderVersion,
-                  resolvedProjectIdSpecs,
-                  browserOnly: publishment.browserOnly ?? false,
-                  i18nKeyScheme: publishment.i18nKeyScheme ?? undefined,
-                  i18nTagPrefix: publishment.i18nTagPrefix ?? undefined,
-                });
-                // Look up API tokens for all projects in this variant so the
-                // warming GET is authorised — the versioned endpoint requires
-                // x-plasmic-api-project-tokens to serve the bundle.
-                const projectTokens = await Promise.all(
-                  resolvedProjectIdSpecs.map(async (spec) => {
-                    const { projectId: specProjectId } =
-                      parseProjectIdSpec(spec);
-                    const token =
-                      await mgr.sudo().validateOrGetProjectApiToken(
-                        specProjectId
-                      );
-                    return `${specProjectId}:${token}`;
-                  })
-                );
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 30_000);
-                const { result, spentTime } = await withTimeSpent(() =>
-                  fetch(`${baseUrl}/api/v1/loader/code/versioned?${query}`, {
-                    signal: controller.signal,
-                    headers: {
-                      "x-plasmic-api-project-tokens": projectTokens.join(","),
-                    },
-                  }).finally(() => clearTimeout(timeoutId))
-                );
-                logger().info("loader-prefill-warming-url", {
-                  project_id: projectId,
-                  platform: publishment.platform,
-                  loader_version: publishment.loaderVersion,
-                  browser_only: publishment.browserOnly ?? false,
-                  app_dir: publishment.appDir ?? false,
-                  duration_ms: spentTime,
-                  ok: result.ok,
-                  status: result.status,
-                  url: `${baseUrl}/api/v1/loader/code/versioned?${query}`,
-                });
-                return result;
-              })
-            );
-
-            const warmingSucceeded = warmingResults.filter(
-              (r) => r.status === "fulfilled" && r.value.ok
-            ).length;
-            const warmingFailed = warmingResults.length - warmingSucceeded;
-            logger().info("loader-prefill-warming-summary", {
-              project_id: projectId,
-              total: warmingResults.length,
-              succeeded: warmingSucceeded,
-              failed: warmingFailed,
-            });
-            if (warmingFailed > 0) {
-              logger().warn(
-                `CloudFront versioned cache warming had ${warmingFailed}/${warmingResults.length} failures for ${projectId} — invalidation will proceed but some clients may hit origin`
-              );
-            }
-          },
-          undefined,
-          { project_id: projectId, variant_count: warmingData.length }
-        );
-      }
-
-      // Mark as prefilled immediately before invalidation. Setting it here
-      // (after warming, before invalidation) ensures:
-      //   1. The versioned cache is already hot for any cache miss on the
-      //      published redirect.
-      //   2. The window between "status = ready" and "published cache
-      //      invalidated" is minimised to just the invalidation API call
-      //      (~100ms), rather than the full warming duration (up to 30s × N).
+      // Mark as prefilled before invalidation to minimise the window between
+      // "status = ready" and "published cache invalidated" to just the
+      // CloudFront API call (~100ms).
       await mgr.updatePkgVersion(
         pkgVersion.pkgId,
         pkgVersion.version,
@@ -247,8 +153,8 @@ export async function prefillCloudfront(
         { isPrefilled: true }
       );
 
-      // Phase 4: invalidate published CDN paths so clients are redirected to
-      // the now-warmed versioned entries.
+      // Phase 3: invalidate published CDN paths so clients see the new redirect
+      // to the freshly S3-prefilled versioned bundle.
       //
       // code/published paths are keyed by sorted project IDs embedded in the
       // URL path by the CloudFront Function (e.g. /published/aaa,zzz*). One
@@ -261,7 +167,7 @@ export async function prefillCloudfront(
       if (distributionId) {
         const codePaths = [
           ...new Set(
-            warmingData.map(
+            prefillData.map(
               ({ publishment }) =>
                 `/api/v1/loader/code/published/${[...publishment.projectIds]
                   .sort()
@@ -325,7 +231,6 @@ export async function prefillCloudfront(
         variant_count: loaderPublishments.length,
         bundle_successes: bundleSuccesses,
         bundle_failures: bundleFailures,
-        warming_variant_count: warmingData.length,
         invalidation_enabled: !!process.env.CLOUDFRONT_DISTRIBUTION_ID,
       });
     },


### PR DESCRIPTION
## What does this MR do?

Removes the CloudFront versioned cache warming phase from `prefillCloudfront`. The versioned endpoint now serves bundles directly from the S3 bundle cache (landed in #260), so pre-warming CloudFront by GETting each versioned URL is unnecessary overhead. CloudFront invalidation of published paths is retained so clients receive the updated published→versioned redirect promptly after a publish.

## Changes

- Remove Phase 3 (CloudFront warming): the `withSpan("loader-prefill-warming")` fetch loop that GETted each versioned URL through the CDN
- Remove unused imports: `makeCacheableVersionedLoaderQuery`, `parseProjectIdSpec`, `withTimeSpent`, `getCodegenPublicUrl`
- Rename `warmingData` → `prefillData` (no longer warming-specific)
- Simplify `isPrefilled` placement comment — warming is gone, invalidation remains
- Remove `warming_variant_count` from the completion log
- Drop two warming-specific tests and clean up `global.fetch` / `validateOrGetProjectApiToken` mocks that were only needed for those tests

## Design decisions

CloudFront warming was added to ensure versioned bundles were cache-hot before clients followed the published redirect. With the S3 early bundle cache (fast-path), the versioned endpoint returns the pre-built S3 bundle in ~40–100ms on a cold CloudFront miss, so pre-warming provides no meaningful latency benefit and adds complexity and latency to the prefill path itself.

CloudFront invalidation of `code/published/*` paths is kept: it still matters for clearing the cached published→versioned redirect so clients see the new version without waiting for TTL expiry.

## Testing

- Removed two warming-specific tests ("should warm CloudFront versioned cache before setting isPrefilled", "should warn and continue if warming fetches fail")
- Updated remaining tests to remove `CODEGEN_HOST` env var setup and `fetch`/`validateOrGetProjectApiToken` mocks that were only used by warming
- Existing invalidation and bundle-generation tests are unchanged and continue to pass