### PR TITLE
fix(wab): fix Pino logger arg order in prefillPkgVersion catch block

### DIFF
--- a/platform/wab/src/wab/server/routes/projects.ts
+++ b/platform/wab/src/wab/server/routes/projects.ts
@@ -2089,8 +2089,8 @@ export async function prefillPkgVersion(
   } catch (err) {
     await req.con.transaction(async (entMgr) => {
       logger().error(
+        { err, error_message: err instanceof Error ? err.message : String(err) },
         `Error pre-filling ${projectId}@${pkgVersion.version}; marking as pre-filled anyway`,
-        err
       );
       const superMgr = new DbMgr(entMgr, SUPER_USER);
       await superMgr.updatePkgVersion(


### PR DESCRIPTION
Closes #12

## Summary
- `logger().error` takes `(obj, message)` not `(message, obj)` — the error object was being passed as a printf format string, silently discarding structured error details from Datadog logs.

## Test plan
- [ ] After deploy, trigger a publish and confirm the prefill error log (if it fires) shows structured `err` and `error_message` fields in Datadog