### PR TITLE
feat(wab): propagate x-request-id across service boundaries

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -440,7 +440,7 @@ function addDatadogErrorHandler(app: express.Application) {
 export function addLoggingMiddleware(app: express.Application) {
   app.use(
     safeCast<RequestHandler>(async (req: Request, res, next) => {
-      req.id = mkShortId();
+      req.id = req.get("x-request-id") ?? mkShortId();
       runWithRequestId(req.id, () => next());
     })
   );

--- a/platform/wab/src/wab/server/routes/projects.ts
+++ b/platform/wab/src/wab/server/routes/projects.ts
@@ -2081,6 +2081,7 @@ export async function prefillPkgVersion(
       `${req.devflags.codegenOriginHost}/api/v1/loader/code/prefill/${pkgVersion.id}`,
       {
         method: "POST",
+        headers: { "x-request-id": req.id },
       }
     );
     if (fetchResponse.status !== 200) {


### PR DESCRIPTION
addLoggingMiddleware now honours an incoming x-request-id header before falling back to mkShortId(), so any service (WAB, codegen, loader) will reuse a caller-supplied ID rather than generating a new one.

The prefill fetch from WAB to codegen now forwards req.id as x-request-id, making the full WAB → codegen prefill trace correlatable in Datadog by filtering on x_request_id.