### PR TITLE
fix(wab): log 4xx ApiErrors as warn, 5xx and unhandled errors as error

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -1969,11 +1969,14 @@ function addEndErrorHandlers(app: express.Application) {
       ) => {
         // Too noisy in CI to print AuthError all the time
         if (!(origErr instanceof AuthError)) {
-          logger().error("ERROR!", {
-            error: origErr.message,
-            stack: origErr.stack,
-            name: origErr.name,
-          });
+          if (isApiError(origErr) && origErr.statusCode < 500) {
+            logger().warn(`${origErr.name} - ${origErr.message}`);
+          } else {
+            logger().error(
+              `${origErr.name ?? "Unhandled server error"} - ${origErr.message}`,
+              { stack: origErr.stack }
+            );
+          }
         }
         if (res.headersSent || res.writableEnded) {
           logError(origErr, "Tried to edit closed response");


### PR DESCRIPTION
## Summary
- 4xx `ApiError` instances (e.g. `BadRequestError`, `NotFoundError`) are now logged at `warn` level since they represent user/client errors, not server failures
- 5xx and unhandled errors (plain `Error`, `TypeError`, DB errors) continue to log at `error` level with stack trace
- Log message now includes both error name and message: `BadRequestError - Project X has not been published yet.`

## Test plan
- [ ] Trigger a 400 response (e.g. request a project that hasn't been published) and confirm log shows `warn` not `error`
- [ ] Trigger an unhandled server error and confirm log still shows `error` with stack trace