### PR TITLE
fix(plasmic-mcp): validators, ingestion, and update-query functionCall

### DIFF
--- a/.github/workflows/plasmic-mcp.yml
+++ b/.github/workflows/plasmic-mcp.yml
@@ -34,7 +34,16 @@ jobs:
 
       - name: Generate required files (PEG parsers, model classes)
         working-directory: platform/wab
-        run: make
+        # Delete generated files first so `make` regenerates from the current
+        # schema. The restored cache (`actions/cache`) carries classes.ts with
+        # a fresh mtime, so make's mtime-based rule would otherwise skip the
+        # regen — and if the cache was built from an older schema (missing
+        # CustomFunctionExpr etc.), TypeScript then fails with spurious
+        # "no exported member" errors that don't reproduce locally.
+        run: |
+          rm -f src/wab/shared/model/classes.ts
+          rm -f src/wab/shared/model/classes-metas.ts
+          make
 
       - name: TypeScript type-check
         working-directory: packages/plasmic-mcp

--- a/packages/plasmic-mcp-registry/src/__tests__/slot-defaults.test.ts
+++ b/packages/plasmic-mcp-registry/src/__tests__/slot-defaults.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { serializeComponentMeta } from "../serialize";
+
+/**
+ * These tests enforce the invariant that slot-typed props keep their
+ * `defaultValue` PlasmicElement JSON tree intact after serialization.
+ *
+ * Studio's `addNewRegisteredComponents` (wab/shared/code-components/
+ * code-components.ts) consumes this field via `elementSchemaToTpl` to
+ * populate default slot contents on first drop of a code component. If
+ * the MCP's registry transport silently drops slot defaults, dev-host
+ * ingestion would succeed but drop the defaults users carefully authored
+ * in their `registerComponent(...)` meta — a silent data-loss footgun.
+ */
+describe("serializeComponentMeta — slot defaults survive JSON transport", () => {
+  it("preserves a single PlasmicElement text default on a slot prop", () => {
+    const meta = {
+      name: "WithTextSlot",
+      props: {
+        children: {
+          type: "slot",
+          defaultValue: { type: "text", value: "Hello world" },
+        },
+      },
+    };
+
+    const result = serializeComponentMeta(meta);
+    const props = result.props as Record<string, Record<string, unknown>>;
+    expect(props.children.type).toBe("slot");
+    expect(props.children.defaultValue).toEqual({
+      type: "text",
+      value: "Hello world",
+    });
+  });
+
+  it("leaves slot props with no defaultValue unchanged (no injected null)", () => {
+    // Studio's ingestion distinguishes "no default" (undefined) from "explicit
+    // null default". The serializer must not inject a synthetic defaultValue
+    // for slot props that didn't have one.
+    const meta = {
+      name: "NoSlotDefault",
+      props: {
+        header: { type: "slot" },
+      },
+    };
+
+    const result = serializeComponentMeta(meta);
+    const props = result.props as Record<string, Record<string, unknown>>;
+    expect(props.header.type).toBe("slot");
+    expect(props.header).not.toHaveProperty("defaultValue");
+  });
+
+  it("preserves an array-of-PlasmicElement default (common slot pattern)", () => {
+    // Exact shape used by EPProductProvider and most EP components — an array
+    // of element schemas as the children slot default.
+    const meta = {
+      name: "WithArraySlot",
+      props: {
+        children: {
+          type: "slot",
+          defaultValue: [
+            { type: "text", value: "Drop product UI here." },
+          ],
+        },
+      },
+    };
+
+    const result = serializeComponentMeta(meta);
+    const props = result.props as Record<string, Record<string, unknown>>;
+    expect(props.children.defaultValue).toEqual([
+      { type: "text", value: "Drop product UI here." },
+    ]);
+  });
+});

--- a/packages/plasmic-mcp-registry/src/next.ts
+++ b/packages/plasmic-mcp-registry/src/next.ts
@@ -40,22 +40,37 @@ interface WebpackContext {
   [key: string]: unknown;
 }
 
-/** Package patterns for serverExternalPackages (all Plasmic-related). */
-const PLASMIC_PACKAGE_PATTERNS = [
+/**
+ * Package patterns for `serverExternalPackages`.
+ *
+ * We ONLY externalise workspace/monorepo packages that (a) register code
+ * components and (b) do not carry a `"use client"` directive at their entry.
+ * The Next.js RSC runtime replaces `react` with `react.shared-subset` (no
+ * `createContext`), so modules that touch `React.createContext` at the top
+ * level blow up during server evaluation of API routes that import them.
+ * Externalising forces Node's `require` to load them outside the RSC graph
+ * using the consumer's full React from `node_modules`.
+ *
+ * Explicitly NOT externalised:
+ *   - `@plasmicapp/host` and `@plasmicapp/query` — published dists that
+ *     carry `"use client"` directives. Externalising them makes Node's
+ *     `require` load their React from the consumer's node_modules, which
+ *     is a different instance than Next's internally-bundled React →
+ *     "Invalid hook call / useContext is null" under the iframe runtime.
+ *     Bundling lets Next's webpack `react$` alias point both server and
+ *     client at Next's internal React, giving one dispatcher end-to-end.
+ *
+ * A consumer who hits a genuine RSC failure from some other package can
+ * still externalise it by passing `serverExternalPackages: ["…"]` in
+ * their own config; this wrapper merges the lists.
+ */
+const PLASMIC_PACKAGE_PATTERNS: RegExp[] = [
   /^@plasmicpkgs\//,
   /^@elasticpath\/plasmic-/,
-  /^@plasmicapp\/host$/,
-  /^@plasmicapp\/query$/,
 ];
 
-/**
- * Subset for webpack externals — only monorepo/workspace packages.
- *
- * @plasmicapp/host and @plasmicapp/query are real node_modules packages,
- * so serverExternalPackages handles them correctly (preserving shared React).
- * Externalizing them via webpack would cause duplicate React in SSR pages.
- */
-const WEBPACK_EXTERNAL_PATTERNS = [
+/** Webpack externals mirror the same set — needed for monorepo packages. */
+const WEBPACK_EXTERNAL_PATTERNS: RegExp[] = [
   /^@plasmicpkgs\//,
   /^@elasticpath\/plasmic-/,
 ];

--- a/packages/plasmic-mcp/src/__mocks__/wab-bundler.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-bundler.ts
@@ -15,6 +15,21 @@ export const mockRecomputeParents = vi.fn();
 export const mockUnbundlePartial = vi.fn();
 export const mockAllUuids = vi.fn().mockReturnValue([]);
 export const mockObjByAddr = vi.fn();
+export const mockCachedBundle = vi.fn();
+
+// Pre-save bundle validators exported from @/wab/shared/bundler in Studio.
+// Exposed as vi.fn() so unit tests can configure them to throw per-case to
+// prove the save-path wiring surfaces validator errors. Default: no-op, which
+// matches the Studio behavior on a well-formed bundle.
+export const mockCheckExistingReferences = vi.fn();
+export const mockCheckRefsInBundle = vi.fn();
+
+export function checkExistingReferences(bundle: unknown): void {
+  mockCheckExistingReferences(bundle);
+}
+export function checkRefsInBundle(bundle: unknown, opts?: unknown): void {
+  mockCheckRefsInBundle(bundle, opts);
+}
 
 export class FastBundler {
   constructor(_meta: any, _classes: any) {}
@@ -49,5 +64,9 @@ export class FastBundler {
 
   objByAddr(addr: { uuid: string; iid: string }): any | undefined {
     return mockObjByAddr(addr);
+  }
+
+  cachedBundle(): any {
+    return mockCachedBundle();
   }
 }

--- a/packages/plasmic-mcp/src/__mocks__/wab-classes.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-classes.ts
@@ -560,8 +560,65 @@ export const isKnownComponentDataQuery = (obj: any): boolean =>
   obj?._type === "ComponentDataQuery";
 export const isKnownComponentServerQuery = (obj: any): boolean =>
   obj?._type === "ComponentServerQuery";
+export const isKnownCustomFunctionExpr = (obj: any): boolean =>
+  obj?._type === "CustomFunctionExpr";
 export const isKnownMixin = (obj: any): boolean =>
   obj?._type === "Mixin";
+
+/** Mock constructor for CustomFunction — site-level registered function.
+ * Real shape (from classes.ts): namespace?, importName, importPath, params, uid.
+ * Only the fields referenced by MCP edit paths are modelled. */
+export class CustomFunction {
+  _type = "CustomFunction";
+  namespace?: string;
+  importName: string;
+  importPath: string;
+  params: any[];
+  uid: number;
+  isDefaultExport?: boolean;
+  isQuery?: boolean;
+  constructor(args: {
+    namespace?: string;
+    importName: string;
+    importPath: string;
+    params?: any[];
+    uid?: number;
+    isDefaultExport?: boolean;
+    isQuery?: boolean;
+  }) {
+    this.namespace = args.namespace;
+    this.importName = args.importName;
+    this.importPath = args.importPath;
+    this.params = args.params ?? [];
+    this.uid = args.uid ?? Math.floor(Math.random() * 1e9);
+    this.isDefaultExport = args.isDefaultExport;
+    this.isQuery = args.isQuery;
+  }
+}
+
+/** Mock constructor for FunctionArg — a single argument of a CustomFunctionExpr. */
+export class FunctionArg {
+  _type = "FunctionArg";
+  uuid: string;
+  expr: any;
+  argType: any;
+  constructor(args: { uuid: string; expr: any; argType: any }) {
+    this.uuid = args.uuid;
+    this.expr = args.expr;
+    this.argType = args.argType;
+  }
+}
+
+/** Mock constructor for CustomFunctionExpr — the query op that calls a custom function. */
+export class CustomFunctionExpr {
+  _type = "CustomFunctionExpr";
+  func: any;
+  args: any[];
+  constructor(args: { func: any; args: any[] }) {
+    this.func = args.func;
+    this.args = args.args;
+  }
+}
 
 /** Mock constructor for Mixin — reusable style bundle stored at site level. */
 export class Mixin {

--- a/packages/plasmic-mcp/src/__mocks__/wab-codegen-util.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-codegen-util.ts
@@ -1,0 +1,6 @@
+export function jsLiteral(value: any): string {
+  return JSON.stringify(value);
+}
+export function toVarName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, "_");
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-core-exprs.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-core-exprs.ts
@@ -1,0 +1,8 @@
+export interface ExprCtx {
+  component: any;
+  projectFlags: any;
+  inStudio: boolean;
+}
+export function getRawCode() {
+  return "";
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-core-sites.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-core-sites.ts
@@ -1,0 +1,6 @@
+export function allGlobalVariantGroups() {
+  return [];
+}
+export function createSite() {
+  return { components: [] } as any;
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-devflags.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-devflags.ts
@@ -1,0 +1,1 @@
+export const DEVFLAGS: Record<string, any> = {};

--- a/packages/plasmic-mcp/src/__mocks__/wab-plume-registry.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-plume-registry.ts
@@ -1,0 +1,3 @@
+export function getPlumeEditorPlugin() {
+  return undefined;
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-refactoring.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-refactoring.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit-test mock for `@/wab/shared/refactoring`.
+ *
+ * Unit tests don't exercise the pre-flight reference check (they run with
+ * mocked components that have no real expressions); returning false here
+ * means the gap #70 guard in `removeQuery` always passes through to the
+ * underlying `TplMgr.removeComponentServerQuery`, matching the behaviour
+ * the data.test.ts suite was written against.
+ *
+ * Integration tests in `real-integration.test.ts` import the real helper
+ * via `vitest.config.integration.ts`, so the guard runs end-to-end there.
+ */
+
+export function isQueryUsedInExpr(
+  _queryName: string,
+  _expr: unknown
+): boolean {
+  return false;
+}
+
+export function isDataTokenUsedInExpr(
+  _token: unknown,
+  _expr: unknown,
+  _projectId: string
+): boolean {
+  return false;
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-serialize-utils.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-serialize-utils.ts
@@ -1,0 +1,21 @@
+export function makeComponentSkeletonIdFileName() {
+  return "";
+}
+export function makeCodeComponentHelperSkeletonIdFileName() {
+  return "";
+}
+export function makeGlobalContextsImport() {
+  return "";
+}
+export function wrapGlobalContexts(s: string) {
+  return s;
+}
+export function makeGlobalGroupImports() {
+  return "";
+}
+export function makePlasmicIsPreviewRootComponent() {
+  return "__plasmicIsPreviewRoot";
+}
+export function wrapGlobalProviderWithCustomValue(_a: any, s: string) {
+  return s;
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-tpls.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-tpls.ts
@@ -160,3 +160,16 @@ export function tryGetOwnerSite(_comp: any): any | undefined {
 export function buildParamToComponent(_components: any[]): Map<any, any> {
   return new Map();
 }
+
+/**
+ * Unit-test stub for Studio's `findExprsInComponent` — returns an empty
+ * list so reference-detection guards (e.g. the gap #70 pre-flight check
+ * in `removeQuery`) treat mock components as having no bindings.
+ * Integration tests in `real-integration.test.ts` use the real helper
+ * against a real bundle.
+ */
+export function findExprsInComponent(
+  _component: any
+): Array<{ node: any; expr: any }> {
+  return [];
+}

--- a/packages/plasmic-mcp/src/__mocks__/wab-url-utils.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-url-utils.ts
@@ -1,0 +1,13 @@
+export function substituteUrlParams(template: string, params: Record<string, string>) {
+  let out = template;
+  for (const [k, v] of Object.entries(params)) {
+    out = out.replace(`[${k}]`, encodeURIComponent(v));
+  }
+  return out;
+}
+export function getMatchingPagePathParams(
+  _pagePath: string,
+  _lookup: string
+): Record<string, string> | false {
+  return false;
+}

--- a/packages/plasmic-mcp/src/__tests__/data.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/data.test.ts
@@ -817,7 +817,7 @@ describe("updateQuery", () => {
     ).rejects.toThrow(/already exists/);
   });
 
-  it("throws when no name provided", async () => {
+  it("throws when no name or functionCall provided", async () => {
     const root = mkTag({ uuid: "root-1" });
     const comp = mkComponent({ uuid: "comp-1", tplTree: root });
     (comp as any).dataQueries = [{ uuid: "q1", name: "products", op: null }];
@@ -829,7 +829,7 @@ describe("updateQuery", () => {
 
     await expect(
       updateQuery(api, "comp-1", "products", undefined)
-    ).rejects.toThrow(/name must be provided/);
+    ).rejects.toThrow(/at least one of.*name.*functionCall/i);
   });
 
   it("throws when query not found", async () => {
@@ -845,6 +845,259 @@ describe("updateQuery", () => {
     await expect(
       updateQuery(api, "comp-1", "nonexistent", "newName")
     ).rejects.toThrow(/not found/);
+  });
+
+  // Gap #74 — functionCall param binds a server query to a registered
+  // custom function. Tracer test: the happy path on a freshly-added server
+  // query (op=null) should leave query.op as a CustomFunctionExpr whose
+  // `func` points at the matching CustomFunction from site.customFunctions
+  // and whose `args` carry one FunctionArg per provided arg name.
+  it("gap #74 tracer: functionCall sets query.op to CustomFunctionExpr referencing the matching CustomFunction", async () => {
+    // Mirror the Studio query-builder shape: a CustomFunction with one
+    // `input` param of type ArgType.
+    const inputParam: any = {
+      _type: "ArgType",
+      argName: "input",
+      type: { _type: "AnyType" },
+    };
+    const { CustomFunction } = await import("../__mocks__/wab-classes");
+    const getProductFn = new CustomFunction({
+      namespace: "ep",
+      importName: "getProduct",
+      importPath: "@elasticpath/plasmic-ep-commerce-elastic-path/server",
+      params: [inputParam],
+      uid: 42,
+    });
+
+    const serverQuery: any = {
+      _type: "ComponentServerQuery",
+      uuid: "sq1",
+      name: "product",
+      op: null,
+    };
+    const root = mkTag({ uuid: "root-1" });
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    (comp as any).dataQueries = [];
+    (comp as any).serverQueries = [serverQuery];
+    const site = {
+      components: [comp],
+      styleTokens: [],
+      customFunctions: [getProductFn],
+      projectDependencies: [],
+    };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await updateQuery(api, "comp-1", "product", undefined, {
+      functionCall: {
+        namespace: "ep",
+        name: "getProduct",
+        args: { input: "{id: $ctx.params.slug}" },
+      },
+    });
+
+    expect(serverQuery.op).toBeTruthy();
+    expect(serverQuery.op._type).toBe("CustomFunctionExpr");
+    expect(serverQuery.op.func).toBe(getProductFn);
+    expect(serverQuery.op.args).toHaveLength(1);
+    expect(serverQuery.op.args[0]._type).toBe("FunctionArg");
+    expect(serverQuery.op.args[0].argType).toBe(inputParam);
+    // The user passed a JS expression, so the arg expr should be a
+    // CustomCode carrying that code (same shape update-text produces for
+    // dynamic text). `{{...}}` delimiters are stripped; `$foo` is unwrapped.
+    expect(serverQuery.op.args[0].expr._type).toBe("CustomCode");
+    // Stored wrapped in parens so `isRealCodeExpr` returns true — matches
+    // Studio's `createExprForDataPickerValue` convention. See exprs.ts in
+    // platform/wab. Without parens the op compiles to bare code and breaks
+    // scope resolution for $q / $queries / $ctx references.
+    expect(serverQuery.op.args[0].expr.code).toBe("({id: $ctx.params.slug})");
+  });
+
+  // Gap #74 error path — if the user supplies a functionCall pointing at a
+  // function that isn't in site.customFunctions (typically because the dev
+  // host never registered it, or project.sync-dev-host hasn't run since it
+  // was added), surface a clear error that names the function and points
+  // at the right recovery action. This prevents silent misconfiguration
+  // where a server query gets bound to a phantom function reference.
+  it("gap #74: throws with clear message when functionCall targets an unregistered function", async () => {
+    const serverQuery: any = {
+      _type: "ComponentServerQuery",
+      uuid: "sq1",
+      name: "product",
+      op: null,
+    };
+    const root = mkTag({ uuid: "root-1" });
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    (comp as any).dataQueries = [];
+    (comp as any).serverQueries = [serverQuery];
+    const site = {
+      components: [comp],
+      styleTokens: [],
+      customFunctions: [],
+      projectDependencies: [],
+    };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await expect(
+      updateQuery(api, "comp-1", "product", undefined, {
+        functionCall: {
+          namespace: "ep",
+          name: "getProduct",
+          args: { input: "{id: 'abc'}" },
+        },
+      })
+    ).rejects.toThrow(/ep\.getProduct.*not found.*sync-dev-host/s);
+    // Bundle must not be mutated when lookup fails.
+    expect(serverQuery.op).toBeNull();
+  });
+
+  // Gap #74 composition — rename + bind in one call must mutate both fields
+  // on the same query. This protects users from having to make two MCP
+  // calls (rename, then bind) and avoids a partial-state window where a
+  // query has a new name but its old op — or vice versa.
+  it("gap #74: rename + functionCall in one call applies both atomically", async () => {
+    const inputParam: any = {
+      _type: "ArgType",
+      argName: "input",
+      type: { _type: "AnyType" },
+    };
+    const { CustomFunction } = await import("../__mocks__/wab-classes");
+    const getProductFn = new CustomFunction({
+      namespace: "ep",
+      importName: "getProduct",
+      importPath: "@elasticpath/plasmic-ep-commerce-elastic-path/server",
+      params: [inputParam],
+      uid: 99,
+    });
+
+    const serverQuery: any = {
+      _type: "ComponentServerQuery",
+      uuid: "sq1",
+      name: "oldName",
+      op: null,
+    };
+    const root = mkTag({ uuid: "root-1" });
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    (comp as any).dataQueries = [];
+    (comp as any).serverQueries = [serverQuery];
+    const site = {
+      components: [comp],
+      styleTokens: [],
+      customFunctions: [getProductFn],
+      projectDependencies: [],
+    };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    const result = await updateQuery(api, "comp-1", "oldName", "product", {
+      functionCall: {
+        namespace: "ep",
+        name: "getProduct",
+        args: { input: "{id: $ctx.params.slug}" },
+      },
+    });
+
+    expect(result.name).toBe("product");
+    expect(serverQuery.name).toBe("product");
+    expect(serverQuery.op?._type).toBe("CustomFunctionExpr");
+    expect(serverQuery.op?.func).toBe(getProductFn);
+  });
+
+  // Gap #74 detach path — explicit functionCall: null clears an existing
+  // op back to null, so the user can unbind a query without deleting and
+  // re-adding it. Distinct from "functionCall field absent" (preserve).
+  it("gap #74: functionCall: null clears the query op", async () => {
+    const { CustomFunction, CustomFunctionExpr } = await import(
+      "../__mocks__/wab-classes"
+    );
+    const existingFn = new CustomFunction({
+      namespace: "ep",
+      importName: "getProduct",
+      importPath: "@elasticpath/plasmic-ep-commerce-elastic-path/server",
+      params: [],
+      uid: 7,
+    });
+    const existingOp = new CustomFunctionExpr({
+      func: existingFn,
+      args: [],
+    });
+
+    const serverQuery: any = {
+      _type: "ComponentServerQuery",
+      uuid: "sq1",
+      name: "product",
+      op: existingOp,
+    };
+    const root = mkTag({ uuid: "root-1" });
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    (comp as any).dataQueries = [];
+    (comp as any).serverQueries = [serverQuery];
+    const site = {
+      components: [comp],
+      styleTokens: [],
+      customFunctions: [existingFn],
+      projectDependencies: [],
+    };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await updateQuery(api, "comp-1", "product", undefined, {
+      functionCall: null,
+    });
+
+    expect(serverQuery.op).toBeNull();
+    // Name preserved
+    expect(serverQuery.name).toBe("product");
+  });
+
+  // Counter-case guard — NOT passing functionCall at all (only newName)
+  // must leave an existing op untouched. Distinguishes "absent field"
+  // from "explicit null".
+  it("gap #74: rename alone preserves existing op", async () => {
+    const { CustomFunction, CustomFunctionExpr } = await import(
+      "../__mocks__/wab-classes"
+    );
+    const existingFn = new CustomFunction({
+      namespace: "ep",
+      importName: "getProduct",
+      importPath: "@elasticpath/plasmic-ep-commerce-elastic-path/server",
+      params: [],
+      uid: 11,
+    });
+    const existingOp = new CustomFunctionExpr({
+      func: existingFn,
+      args: [],
+    });
+    const serverQuery: any = {
+      _type: "ComponentServerQuery",
+      uuid: "sq1",
+      name: "oldName",
+      op: existingOp,
+    };
+    const root = mkTag({ uuid: "root-1" });
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    (comp as any).dataQueries = [];
+    (comp as any).serverQueries = [serverQuery];
+    const site = {
+      components: [comp],
+      styleTokens: [],
+      customFunctions: [existingFn],
+      projectDependencies: [],
+    };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await updateQuery(api, "comp-1", "oldName", "newName");
+
+    expect(serverQuery.name).toBe("newName");
+    // Op reference identity preserved — not replaced/cloned
+    expect(serverQuery.op).toBe(existingOp);
   });
 });
 

--- a/packages/plasmic-mcp/src/__tests__/devhost-ingestion.integration.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/devhost-ingestion.integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the dev-host ingestion orchestrator — the MCP glue that calls
+ * Studio's shared `syncCodeComponents` against a fake registry snapshot,
+ * absorbing new dev-host components into `site.components`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// Studio's `builtin-code-components.ts` pulls plasmicHeadMeta / FetcherMeta
+// from `@plasmicapp/react-web`. Under the integration-test stub those are
+// undefined, which cascades into `c.meta.importPath` crashes inside Studio's
+// `getBuiltinImportPaths`. The MCP's ingestion path doesn't need those
+// built-ins, so mock the module to return an empty bag.
+vi.mock("@/wab/shared/code-components/builtin-code-components", () => ({
+  getBuiltinComponentRegistrations: () => ({}),
+  isBuiltinCodeComponentImportPath: () => false,
+  isBuiltinCodeComponent: () => false,
+  isBuiltinCodeComponentName: () => false,
+  isTplDataFetcher: () => false,
+}));
+
+import { createSite } from "@/wab/shared/core/sites";
+import { ingestDevHostComponents } from "../devhost-ingestion";
+import { syncFromDevHost, clearRegistryCache } from "../devhost-sync";
+import type { FullRegistryData } from "../devhost-sync";
+import { vi as vi2 } from "vitest"; // alias for scoping below
+
+const EMPTY_REGISTRY: FullRegistryData = {
+  components: [],
+  contexts: [],
+  functions: [],
+  tokens: [],
+  traits: [],
+};
+
+describe("ingestDevHostComponents", () => {
+  it("returns an empty IngestionResult when registry is empty and site has no components", async () => {
+    const site = createSite();
+    const result = await ingestDevHostComponents(site, EMPTY_REGISTRY);
+
+    expect(result.addedComponents).toEqual([]);
+    expect(result.removedComponents).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.fatalError).toBeUndefined();
+  });
+
+  it("adds a newly-registered code component to site.components", async () => {
+    const site = createSite();
+    const before = site.components.length;
+
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      components: [
+        {
+          name: "ep-product-provider",
+          displayName: "EP Product Provider",
+          importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+          importName: "EPProductProvider",
+          props: {
+            productId: { type: "string" },
+          },
+        },
+      ],
+    };
+
+    const result = await ingestDevHostComponents(site, registry);
+
+    expect(result.fatalError).toBeUndefined();
+    expect(result.addedComponents).toContain("ep-product-provider");
+    expect(site.components.length).toBe(before + 1);
+    const added = site.components.find((c: any) => c.name === "ep-product-provider");
+    expect(added).toBeTruthy();
+    expect(added.params.some((p: any) => p.variable.name === "productId")).toBe(true);
+  });
+
+  it("returns a fatalError and leaves site untouched when the registry has duplicate names", async () => {
+    const site = createSite();
+    const before = site.components.length;
+
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      components: [
+        {
+          name: "collider",
+          displayName: "First",
+          importPath: "@pkg/a",
+          importName: "First",
+          props: {},
+        },
+        {
+          name: "collider",
+          displayName: "Second",
+          importPath: "@pkg/b",
+          importName: "Second",
+          props: {},
+        },
+      ],
+    };
+
+    const result = await ingestDevHostComponents(site, registry);
+
+    expect(result.fatalError).toBeDefined();
+    expect(result.fatalError?.code).toBe("DuplicateCodeComponentError");
+    expect(result.addedComponents).toEqual([]);
+    expect(site.components.length).toBe(before);
+  });
+
+  it("syncFromDevHost in syncMode='full' populates result.ingestion with added components", async () => {
+    const site = createSite();
+    const before = site.components.length;
+
+    const registryResponse = {
+      components: [
+        {
+          name: "via-http-sync",
+          displayName: "Via HTTP",
+          importPath: "@pkg/http",
+          importName: "ViaHttp",
+          props: {},
+        },
+      ],
+      contexts: [],
+      functions: [],
+      tokens: [],
+      traits: [],
+    };
+
+    clearRegistryCache();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(registryResponse),
+    }) as any;
+
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "full",
+    });
+
+    expect(result.devHostSynced).toBe(true);
+    expect(result.ingestion).toBeDefined();
+    expect(result.ingestion!.addedComponents).toContain("via-http-sync");
+    expect(site.components.length).toBe(before + 1);
+  });
+
+  it("syncFromDevHost in syncMode='variants-only' does NOT call ingestion", async () => {
+    const site = createSite();
+    const before = site.components.length;
+
+    clearRegistryCache();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          components: [
+            {
+              name: "should-not-be-ingested",
+              importPath: "@pkg/skip",
+              importName: "Skip",
+              props: {},
+            },
+          ],
+          contexts: [],
+          functions: [],
+          tokens: [],
+          traits: [],
+        }),
+    }) as any;
+
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "variants-only",
+    });
+
+    expect(result.devHostSynced).toBe(true);
+    expect(result.ingestion).toBeUndefined();
+    expect(site.components.length).toBe(before); // not ingested
+  });
+
+  it("preserves components in site.components when dropped from the registry (non-destructive)", async () => {
+    const site = createSite();
+
+    // First pass: add a component.
+    await ingestDevHostComponents(site, {
+      ...EMPTY_REGISTRY,
+      components: [
+        {
+          name: "ep-keep-me",
+          displayName: "Keep Me",
+          importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+          importName: "KeepMe",
+          props: {},
+        },
+      ],
+    });
+    const afterFirst = site.components.find((c: any) => c.name === "ep-keep-me");
+    expect(afterFirst).toBeTruthy();
+    const countAfterFirst = site.components.length;
+
+    // Second pass: remove that registration from the incoming registry.
+    // Studio's fixMissingCodeComponents should preserve the component
+    // (not auto-delete) and our callbacks should surface a warning.
+    const second = await ingestDevHostComponents(site, EMPTY_REGISTRY);
+
+    // Still in the site
+    expect(site.components.find((c: any) => c.name === "ep-keep-me")).toBeTruthy();
+    // No delete reflected in diff
+    expect(second.removedComponents).toEqual([]);
+    // But the user should be warned
+    expect(
+      second.warnings.some(
+        (w: any) => w.code === "missing-component" && w.componentName === "ep-keep-me"
+      )
+    ).toBe(true);
+    // No change in overall component count
+    expect(site.components.length).toBe(countAfterFirst);
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/devhost-sync-shim.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/devhost-sync-shim.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the fake-window shim that lets Studio's `CodeComponentsRegistry`
+ * read from a serialized `FullRegistryData` (fetched over HTTP from the
+ * dev host) without an actual browser window.
+ *
+ * Studio reads registrations from globals like `window.__PlasmicComponentRegistry`.
+ * The MCP doesn't have a window — the shim builds an object with those same
+ * globals populated from the JSON registry snapshot, ready to be passed to
+ * `new CodeComponentsRegistry(fakeWindow, builtins)`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createFakeDevHostWindow } from "../devhost-sync-shim";
+import type { FullRegistryData } from "../devhost-sync";
+
+const EMPTY_REGISTRY: FullRegistryData = {
+  components: [],
+  contexts: [],
+  functions: [],
+  tokens: [],
+  traits: [],
+};
+
+describe("createFakeDevHostWindow", () => {
+  it("exposes a registered component under __PlasmicComponentRegistry in {component, meta} shape", () => {
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      components: [
+        {
+          name: "my-comp",
+          displayName: "My Comp",
+          props: { label: { type: "string" } },
+        },
+      ],
+    };
+
+    const fakeWin = createFakeDevHostWindow(registry);
+    const reg = (fakeWin as any).__PlasmicComponentRegistry;
+    expect(Array.isArray(reg)).toBe(true);
+    expect(reg).toHaveLength(1);
+    expect(reg[0].meta.name).toBe("my-comp");
+    expect(reg[0].meta.displayName).toBe("My Comp");
+    expect(typeof reg[0].component).toBe("function"); // stub impl
+  });
+
+  it("exposes contexts under __PlasmicContextRegistry in {component, meta} shape", () => {
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      contexts: [
+        {
+          name: "my-provider",
+          displayName: "My Provider",
+          props: { apiKey: { type: "string" } },
+        },
+      ],
+    };
+
+    const fakeWin = createFakeDevHostWindow(registry);
+    const reg = (fakeWin as any).__PlasmicContextRegistry;
+    expect(reg).toHaveLength(1);
+    expect(reg[0].meta.name).toBe("my-provider");
+    expect(typeof reg[0].component).toBe("function");
+  });
+
+  it("exposes tokens and traits as flat arrays; functions as {fn, meta} pairs", () => {
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      tokens: [{ name: "Primary", type: "color", value: "#FF0000" }],
+      traits: [{ trait: "device", meta: { type: "choice", options: ["desktop", "mobile"] } }],
+      functions: [{ name: "formatDate", namespace: "dates" }],
+    };
+
+    const fakeWin = createFakeDevHostWindow(registry);
+    expect((fakeWin as any).__PlasmicTokenRegistry).toEqual(registry.tokens);
+    expect((fakeWin as any).__PlasmicTraitRegistry).toEqual(registry.traits);
+    // Functions must follow Studio's {fn, meta} shape — `registeredFunctionId`
+    // and the whole syncCodeComponents pipeline read `r.meta.namespace` /
+    // `r.meta.name`. Flat metas cause "Cannot read properties of undefined
+    // (reading 'namespace')" during ingestion.
+    const fnReg = (fakeWin as any).__PlasmicFunctionsRegistry;
+    expect(fnReg).toHaveLength(1);
+    expect(fnReg[0].meta).toEqual(registry.functions[0]);
+    expect(typeof fnReg[0].fn).toBe("function");
+    expect((fakeWin as any).__PlasmicLibraryRegistry).toEqual([]); // not in FullRegistryData
+  });
+
+  it("handles empty registry without throwing", () => {
+    const fakeWin = createFakeDevHostWindow(EMPTY_REGISTRY);
+    expect((fakeWin as any).__PlasmicComponentRegistry).toEqual([]);
+    expect((fakeWin as any).__PlasmicContextRegistry).toEqual([]);
+    expect((fakeWin as any).__PlasmicTokenRegistry).toEqual([]);
+  });
+
+  it("preserves multiple component entries (Studio de-dupes downstream)", () => {
+    const registry: FullRegistryData = {
+      ...EMPTY_REGISTRY,
+      components: [
+        { name: "a", displayName: "A" },
+        { name: "a", displayName: "A duplicate" },
+        { name: "b" },
+      ],
+    };
+    const fakeWin = createFakeDevHostWindow(registry);
+    expect((fakeWin as any).__PlasmicComponentRegistry).toHaveLength(3);
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/devhost-sync.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/devhost-sync.test.ts
@@ -673,7 +673,9 @@ describe("syncFromDevHost", () => {
     }) as any;
     const site = mkSite([]);
 
-    const result = await syncFromDevHost(site, "http://localhost:3388");
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "variants-only",
+    });
     expect(result.devHostSynced).toBe(true);
     expect(result.syncedVariantComponents).toEqual([]);
   });
@@ -702,7 +704,13 @@ describe("syncFromDevHost", () => {
         }),
     }) as any;
 
-    const result = await syncFromDevHost(site, "http://localhost:3388");
+    // syncMode="variants-only" keeps this test scoped to the variant-metadata
+    // path (the only path this unit suite exercises). Full code-component
+    // ingestion requires a real Plasmic site and is covered by
+    // devhost-ingestion.integration.test.ts.
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "variants-only",
+    });
 
     // Sync result
     expect(result.devHostSynced).toBe(true);
@@ -744,7 +752,9 @@ describe("syncFromDevHost", () => {
       json: () => Promise.resolve(registryResponse),
     }) as any;
 
-    const result = await syncFromDevHost(site, "http://localhost:3388");
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "variants-only",
+    });
 
     expect(result.devHostSynced).toBe(true);
     expect(result.registryData).not.toBeUndefined();
@@ -770,7 +780,9 @@ describe("syncFromDevHost", () => {
     }) as any;
 
     const site = mkSite([]);
-    const result = await syncFromDevHost(site, "http://localhost:3388");
+    const result = await syncFromDevHost(site, "http://localhost:3388", {
+      syncMode: "variants-only",
+    });
 
     expect(result.devHostSynced).toBe(true);
     expect(result.syncedVariantComponents).toEqual([]);

--- a/packages/plasmic-mcp/src/__tests__/ingestion-callbacks.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/ingestion-callbacks.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the ingestion callback surface.
+ *
+ * Studio's `syncCodeComponents` orchestrator surfaces sync-time anomalies
+ * through a `CodeComponentSyncCallbackFns` interface (code-components.ts:643)
+ * designed for a browser UI — it expects callers to pop antd notifications.
+ *
+ * The MCP needs the same information in a JSON-response shape. These tests
+ * lock in the callback → IngestionResult.warnings translation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createIngestionCallbacks } from "../ingestion-callbacks";
+
+describe("createIngestionCallbacks", () => {
+  it("starts with an empty result", () => {
+    const { getResult } = createIngestionCallbacks();
+    expect(getResult().warnings).toEqual([]);
+  });
+
+  it("records a warning for each missing code component", async () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    await callbacks.onMissingCodeComponents(
+      {} as any,
+      [{ name: "comp-a" }, { name: "comp-b" }] as any,
+      [] as any
+    );
+
+    const warnings = getResult().warnings;
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toMatchObject({ code: "missing-component", componentName: "comp-a" });
+    expect(warnings[1]).toMatchObject({ code: "missing-component", componentName: "comp-b" });
+  });
+
+  it("records a warning for each missing context", async () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    await callbacks.onMissingCodeComponents(
+      {} as any,
+      [] as any,
+      [{ name: "my-provider" }] as any
+    );
+
+    const warnings = getResult().warnings;
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ code: "missing-context", componentName: "my-provider" });
+  });
+
+  it("records a warning for schema-to-tpl warnings", () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    callbacks.onSchemaToTplWarnings([
+      { message: "unknown allowedComponent 'X'", description: "details" },
+    ]);
+
+    const warnings = getResult().warnings;
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("schema-to-tpl");
+    expect(warnings[0].message).toContain("unknown allowedComponent");
+  });
+
+  it("records a warning for invalid JSON defaults", () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    callbacks.onInvalidJsonForDefaultValue("default value not valid JSON");
+
+    const warnings = getResult().warnings;
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("invalid-json-default");
+  });
+
+  it("onInvalidComponentImportNames records one warning per bad name", () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    callbacks.onInvalidComponentImportNames(["BadName With Space", "Another Bad"]);
+
+    const warnings = getResult().warnings;
+    expect(warnings).toHaveLength(2);
+    expect(warnings.every((w: any) => w.code === "invalid-import-name")).toBe(true);
+  });
+
+  it("onReset clears accumulated state so a subsequent sync starts clean", () => {
+    const { callbacks, getResult } = createIngestionCallbacks();
+    callbacks.onInvalidJsonForDefaultValue("first-run warning");
+    expect(getResult().warnings).toHaveLength(1);
+
+    callbacks.onReset?.();
+    expect(getResult().warnings).toEqual([]);
+    expect(getResult().addedComponents).toEqual([]);
+    expect(getResult().removedComponents).toEqual([]);
+  });
+});

--- a/packages/plasmic-mcp/src/__tests__/node.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/node.test.ts
@@ -3436,7 +3436,10 @@ describe("edit-tools", () => {
       const attrs = node.vsettings[0].attrs;
       expect(attrs.href._type).toBe("CustomCode");
       // $props.url → strips $ → detects bare "props." → corrects to "$props.url"
-      expect(attrs.href.code).toBe("$props.url");
+      // Stored wrapped in parens — matches Studio's `createExprForDataPickerValue`
+      // so `isRealCodeExpr` returns true and Plasmic codegen emits the safe
+      // wrapper around scope references ($q, $queries, $ctx, $state, $props).
+      expect(attrs.href.code).toBe("($props.url)");
       expect(result.warnings).toBeDefined();
       expect(result.warnings![0]).toContain("corrected");
     });
@@ -3458,7 +3461,7 @@ describe("edit-tools", () => {
 
       const attrs = node.vsettings[0].attrs;
       expect(attrs.href._type).toBe("CustomCode");
-      expect(attrs.href.code).toBe("props.url");
+      expect(attrs.href.code).toBe("(props.url)");
     });
 
     it("removes attributes with null value", async () => {
@@ -3718,7 +3721,7 @@ describe("edit-tools", () => {
       expect(result.warnings![0]).toContain("corrected");
       const attrs = node.vsettings[0].attrs;
       expect(attrs.value._type).toBe("CustomCode");
-      expect(attrs.value.code).toBe("$state.firstName");
+      expect(attrs.value.code).toBe("($state.firstName)");
     });
 
     it("rejects invalid JS expression with $ prefix", async () => {
@@ -6650,7 +6653,10 @@ describe("updateProps", () => {
     const callArgs = mockSetTplComponentArg.mock.calls[0];
     expect(callArgs[3]._type).toBe("CustomCode");
     // $ctx.params.orderId → strips $ → detects bare "ctx." → corrects to "$ctx.params.orderId"
-    expect(callArgs[3].code).toBe("$ctx.params.orderId");
+    // Wrapped in parens per Studio's `createExprForDataPickerValue` convention
+    // — ensures `isRealCodeExpr` returns true and Plasmic codegen wraps the
+    // expression in a safe IIFE that exposes $q / $queries / $ctx in scope.
+    expect(callArgs[3].code).toBe("($ctx.params.orderId)");
     expect(result.warnings).toBeDefined();
     expect(result.warnings![0]).toContain("corrected");
   });
@@ -6670,7 +6676,7 @@ describe("updateProps", () => {
 
     expect(result.updatedProps).toEqual(["amount"]);
     const callArgs = mockSetTplComponentArg.mock.calls[0];
-    expect(callArgs[3].code).toBe("$queries.cart.data.total");
+    expect(callArgs[3].code).toBe("($queries.cart.data.total)");
   });
 
   it("sets boolean and number props", async () => {

--- a/packages/plasmic-mcp/src/__tests__/real-integration.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/real-integration.test.ts
@@ -4212,6 +4212,299 @@ describe("data queries", () => {
     // Undo
     await client.callTool({ name: "project", arguments: { action: "undo" } });
   });
+
+  // Gap #70 guard — part A: pre-flight reference check on remove-query.
+  //
+  // Studio's UI refuses to delete a query that's referenced anywhere in the
+  // component (see platform/wab/src/wab/client/components/canvas/site-ops.tsx
+  // removeComponentServerQuery — it surfaces a "Cannot delete server query"
+  // notification). The MCP skipped this check, so it happily removed a query
+  // whose expressions were still bound to it, leaving the bundle in a state
+  // where downstream mutations could trip the `parentKey already used`
+  // assertion. This test asserts the MCP now performs the same pre-flight
+  // check using Studio's shared `findExprsInComponent` / `isQueryUsedInExpr`
+  // helpers.
+  it("gap #70: remove-query refuses to delete a server query that is still referenced", async () => {
+    const page = discoveredComponents.find((c) => c.type === "page") ??
+      discoveredComponents[0];
+    const queryName = "gap70Probe";
+
+    // Step 1 — add a server query.
+    const addResult = parseResponse(
+      await client.callTool({
+        name: "data",
+        arguments: {
+          action: "add-query",
+          componentUuid: page.uuid,
+          name: queryName,
+          queryType: "serverQuery",
+        },
+      })
+    );
+    expect(addResult.success).toBe(true);
+
+    // Step 2 — reference it from a node's dynamic text. This mirrors the
+    // real-world pattern: designer binds an h1 to `$queries.gap70Probe.data`.
+    const tree = parseResponse(
+      await client.callTool({
+        name: "inspect",
+        arguments: { action: "tree", componentUuid: page.uuid, maxDepth: 2 },
+      })
+    ).tree;
+
+    // Add a text node we can bind.
+    const addNode = parseResponse(
+      await client.callTool({
+        name: "node",
+        arguments: {
+          action: "add",
+          componentUuid: page.uuid,
+          parentRef: tree.uuid,
+          child: { type: "text", value: "placeholder" },
+        },
+      })
+    );
+    const textNodeUuid = addNode.uuid ?? addNode.child ?? tree.children?.[0]?.uuid;
+    // Fall back to the last child of the root if the add response doesn't
+    // echo the node uuid.
+    const afterAdd = parseResponse(
+      await client.callTool({
+        name: "inspect",
+        arguments: { action: "tree", componentUuid: page.uuid, maxDepth: 2 },
+      })
+    ).tree;
+    const newest = afterAdd.children[afterAdd.children.length - 1];
+
+    // Bind the text to a dynamic expression that references the query.
+    await client.callTool({
+      name: "node",
+      arguments: {
+        action: "update-text",
+        componentUuid: page.uuid,
+        nodeRef: textNodeUuid ?? newest.uuid,
+        text: "$queries.gap70Probe.data",
+        dynamic: true,
+        fallback: "loading",
+      },
+    });
+
+    // Step 3 — try to remove the query. Under the fix this must fail with a
+    // clear "in use" error; under the bug this silently succeeds and seeds
+    // the orphan-parentKey class of corruption.
+    const removeCall = await client.callTool({
+      name: "data",
+      arguments: {
+        action: "remove-query",
+        componentUuid: page.uuid,
+        queryRef: queryName,
+      },
+    });
+    const removeResult = parseResponse(removeCall);
+
+    expect({
+      isError: (removeCall as any).isError,
+      body: removeResult,
+    }).toMatchObject({
+      isError: true,
+      body: expect.stringMatching(/still referenced|in use|cannot (remove|delete)/i),
+    });
+
+    // Cleanup — clear the binding, then remove the query cleanly, then remove
+    // the probe node so later tests start from the original fixture state.
+    await client.callTool({
+      name: "node",
+      arguments: {
+        action: "update-text",
+        componentUuid: page.uuid,
+        nodeRef: textNodeUuid ?? newest.uuid,
+        text: "placeholder",
+      },
+    });
+    await client.callTool({
+      name: "data",
+      arguments: {
+        action: "remove-query",
+        componentUuid: page.uuid,
+        queryRef: queryName,
+      },
+    });
+    await client.callTool({
+      name: "node",
+      arguments: {
+        action: "remove",
+        componentUuid: page.uuid,
+        nodeRef: textNodeUuid ?? newest.uuid,
+      },
+    });
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+  });
+
+  // Gap #70 guard — part B: unreferenced remove + re-add + downstream
+  // mutation completes cleanly. If the pre-flight check (part A) is the
+  // only thing blocking corruption, this case should already be safe
+  // because nothing was bound to the query. This test locks in the
+  // invariant: a fresh add/remove cycle with no references must never
+  // leave the bundle in a state where subsequent mutations throw.
+  it("gap #70: remove + re-add of an unreferenced server query leaves the bundle healthy", async () => {
+    const page = discoveredComponents.find((c) => c.type === "page") ??
+      discoveredComponents[0];
+    const queryName = "gap70Plain";
+
+    // Add → remove → re-add, all without any references to the query.
+    await client.callTool({
+      name: "data",
+      arguments: {
+        action: "add-query",
+        componentUuid: page.uuid,
+        name: queryName,
+        queryType: "serverQuery",
+      },
+    });
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+
+    const firstRemove = parseResponse(
+      await client.callTool({
+        name: "data",
+        arguments: {
+          action: "remove-query",
+          componentUuid: page.uuid,
+          queryRef: queryName,
+        },
+      })
+    );
+    expect(firstRemove.success).toBe(true);
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+
+    const secondAdd = parseResponse(
+      await client.callTool({
+        name: "data",
+        arguments: {
+          action: "add-query",
+          componentUuid: page.uuid,
+          name: queryName,
+          queryType: "serverQuery",
+        },
+      })
+    );
+    expect(secondAdd.success).toBe(true);
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+
+    // Any downstream mutation must succeed. If the bundler has a stale
+    // `_iid2Parents` entry for the removed query, this throws.
+    const tree = parseResponse(
+      await client.callTool({
+        name: "inspect",
+        arguments: { action: "tree", componentUuid: page.uuid, maxDepth: 1 },
+      })
+    ).tree;
+    const trivial = await client.callTool({
+      name: "node",
+      arguments: {
+        action: "add",
+        componentUuid: page.uuid,
+        parentRef: tree.uuid,
+        child: { type: "text", value: "Gap70 Part B" },
+      },
+    });
+    const trivialBody = parseResponse(trivial);
+    expect((trivial as any).isError).toBeFalsy();
+    expect(trivialBody).toMatchObject({ success: true });
+
+    // Cleanup.
+    const freshTree = parseResponse(
+      await client.callTool({
+        name: "inspect",
+        arguments: { action: "tree", componentUuid: page.uuid, maxDepth: 1 },
+      })
+    ).tree;
+    const probe = freshTree.children[freshTree.children.length - 1];
+    if (probe?.uuid) {
+      await client.callTool({
+        name: "node",
+        arguments: {
+          action: "remove",
+          componentUuid: page.uuid,
+          nodeRef: probe.uuid,
+        },
+      });
+    }
+    await client.callTool({
+      name: "data",
+      arguments: {
+        action: "remove-query",
+        componentUuid: page.uuid,
+        queryRef: queryName,
+      },
+    });
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+  });
+
+  // Pre-save bundle validation (gap #71): if the live bundle has a
+  // dangling `__ref` (points to an IID not in `bundle.map`),
+  // `checkExistingReferences` — a shared Studio helper from
+  // `@/wab/shared/bundler` — must throw, and the MCP save path must
+  // surface that error prefixed with "Pre-save bundle validation failed"
+  // so a corrupt bundle never reaches the server.
+  it("gap #71: save rejects when the cached bundle has a dangling __ref", async () => {
+    const comp = discoveredComponents[0];
+
+    // Step 1 — establish a healthy baseline save so `bundler.cachedBundle()`
+    // contains a well-formed bundle we can then corrupt.
+    await client.callTool({ name: "project", arguments: { action: "save" } });
+
+    // Step 2 — inject a dangling `__ref` into the live bundle, then make a
+    // trivial edit so the save path's validators walk the corrupted bundle.
+    // The corruption lives on a REACHABLE node (the bundle root) so
+    // upstream "unreachable instance" detection doesn't catch it — only
+    // `checkExistingReferences` (which walks every map entry and asserts
+    // each `__ref` points at an existing IID) will surface it. That's the
+    // specific shared Studio validator we wired into save-manager.ts.
+    const { requireSession } = await import("../session.js");
+    const session = requireSession() as any;
+    const fullBundle = session.bundler.cachedBundle();
+    expect(fullBundle).toBeTruthy();
+    const rootEntry = fullBundle.map[fullBundle.root];
+    expect(rootEntry).toBeTruthy();
+    const ghostIid = "ghost-iid-does-not-exist-in-bundle";
+    // Poison the root with a new field that carries a dangling __ref.
+    // We snapshot the original value so cleanup can restore it.
+    const poisonKey = "__mcpTestPoison__";
+    const originalValue = rootEntry[poisonKey];
+    rootEntry[poisonKey] = { __ref: ghostIid };
+
+    // Step 3 — make any trivial edit so `fastBundle` runs and the pre-save
+    // validator walks the (now corrupt) bundle. The validator must reject.
+    const tree = parseResponse(
+      await client.callTool({
+        name: "inspect",
+        arguments: { action: "tree", componentUuid: comp.uuid, maxDepth: 1 },
+      })
+    ).tree;
+    const trivialAdd = await client.callTool({
+      name: "node",
+      arguments: {
+        action: "add",
+        componentUuid: comp.uuid,
+        parentRef: tree.uuid,
+        child: { type: "text", value: "gap71 probe" },
+      },
+    });
+
+    expect((trivialAdd as any).isError).toBe(true);
+    const body = parseResponse(trivialAdd);
+    expect(typeof body).toBe("string");
+    expect(body).toContain("Pre-save bundle validation failed");
+    expect(body).toContain(ghostIid);
+
+    // Cleanup — restore the root entry so later tests work against a
+    // well-formed bundle. Saves are idempotent against the live site,
+    // so the next save will re-bundle from the clean in-memory site.
+    if (originalValue === undefined) {
+      delete rootEntry[poisonKey];
+    } else {
+      rootEntry[poisonKey] = originalValue;
+    }
+  });
 });
 
 // =============================================================================

--- a/packages/plasmic-mcp/src/__tests__/save-manager.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/save-manager.test.ts
@@ -19,7 +19,14 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SaveManager, isSaving } from "../save-manager";
 import { setSession, clearSession } from "../session";
-import { mockFastBundle, mockAddrOf } from "../__mocks__/wab-bundler";
+import {
+  mockFastBundle,
+  mockAddrOf,
+  mockCachedBundle,
+  mockCheckExistingReferences,
+  mockCheckRefsInBundle,
+} from "../__mocks__/wab-bundler";
+import { mockAssertSiteInvariants } from "../__mocks__/wab-site-invariants";
 import { PlasmicApiError } from "../api-client";
 import type { PlasmicApiClient } from "../api-client";
 import type { Session } from "../session";
@@ -48,6 +55,7 @@ function makeSession(overrides?: Partial<Session>): Session {
       fastBundle: mockFastBundle,
       addrOf: mockAddrOf,
       bundle: vi.fn().mockReturnValue({ map: {}, root: "0", version: "256-test-version" }),
+      cachedBundle: mockCachedBundle,
     },
     revisionNum: 10,
     modelVersion: 5,
@@ -207,6 +215,146 @@ describe("SaveManager", () => {
     });
   });
 
+  // Pre-save bundle validation wires three shared Studio validators into the
+  // save path — `assertSiteInvariants`, `checkExistingReferences`,
+  // `checkRefsInBundle`. When any of them throws, the save manager must refuse
+  // to persist the bundle and surface a "Pre-save bundle validation failed"
+  // error. These tests prove that wiring: when a validator throws, the error
+  // reaches the caller with the expected prefix and the original message, and
+  // `saveRevision` is never called. Without the wiring, a corrupt bundle would
+  // reach the server (gap #71).
+  describe("pre-save bundle validation", () => {
+    it("surfaces assertSiteInvariants errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      mockAssertSiteInvariants.mockImplementation(() => {
+        throw new Error("Duplicated component name: Foo");
+      });
+
+      await expect(
+        saveManager.saveChanges({
+          changes: [],
+          newInsts: [],
+          removedInsts: [],
+        } as any)
+      ).rejects.toThrow(
+        /Pre-save bundle validation failed: Duplicated component name: Foo/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
+    });
+
+    it("surfaces checkExistingReferences errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({
+        map: { "0": { __type: "Site" } },
+        root: "0",
+        deps: [],
+      });
+      mockCheckExistingReferences.mockImplementation(() => {
+        throw new Error("Missing reference (IID ghost-iid)");
+      });
+
+      await expect(
+        saveManager.saveChanges({
+          changes: [],
+          newInsts: [],
+          removedInsts: [],
+        } as any)
+      ).rejects.toThrow(
+        /Pre-save bundle validation failed: Missing reference \(IID ghost-iid\)/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
+    });
+
+    it("surfaces checkRefsInBundle errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({
+        map: { "0": { __type: "Site" } },
+        root: "0",
+        deps: [],
+      });
+      mockCheckRefsInBundle.mockImplementation(() => {
+        throw new Error("Unreachable instance has weak refs");
+      });
+
+      await expect(
+        saveManager.saveChanges({
+          changes: [],
+          newInsts: [],
+          removedInsts: [],
+        } as any)
+      ).rejects.toThrow(
+        /Pre-save bundle validation failed: Unreachable instance has weak refs/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
+    });
+
+    it("includes recovery guidance pointing to refresh-project and gap #71", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      mockAssertSiteInvariants.mockImplementation(() => {
+        throw new Error("invariant broken");
+      });
+
+      await expect(
+        saveManager.saveChanges({
+          changes: [],
+          newInsts: [],
+          removedInsts: [],
+        } as any)
+      ).rejects.toThrow(/refresh-project/);
+      await expect(
+        (async () => {
+          mockAssertSiteInvariants.mockImplementation(() => {
+            throw new Error("invariant broken");
+          });
+          return saveManager.saveChanges({
+            changes: [],
+            newInsts: [],
+            removedInsts: [],
+          } as any);
+        })()
+      ).rejects.toThrow(/gap #71/);
+    });
+
+    it("saves normally when all three validators pass", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      // No validator throws — save must proceed.
+      const result = await saveManager.saveChanges({
+        changes: [],
+        newInsts: [],
+        removedInsts: [],
+      } as any);
+
+      expect(result.revisionNum).toBe(11);
+      expect(api.saveRevision).toHaveBeenCalledTimes(1);
+      expect(mockAssertSiteInvariants).toHaveBeenCalled();
+      expect(mockCheckExistingReferences).toHaveBeenCalled();
+      expect(mockCheckRefsInBundle).toHaveBeenCalled();
+    });
+
+    it("skips bundle-level validators when bundler lacks cachedBundle", async () => {
+      // Some bundler variants (pre-P0.0) don't expose cachedBundle. Verify
+      // the save-manager tolerates that without throwing, and still runs
+      // the site-level invariant check.
+      const session = makeSession();
+      (session.bundler as any).cachedBundle = undefined;
+      setSession(session);
+
+      const result = await saveManager.saveChanges({
+        changes: [],
+        newInsts: [],
+        removedInsts: [],
+      } as any);
+
+      expect(result.revisionNum).toBe(11);
+      expect(mockAssertSiteInvariants).toHaveBeenCalled();
+      expect(mockCheckExistingReferences).not.toHaveBeenCalled();
+      expect(mockCheckRefsInBundle).not.toHaveBeenCalled();
+    });
+  });
+
   describe("412 error handling", () => {
     it("throws conflict error on ProjectRevisionError", async () => {
       setSession(makeSession());
@@ -286,6 +434,49 @@ describe("SaveManager", () => {
 
       // Revision should not have been incremented
       expect(session.revisionNum).toBe(10);
+    });
+  });
+
+  // Mirrors the saveChanges pre-save tests above — `saveFullBundle` runs the
+  // same three validators, so its wiring must also refuse a corrupt bundle.
+  describe("saveFullBundle pre-save validation", () => {
+    it("surfaces assertSiteInvariants errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      mockAssertSiteInvariants.mockImplementation(() => {
+        throw new Error("site broken");
+      });
+
+      await expect(saveManager.saveFullBundle()).rejects.toThrow(
+        /Pre-save bundle validation failed: site broken/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
+    });
+
+    it("surfaces checkExistingReferences errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      mockCheckExistingReferences.mockImplementation(() => {
+        throw new Error("dangling __ref");
+      });
+
+      await expect(saveManager.saveFullBundle()).rejects.toThrow(
+        /Pre-save bundle validation failed: dangling __ref/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
+    });
+
+    it("surfaces checkRefsInBundle errors and skips saveRevision", async () => {
+      setSession(makeSession());
+      mockCachedBundle.mockReturnValue({ map: {}, root: "0", deps: [] });
+      mockCheckRefsInBundle.mockImplementation(() => {
+        throw new Error("weak ref to unreachable");
+      });
+
+      await expect(saveManager.saveFullBundle()).rejects.toThrow(
+        /Pre-save bundle validation failed: weak ref to unreachable/
+      );
+      expect(api.saveRevision).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/plasmic-mcp/src/__tests__/server.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/server.test.ts
@@ -716,7 +716,10 @@ describe("tool handlers", () => {
           hostlessDataVersion: 0,
         })
       );
-      expect(mockInitChangeTracker).toHaveBeenCalledWith(mockSite);
+      expect(mockInitChangeTracker).toHaveBeenCalledWith(
+        mockSite,
+        expect.objectContaining({ bundler: { fake: true }, projectUuid: "proj-123" })
+      );
     });
 
     it("returns error on API failure", async () => {
@@ -4788,7 +4791,10 @@ describe("tool handlers", () => {
       expect(mockClearRegistryCache).toHaveBeenCalled();
       expect(mockLoadProject).toHaveBeenCalledWith(mockApiClient, "proj-123", undefined);
       expect(mockSetSession).toHaveBeenCalled();
-      expect(mockInitChangeTracker).toHaveBeenCalledWith(refreshedSite);
+      expect(mockInitChangeTracker).toHaveBeenCalledWith(
+        refreshedSite,
+        expect.objectContaining({ projectUuid: "proj-123" })
+      );
     });
 
     it("clears registry cache with hostUrl on refresh", async () => {
@@ -6737,6 +6743,76 @@ describe("tool handlers", () => {
       expect(output.success).toBe(true);
       expect(output.name).toBe("fetchItems");
       expect(output.revision).toBe(41);
+    });
+
+    // Gap #74 wiring — the MCP tool surface forwards `functionCall` through
+    // to `updateQuery` intact. The Zod schema on the data tool accepts
+    // {namespace, name, args} and null; both shapes reach the implementation
+    // via options.functionCall.
+    it("forwards functionCall through to updateQuery for serverQuery binding", async () => {
+      mockUpdateQuery.mockResolvedValue({
+        queryUuid: "q-1",
+        name: "product",
+        queryType: "serverQuery",
+        save: { revisionNum: 50, incremental: true },
+      });
+
+      const result = await client.callTool({
+        name: "data",
+        arguments: {
+          action: "update-query",
+          componentUuid: "comp-1",
+          queryRef: "product",
+          functionCall: {
+            namespace: "ep",
+            name: "getProduct",
+            args: { input: "{id: $ctx.params.slug}" },
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      // The 5th arg (options) must carry the functionCall through verbatim.
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        "comp-1",
+        "product",
+        undefined,
+        {
+          functionCall: {
+            namespace: "ep",
+            name: "getProduct",
+            args: { input: "{id: $ctx.params.slug}" },
+          },
+        }
+      );
+    });
+
+    it("forwards functionCall: null to clear a server query op", async () => {
+      mockUpdateQuery.mockResolvedValue({
+        queryUuid: "q-1",
+        name: "product",
+        queryType: "serverQuery",
+        save: { revisionNum: 51, incremental: true },
+      });
+
+      await client.callTool({
+        name: "data",
+        arguments: {
+          action: "update-query",
+          componentUuid: "comp-1",
+          queryRef: "product",
+          functionCall: null,
+        },
+      });
+
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        "comp-1",
+        "product",
+        undefined,
+        { functionCall: null }
+      );
     });
   });
 

--- a/packages/plasmic-mcp/src/change-tracker.ts
+++ b/packages/plasmic-mcp/src/change-tracker.ts
@@ -69,17 +69,21 @@ let currentTracker: ChangeTracker | null = null;
  * the ChangeRecorder observes all reachable instances including the entire
  * dependency tree, which is wasteful and can cause spurious change recordings.
  */
-export function initChangeTracker(site: any): ChangeTracker {
+export function initChangeTracker(
+  site: any,
+  opts?: { bundler?: any; projectUuid?: string }
+): ChangeTracker {
   if (currentTracker) {
     currentTracker.dispose();
   }
 
-  // Auto-detect bundler and projectId from session to create isExternalRef.
-  // This works because initChangeTracker is always called AFTER setSession().
+  // Prefer explicit opts (callable BEFORE setSession) and fall back to the
+  // current session for backward-compatible callers.
   let isExternalRef: ((obj: any) => boolean) | undefined;
-  const session = getSession();
-  if (session?.bundler && session?.projectUuid) {
-    isExternalRef = makeIsExternalRef(session.bundler, session.projectUuid);
+  const bundler = opts?.bundler ?? getSession()?.bundler;
+  const projectUuid = opts?.projectUuid ?? getSession()?.projectUuid;
+  if (bundler && projectUuid) {
+    isExternalRef = makeIsExternalRef(bundler, projectUuid);
   }
 
   currentTracker = new ChangeTracker(site, isExternalRef);

--- a/packages/plasmic-mcp/src/devhost-ingestion.ts
+++ b/packages/plasmic-mcp/src/devhost-ingestion.ts
@@ -1,0 +1,226 @@
+/**
+ * Ingestion orchestrator — drives Studio's shared `syncCodeComponents`
+ * against a fake registry built from the dev host's `/api/plasmic-registry`
+ * snapshot. Closes MCP gap #73: new dev-host code components become
+ * available in `site.components` without a manual Studio trip.
+ *
+ * Contract:
+ *   given a live `site` and a `FullRegistryData` snapshot,
+ *     - new registrations get added via Studio's ingestion path,
+ *     - registrations absent from the snapshot are preserved in-place
+ *       (Studio's `fixMissingCodeComponents` — non-destructive),
+ *     - validation anomalies surface as `warnings` on the result,
+ *     - structural corruption (duplicate names, malformed meta) returns
+ *       a `fatalError` and the site is left untouched.
+ *
+ * Wiring mirrors the server-side hostless pattern at
+ * `platform/wab/src/wab/server/code-components/code-components.ts:311-326`.
+ */
+
+import { failable } from "ts-failable";
+import {
+  CodeComponentsRegistry,
+  syncCodeComponents,
+} from "@/wab/shared/code-components/code-components";
+import { TplMgr } from "@/wab/shared/TplMgr";
+import {
+  mergeRecordedChanges,
+  type RecordedChanges,
+} from "@/wab/shared/core/observable-model";
+
+// Plasmic's `getBuiltinComponentRegistrations` pulls from @plasmicapp/react-web
+// (PlasmicHead, Fetcher). In a server/MCP context those dists may be absent
+// or stubbed, which would hand `CodeComponentsRegistry` a `{meta: undefined}`
+// entry that crashes `uniqBy(..., cc => cc.meta.name)`. We don't need the
+// built-ins for ingestion — we're only reconciling the dev host's
+// registrations against `site.components`. Pass an empty bag.
+const NO_BUILTINS = {} as any;
+import type { FullRegistryData } from "./devhost-sync.js";
+import { createFakeDevHostWindow } from "./devhost-sync-shim.js";
+import {
+  createIngestionCallbacks,
+  type IngestionResult as CallbackIngestionResult,
+} from "./ingestion-callbacks.js";
+import type { ChangeTracker } from "./change-tracker.js";
+
+export interface IngestionResult extends CallbackIngestionResult {
+  fatalError?: { code: string; message: string };
+  /**
+   * Merged `RecordedChanges` from all internal `ctx.change()` passes during
+   * `syncCodeComponents`. Non-empty when tracker was provided and the sync
+   * actually mutated the site. Pass to `SaveManager.saveChanges()` to
+   * persist+broadcast via the normal incremental save path (which emits
+   * socket updates to connected Studio clients).
+   */
+  recordedChanges?: RecordedChanges;
+}
+
+export async function ingestDevHostComponents(
+  site: any,
+  registry: FullRegistryData,
+  opts?: { tracker?: ChangeTracker }
+): Promise<IngestionResult> {
+  const { callbacks, getResult } = createIngestionCallbacks();
+
+  // Build a registry snapshot that unions the incoming dev-host registrations
+  // with "shadow" entries for any site component the incoming registry doesn't
+  // cover. Without this, Plasmic's own downstream passes
+  // (`fixMissingDefaultComponents`, `refreshDefaultSlotContents`) throw
+  // `NullOrUndefinedValueError` because they assume every site component has
+  // a registry entry. Shadows preserve current metadata in-place and surface
+  // the "no longer on the dev host" state via `onMissingCodeComponents`
+  // warnings — non-destructive per PRD Q3.
+  // Cover-set: site components whose name appears under registry.components OR
+  // registry.contexts should NOT be shadowed. A context code-component in the
+  // site (e.g. `plasmic-commerce-elastic-path-provider$dev`) is registered on
+  // the dev host as a context, not a component. Shadowing it under components
+  // would collide with its real context entry and trigger
+  // `DuplicateCodeComponentError`.
+  const coveredNames = new Set<string>([
+    ...(registry.components ?? []).map((c: any) => c.name),
+    ...(registry.contexts ?? []).map((c: any) => c.name),
+  ]);
+
+  const missingCodeComponents: any[] = [];
+  const missingContextComponents: any[] = [];
+  for (const c of site.components ?? []) {
+    if (!c.codeComponentMeta) continue;
+    if (coveredNames.has(c.name)) continue;
+    if (c.codeComponentMeta.isContext) {
+      missingContextComponents.push(c);
+    } else {
+      missingCodeComponents.push(c);
+    }
+  }
+
+  // Build a shadow meta for a site component. Forces `name` + the top-level
+  // required fields Studio's `typeCheckRegistrations` insists on (name,
+  // importPath, props) — the persisted codeComponentMeta may not have them.
+  const toShadow = (c: any) => {
+    const base = {
+      importPath: c.codeComponentMeta?.importPath ?? c.name,
+      importName: c.codeComponentMeta?.importName ?? c.name,
+      displayName: c.codeComponentMeta?.displayName ?? c.name,
+      props: c.codeComponentMeta?.props ?? {},
+    };
+    // Spread base → spread codeComponentMeta → force `name` last so it
+    // wins even if codeComponentMeta has an undefined `name` field.
+    return { ...base, ...c.codeComponentMeta, name: c.name };
+  };
+
+  const fakeWindow = createFakeDevHostWindow({
+    ...registry,
+    components: [
+      ...registry.components,
+      ...missingCodeComponents.map(toShadow),
+    ],
+    contexts: [
+      ...registry.contexts,
+      ...missingContextComponents.map(toShadow),
+    ],
+  });
+
+  // All shadowed (either kind) are reported as "no longer on dev host"
+  // — so the user knows the project is carrying unresolved references.
+  const shadowCodeComponents = [
+    ...missingCodeComponents,
+    ...missingContextComponents,
+  ];
+
+  const beforeNames = new Set<string>(
+    (site.components ?? []).map((c: any) => c.name)
+  );
+
+  const tplMgr = new TplMgr({ site });
+
+  // Every internal `ctx.change(...)` call during syncCodeComponents must
+  // run inside the shared ChangeRecorder so the FastBundler tracks new
+  // Component / Param / State instances and the SaveManager can broadcast
+  // them to Studio via the normal incremental-save / socket path.
+  // Accumulate changes across all calls so the caller can save+broadcast
+  // atomically.
+  const recordedChangesList: RecordedChanges[] = [];
+  const ctxChange = opts?.tracker
+    ? async (f: any) => {
+        const tracker = opts.tracker!;
+        let result: any;
+        const recorded = tracker.withRecording(() => {
+          result = failable((args: any) => f(args));
+        });
+        if (recorded.changes.length > 0 || recorded.removedInsts.length > 0) {
+          recordedChangesList.push(recorded);
+        }
+        return result;
+      }
+    : // No tracker (test path / no-op context): run the mutation without
+      // recording. Incremental save + live sync don't apply in this mode.
+      async (f: any) => failable((args: any) => f(args));
+
+  const ctx: any = {
+    site,
+    codeComponentsRegistry: new CodeComponentsRegistry(
+      fakeWindow as any,
+      NO_BUILTINS
+    ),
+    change: ctxChange,
+    observeComponents: () => true,
+    getPlumeSite: () => undefined,
+    getRootSubReact: () => ({ version: "18.0.0" } as any),
+    tplMgr: () => tplMgr,
+  };
+
+  // Reset before sync (Studio's server pattern does this too — see
+  // server/code-components/code-components.ts:309).
+  callbacks.onReset?.();
+
+  const syncResult = await syncCodeComponents(ctx, callbacks as any, {
+    force: false,
+  });
+
+  // Surface "no longer on the dev host" as warnings on the result. We do
+  // this AFTER the sync (post-onReset so the warnings survive) and directly
+  // rather than via onMissingCodeComponents (those components are shadowed
+  // in the registry so Plasmic doesn't see them as missing — the callback
+  // wouldn't fire). Non-destructive per PRD Q3.
+  const result = getResult();
+  for (const c of shadowCodeComponents) {
+    result.warnings.push({
+      code: "missing-component",
+      componentName: c.name,
+      message: `Code component "${c.name}" is referenced by the project but no longer registered on the dev host. Preserved in site.`,
+    });
+  }
+
+  if ((syncResult as any)?.result?.isError) {
+    const err = (syncResult as any).result.error;
+    return {
+      ...result,
+      fatalError: {
+        code: err?.name ?? "SyncError",
+        message: err?.message ?? String(err),
+      },
+    };
+  }
+
+  const afterNames = new Set<string>(
+    (site.components ?? []).map((c: any) => c.name)
+  );
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  for (const n of afterNames) if (!beforeNames.has(n)) added.push(n);
+  for (const n of beforeNames) if (!afterNames.has(n)) removed.push(n);
+
+  result.addedComponents = added;
+  result.removedComponents = removed;
+
+  const fullResult: IngestionResult = result as IngestionResult;
+  if (recordedChangesList.length > 0) {
+    fullResult.recordedChanges =
+      recordedChangesList.length === 1
+        ? recordedChangesList[0]
+        : (mergeRecordedChanges as any)(...recordedChangesList);
+  }
+
+  return fullResult;
+}

--- a/packages/plasmic-mcp/src/devhost-sync-shim.ts
+++ b/packages/plasmic-mcp/src/devhost-sync-shim.ts
@@ -1,0 +1,54 @@
+/**
+ * Fake dev-host window shim.
+ *
+ * Studio's `CodeComponentsRegistry` (platform/wab/src/wab/shared/code-components/
+ * code-components.ts:503) reads registered components, contexts, tokens,
+ * traits, functions, and libraries from globals on a Window-like object:
+ * `__PlasmicComponentRegistry`, `__PlasmicContextRegistry`, etc.
+ *
+ * The MCP fetches a JSON-serialized snapshot of these same registries via
+ * the dev host's `/api/plasmic-registry` endpoint. This shim rehydrates the
+ * snapshot into the {component, meta} pair shape that `CodeComponentsRegistry`
+ * expects — with stub no-op React-component impls, since Studio's ingestion
+ * path (`addNewRegisteredComponents`) only reads `meta`.
+ */
+
+import type { FullRegistryData } from "./devhost-sync.js";
+
+const NOOP_COMPONENT: any = () => null;
+const NOOP_FN: any = () => undefined;
+
+export interface FakeDevHostWindow {
+  __PlasmicComponentRegistry: Array<{ component: unknown; meta: unknown }>;
+  __PlasmicContextRegistry: Array<{ component: unknown; meta: unknown }>;
+  __PlasmicTokenRegistry: unknown[];
+  __PlasmicTraitRegistry: unknown[];
+  __PlasmicFunctionsRegistry: Array<{ fn: unknown; meta: unknown }>;
+  __PlasmicLibraryRegistry: unknown[];
+}
+
+export function createFakeDevHostWindow(
+  registry: FullRegistryData
+): FakeDevHostWindow {
+  return {
+    __PlasmicComponentRegistry: registry.components.map((meta: unknown) => ({
+      component: NOOP_COMPONENT,
+      meta,
+    })),
+    __PlasmicContextRegistry: registry.contexts.map((meta: unknown) => ({
+      component: NOOP_COMPONENT,
+      meta,
+    })),
+    __PlasmicTokenRegistry: [...registry.tokens],
+    __PlasmicTraitRegistry: [...registry.traits],
+    // Functions follow the same `{fn, meta}` shape Studio's
+    // `CodeComponentsRegistry` expects — `registeredFunctionId(r)` reads
+    // `r.meta.namespace` / `r.meta.name`. Without the meta wrapper the
+    // whole ingestion pass crashes when any function is registered.
+    __PlasmicFunctionsRegistry: registry.functions.map((meta: unknown) => ({
+      fn: NOOP_FN,
+      meta,
+    })),
+    __PlasmicLibraryRegistry: [],
+  };
+}

--- a/packages/plasmic-mcp/src/devhost-sync.ts
+++ b/packages/plasmic-mcp/src/devhost-sync.ts
@@ -109,7 +109,30 @@ export interface SyncResult {
   syncedVariantComponents: string[];
   /** Full registry data from the dev host (available when devHostSynced is true). */
   registryData?: FullRegistryData;
+  /**
+   * Populated when `syncMode === "full"` (default). Reports which dev-host
+   * code components were ingested into `site.components` this pass, which
+   * were found to be no-longer-registered (preserved as warnings), and any
+   * structural-corruption fatal error. Absent in `variants-only` mode.
+   *
+   * When a ChangeTracker was active during the ingestion, `recordedChanges`
+   * carries the merged `RecordedChanges` from all internal `ctx.change()`
+   * passes. Callers are expected to pipe these into `SaveManager.saveChanges`
+   * so the newly-ingested Component / Param / State instances are broadcast
+   * to Studio clients over the normal incremental-save socket channel
+   * (preserves MCP→Studio live sync).
+   */
+  ingestion?: {
+    addedComponents: string[];
+    removedComponents: string[];
+    warnings: Array<{ code: string; componentName?: string; message: string }>;
+    fatalError?: { code: string; message: string };
+    recordedChanges?: unknown;
+  };
 }
+
+/** Sync mode selects how aggressively dev-host state is reconciled. */
+export type SyncMode = "full" | "variants-only";
 
 const FETCH_TIMEOUT_MS = 5_000;
 
@@ -451,9 +474,31 @@ export function ensureVariantObjects(
  * Called from server.ts on `project.set` and `project.refresh`.
  * Non-fatal — returns `{ devHostSynced: false }` on any failure.
  */
+/**
+ * Decide which sync mode to run given an explicit opts override and the
+ * `PLASMIC_MCP_SKIP_DEV_HOST_INGESTION` env var.
+ *
+ * Default is "full" — ingests newly-registered dev-host code components into
+ * `site.components` via Studio's shared `syncCodeComponents`. Ingestion runs
+ * inside `ChangeRecorder.withRecording()` so the FastBundler and live-sync
+ * socket path see the new instances. `PLASMIC_MCP_SKIP_DEV_HOST_INGESTION=1`
+ * or per-call `syncMode: "variants-only"` skips ingestion — legacy behavior.
+ */
+export function resolveSyncMode(opts?: { syncMode?: SyncMode }): SyncMode {
+  if (opts?.syncMode) return opts.syncMode;
+  if (
+    typeof process !== "undefined" &&
+    process.env?.PLASMIC_MCP_SKIP_DEV_HOST_INGESTION === "1"
+  ) {
+    return "variants-only";
+  }
+  return "full";
+}
+
 export async function syncFromDevHost(
   site: any,
-  hostUrl: string | undefined
+  hostUrl: string | undefined,
+  opts?: { syncMode?: SyncMode; tracker?: unknown }
 ): Promise<SyncResult> {
   if (!hostUrl) {
     return { devHostSynced: false, syncedVariantComponents: [], registryData: undefined };
@@ -474,31 +519,46 @@ export async function syncFromDevHost(
     (c) => c.variants && Object.keys(c.variants).length > 0
   );
 
-  if (variantComponents.length === 0) {
-    console.error(
-      `[plasmic-mcp] Dev host sync: no variant-bearing components found`
-    );
-    return { devHostSynced: true, syncedVariantComponents: [], registryData: registry };
-  }
-
-  console.error(
-    `[plasmic-mcp] Dev host sync: ${variantComponents.length} variant-bearing component(s) found`
-  );
-
-  // Identify which components WILL be synced, but do NOT write to the model
-  // here. Writing must happen inside a ChangeRecorder.withRecording() block
-  // (via recordVariantMetadataSync) so the FastBundler can track the changes
-  // for incremental saves. If we write here eagerly, recordVariantMetadataSync
-  // sees no diff and skips the recording — so the metadata never persists.
+  // Identify which components WILL be variant-synced, but do NOT write to the
+  // model here. Writing must happen inside a ChangeRecorder.withRecording()
+  // block (via recordVariantMetadataSync) so the FastBundler can track the
+  // changes for incremental saves. If we write here eagerly,
+  // recordVariantMetadataSync sees no diff and skips the recording — so the
+  // metadata never persists.
   const syncedNames: string[] = [];
   for (const regComp of variantComponents) {
     const codeComp = findCodeComponentByName(site, regComp.name);
     if (codeComp) syncedNames.push(codeComp.name);
   }
 
+  if (variantComponents.length > 0) {
+    console.error(
+      `[plasmic-mcp] Dev host sync: ${variantComponents.length} variant-bearing component(s) found: ${syncedNames.join(", ")}`
+    );
+  }
+
+  const mode = resolveSyncMode(opts);
+  if (mode === "variants-only") {
+    console.error(
+      `[plasmic-mcp] Dev host sync: variants-only mode, skipping code-component ingestion`
+    );
+    return { devHostSynced: true, syncedVariantComponents: syncedNames, registryData: registry };
+  }
+
+  // Lazy import — devhost-ingestion pulls in real Plasmic model code, which
+  // we don't want loaded when MCP runs in variants-only mode.
+  const { ingestDevHostComponents } = await import("./devhost-ingestion.js");
+  const ingestion = await ingestDevHostComponents(site, registry, {
+    tracker: opts?.tracker as any,
+  });
   console.error(
-    `[plasmic-mcp] Dev host sync complete: ${syncedNames.length} variant-bearing component(s) found: ${syncedNames.join(", ")}`
+    `[plasmic-mcp] Dev host ingestion: added ${ingestion.addedComponents.length}, removed ${ingestion.removedComponents.length}, warnings ${ingestion.warnings.length}${ingestion.fatalError ? `, fatal ${ingestion.fatalError.code}` : ""}`
   );
 
-  return { devHostSynced: true, syncedVariantComponents: syncedNames, registryData: registry };
+  return {
+    devHostSynced: true,
+    syncedVariantComponents: syncedNames,
+    registryData: registry,
+    ingestion,
+  };
 }

--- a/packages/plasmic-mcp/src/edit-tools.ts
+++ b/packages/plasmic-mcp/src/edit-tools.ts
@@ -65,6 +65,8 @@ import {
   ComponentServerQuery,
   isKnownComponentDataQuery,
   isKnownComponentServerQuery,
+  CustomFunctionExpr,
+  FunctionArg,
   Mixin,
   isKnownMixin,
   KeyFrame,
@@ -90,7 +92,8 @@ import { RSH } from "@/wab/shared/RuleSetHelpers";
 import { TplMgr, setTplComponentArg } from "@/wab/shared/TplMgr";
 import { ensureVariantSetting, mkVariant } from "@/wab/shared/Variants";
 import { mkTplTagX, mkTplInlinedText, mkTplComponentX, clone as cloneTpl, TplTagType } from "@/wab/shared/core/tpls";
-import { flattenTpls } from "@/wab/shared/core/tpls";
+import { flattenTpls, findExprsInComponent } from "@/wab/shared/core/tpls";
+import { isQueryUsedInExpr } from "@/wab/shared/refactoring";
 import { elementSchemaToTpl as studioElementSchemaToTpl } from "@/wab/shared/code-components/code-components";
 import { requireSession } from "./session.js";
 import { getChangeTracker } from "./change-tracker.js";
@@ -323,16 +326,23 @@ function createAttrExpr(value: unknown, warnings: string[]): any {
           `Plasmic scope variables use $ prefix ($props, $state, $ctx).`
         );
         validateJsExpression(corrected);
-        return new CustomCode({ code: corrected, fallback: null });
+        // Wrap in parens so `isRealCodeExpr` returns true — same shape
+        // Studio's `createExprForDataPickerValue` uses. Without the parens,
+        // Plasmic's codegen emits the bare code unwrapped, which breaks
+        // server-query references like `$q.x.data` where `$q` is only a
+        // local after codegen inserts the parens-triggered safe wrapper.
+        return new CustomCode({ code: `(${corrected})`, fallback: null });
       }
       validateJsExpression(code);
-      return new CustomCode({ code, fallback: null });
+      return new CustomCode({ code: `(${code})`, fallback: null });
     }
     // Dynamic value: {{expression}}
     if (value.startsWith("{{") && value.endsWith("}}")) {
       const code = value.slice(2, -2).trim();
       validateJsExpression(code);
-      return new CustomCode({ code, fallback: null });
+      // See note above — parens wrap tells Plasmic codegen this is a
+      // real code expression (see `isRealCodeExpr` in @/wab/shared/core/exprs).
+      return new CustomCode({ code: `(${code})`, fallback: null });
     }
     // Static string literal — check for accidental expression patterns
     const warning = checkLiteralWarning(value);
@@ -6631,6 +6641,41 @@ export async function removeQuery(
   const removedName = query.name;
   const removedUuid = query.uuid;
 
+  // Pre-flight reference check — mirrors Studio's
+  // site-ops.removeComponentServerQuery / removeComponentQuery behaviour.
+  // Studio refuses to delete a query whose `$queries.<name>` is still
+  // bound from any expression in the component tree; skipping this guard
+  // was one of the paths that seeded the gap #70 bundle corruption (the
+  // removed query's parentKey wasn't fully unwound because an invalidation
+  // or selector expression still held a reference).
+  // Detect any expression that references `$queries.<name>`. We use
+  // Studio's shared helper as the primary source of truth (handles the
+  // paren-wrapped "real code" case that `isQueryUsedInExpr` parses via
+  // `parseExpr`). The regex fallback below catches the case where an
+  // expression was stored as a bare `CustomCode({ code: "$queries..." })`
+  // without the `(...)` wrapping that `isRealCodeExpr` requires — the
+  // MCP's `update-text` currently produces this shape for dynamic text,
+  // so `isQueryUsedInExpr` wouldn't see it. Text-pattern fallback is
+  // strictly a superset: any `$queries.<name>` usage is a reference.
+  const queryRefPattern = new RegExp(
+    String.raw`\$queries\.` +
+      query.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+      String.raw`\b`
+  );
+  const allExprs = findExprsInComponent(component);
+  const refs = allExprs.filter(({ expr }) => {
+    if (isQueryUsedInExpr(query.name, expr)) return true;
+    const code = (expr as any)?.code;
+    return typeof code === "string" && queryRefPattern.test(code);
+  });
+  if (refs.length > 0) {
+    throw new Error(
+      `Cannot remove query "${query.name}" — it is still referenced in ${refs.length} expression(s) in component "${component.name}". ` +
+        `Clear the bindings first (update-text, update-props, set-data-cond, set-data-rep) before removing the query. ` +
+        `This check prevents bundle corruption (gap #70 — server query remove/re-add).`
+    );
+  }
+
   const tplMgr = new TplMgr({ site: session.site });
 
   const changes = tracker.withRecording(() => {
@@ -6660,54 +6705,170 @@ export interface UpdateQueryResult {
 }
 
 /**
- * Update a data query's name.
+ * Specification for binding a query to a registered custom function.
+ *
+ * Mirrors the shape Studio's query builder produces via
+ * `client/components/sidebar-tabs/ServerQuery/ServerQueryOpPicker.tsx`
+ * (`new CustomFunctionExpr({ func, args })` + one `FunctionArg` per arg).
+ * `null` clears the op (detach path).
+ *
+ * Each value in `args` is a JS expression string — stored verbatim as the
+ * `CustomCode.code` for that argument. Same convention as update-text's
+ * `dynamic:true` path — no magic `$`/`{{}}` unwrapping.
+ */
+export interface FunctionCallSpec {
+  namespace?: string;
+  name: string;
+  args: Record<string, string>;
+}
+
+/**
+ * Update a data/server query — rename and/or bind its op to a registered
+ * custom function. At least one of `newName` or `options.functionCall`
+ * must be provided.
  */
 export async function updateQuery(
   apiClient: PlasmicApiClient,
   componentUuid: string,
   queryRef: string,
-  newName?: string
+  newName?: string,
+  options?: { functionCall?: FunctionCallSpec | null }
 ): Promise<UpdateQueryResult> {
   const component = findComponent(componentUuid);
-  requireSession();
+  const session = requireSession();
   const tracker = getChangeTracker();
   const { query, queryType } = findQuery(component, queryRef);
 
-  if (!newName) {
-    throw new Error("At least a new name must be provided for update-query.");
-  }
-
-  const validName = validateQueryName(newName);
-
-  // Check for duplicate names (excluding current query)
-  const allQueries = [
-    ...(component.dataQueries ?? []),
-    ...(component.serverQueries ?? []),
-  ].filter((q: any) => q.uuid !== query.uuid);
-  if (allQueries.some((q: any) => q.name === validName)) {
+  const hasFunctionCallField =
+    options !== undefined &&
+    Object.prototype.hasOwnProperty.call(options, "functionCall");
+  if (!newName && !hasFunctionCallField) {
     throw new Error(
-      `Query "${validName}" already exists on component "${component.name}".`
+      "At least one of 'name' or 'functionCall' must be provided for update-query."
     );
   }
 
+  let validName: string | undefined;
+  if (newName) {
+    validName = validateQueryName(newName);
+    const allQueries = [
+      ...(component.dataQueries ?? []),
+      ...(component.serverQueries ?? []),
+    ].filter((q: any) => q.uuid !== query.uuid);
+    if (allQueries.some((q: any) => q.name === validName)) {
+      throw new Error(
+        `Query "${validName}" already exists on component "${component.name}".`
+      );
+    }
+  }
+
   const changes = tracker.withRecording(() => {
-    query.name = validName;
+    if (validName) {
+      query.name = validName;
+    }
+    if (hasFunctionCallField) {
+      query.op = options!.functionCall
+        ? buildCustomFunctionExpr(session.site, options!.functionCall)
+        : null;
+    }
   });
 
   const componentIid = getComponentIid(component);
+  const finalName = validName ?? query.name;
   const save = await saveOrAccumulate(
     apiClient,
     changes,
-    `update-query: rename to ${validName} on ${component.name}`,
+    hasFunctionCallField
+      ? `update-query: ${finalName} → ${
+          options!.functionCall
+            ? `${options!.functionCall.namespace ? options!.functionCall.namespace + "." : ""}${options!.functionCall.name}`
+            : "(cleared)"
+        } on ${component.name}`
+      : `update-query: rename to ${finalName} on ${component.name}`,
     componentIid ? [componentIid] : []
   );
 
   return {
     save,
     queryUuid: query.uuid,
-    name: validName,
+    name: finalName,
     queryType,
   };
+}
+
+/**
+ * Build a `CustomFunctionExpr` from a user-supplied function call spec.
+ *
+ * Lookup and construction mirror Studio's `ServerQueryOpPicker` — the
+ * function is resolved from `site.customFunctions` (also traverses
+ * projectDependencies when present, matching `allCustomFunctions` from
+ * `@/wab/shared/cached-selectors`). Each named arg in `spec.args` is
+ * matched to the function's declared `params` by `argName` and wrapped
+ * in a `FunctionArg` carrying a `CustomCode` expression.
+ */
+function buildCustomFunctionExpr(site: any, spec: FunctionCallSpec): any {
+  // Collect functions from the site + all transitive project dependencies.
+  // Shape mirrors `allCustomFunctions(site)` from Studio's cached-selectors.
+  const localFns: any[] = site?.customFunctions ?? [];
+  const depFns: any[] = [];
+  for (const dep of site?.projectDependencies ?? []) {
+    for (const fn of dep?.site?.customFunctions ?? []) {
+      depFns.push(fn);
+    }
+  }
+  const allFns = [...localFns, ...depFns];
+
+  const matches = allFns.filter(
+    (fn: any) =>
+      fn.importName === spec.name &&
+      (fn.namespace ?? undefined) === (spec.namespace ?? undefined)
+  );
+  if (matches.length === 0) {
+    const label = `${spec.namespace ? spec.namespace + "." : ""}${spec.name}`;
+    throw new Error(
+      `Custom function "${label}" not found in site.customFunctions. ` +
+        `Ensure the dev host is registering it (registerFunction) and call ` +
+        `project.sync-dev-host so the MCP ingests it into site.customFunctions.`
+    );
+  }
+  const func = matches[0];
+
+  const args: any[] = [];
+  for (const [argName, codeString] of Object.entries(spec.args ?? {})) {
+    const param = (func.params ?? []).find(
+      (p: any) => p.argName === argName
+    );
+    if (!param) {
+      const label = `${spec.namespace ? spec.namespace + "." : ""}${spec.name}`;
+      const declared = (func.params ?? [])
+        .map((p: any) => p.argName)
+        .join(", ");
+      throw new Error(
+        `Unknown arg "${argName}" for custom function "${label}". ` +
+          `Declared params: ${declared || "(none)"}.`
+      );
+    }
+    if (typeof codeString !== "string") {
+      throw new Error(
+        `Arg "${argName}" must be a JS expression string (got ${typeof codeString}).`
+      );
+    }
+    validateJsExpression(codeString);
+    args.push(
+      new FunctionArg({
+        uuid: randomUUID(),
+        // Wrap in parens so `isRealCodeExpr` returns true — Studio's UI
+        // reads the arg via `argsMap[param.argName][0].expr` then decomposes
+        // for display; unwrapped CustomCode shows as "unset" and the
+        // Plasmic codegen emits the bare code without the safe IIFE wrapper.
+        // Mirrors `createExprForDataPickerValue` in @/wab/shared/core/exprs.
+        expr: new CustomCode({ code: `(${codeString})`, fallback: null }),
+        argType: param,
+      })
+    );
+  }
+
+  return new CustomFunctionExpr({ func, args });
 }
 
 // =============================================================================

--- a/packages/plasmic-mcp/src/ingestion-callbacks.ts
+++ b/packages/plasmic-mcp/src/ingestion-callbacks.ts
@@ -1,0 +1,129 @@
+/**
+ * Collects warnings surfaced by Studio's `syncCodeComponents` during a
+ * dev-host ingestion pass and translates them into a JSON-response-shaped
+ * `IngestionResult`. Fatal errors (e.g. `DuplicateCodeComponentError`,
+ * `CodeComponentRegistrationTypeError`) come from the failable return of
+ * `syncCodeComponents` itself — this callback surface only handles the
+ * non-fatal, "tell the user what happened but keep going" cases that
+ * Studio's UI would pop as antd notifications.
+ */
+
+import { failableAsync } from "ts-failable";
+
+export interface IngestionWarning {
+  code: string;
+  componentName?: string;
+  message: string;
+}
+
+export interface IngestionResult {
+  addedComponents: string[];
+  removedComponents: string[];
+  warnings: IngestionWarning[];
+}
+
+export function createIngestionCallbacks(): {
+  callbacks: Record<string, any>;
+  getResult: () => IngestionResult;
+} {
+  const result: IngestionResult = {
+    addedComponents: [],
+    removedComponents: [],
+    warnings: [],
+  };
+
+  const push = (warning: IngestionWarning) => {
+    result.warnings.push(warning);
+  };
+
+  const callbacks = {
+    onReset: () => {
+      result.warnings.length = 0;
+      result.addedComponents.length = 0;
+      result.removedComponents.length = 0;
+    },
+
+    onMissingCodeComponents: (
+      _ctx: unknown,
+      missingComponents: Array<{ name: string }>,
+      missingContexts: Array<{ name: string }>
+    ) =>
+      failableAsync<void, never>(async ({ success }) => {
+        for (const c of missingComponents) {
+          push({
+            code: "missing-component",
+            componentName: c.name,
+            message: `Code component "${c.name}" is referenced by the project but no longer registered on the dev host.`,
+          });
+        }
+        for (const c of missingContexts) {
+          push({
+            code: "missing-context",
+            componentName: c.name,
+            message: `Context "${c.name}" is referenced by the project but no longer registered on the dev host.`,
+          });
+        }
+        return success();
+      }),
+
+    onInvalidReactVersion: (
+      _ctx: unknown,
+      pkgInfo: { name: string; minimumReactVersion?: string }
+    ) =>
+      failableAsync<void, never>(async ({ success }) => {
+        push({
+          code: "invalid-react-version",
+          componentName: pkgInfo.name,
+          message: `Package "${pkgInfo.name}" requires React >= ${pkgInfo.minimumReactVersion ?? "unknown"}.`,
+        });
+        return success();
+      }),
+
+    onInvalidComponentImportNames: (componentNames: string[]) => {
+      for (const name of componentNames) {
+        push({
+          code: "invalid-import-name",
+          componentName: name,
+          message: `Component "${name}" has an invalid importName (e.g. whitespace).`,
+        });
+      }
+    },
+
+    onStaleProps: async () => false, // don't force-update props; Studio defaults to user-driven choice
+
+    onNewDefaultComponents: (message: string) => {
+      push({ code: "new-default-component", message });
+    },
+
+    onSchemaToTplWarnings: (warnings: Array<{ message: string; description?: string }>) => {
+      for (const w of warnings) {
+        push({
+          code: "schema-to-tpl",
+          message: w.message + (w.description ? ` (${w.description})` : ""),
+        });
+      }
+    },
+
+    onSchemaToTplError: (error: Error) => {
+      push({ code: "schema-to-tpl-error", message: error.message });
+    },
+
+    onElementStyleWarnings: (warnings: Array<{ message: string; description?: string }>) => {
+      for (const w of warnings) {
+        push({
+          code: "element-style",
+          message: w.message + (w.description ? ` (${w.description})` : ""),
+        });
+      }
+    },
+
+    onInvalidJsonForDefaultValue: (message: string) => {
+      push({ code: "invalid-json-default", message });
+    },
+  };
+
+  return {
+    callbacks,
+    getResult: () => result,
+  };
+}

--- a/packages/plasmic-mcp/src/preview-server.ts
+++ b/packages/plasmic-mcp/src/preview-server.ts
@@ -28,16 +28,53 @@ import { CssVarResolver } from "@/wab/shared/core/styles";
 import { exportGlobalVariantGroup } from "@/wab/shared/codegen/variants";
 import { exportIconAsset, extractUsedIconAssetsForComponents } from "@/wab/shared/codegen/image-assets";
 import { walkDependencyTree } from "@/wab/shared/core/project-deps";
+import {
+  isCodeComponent,
+  isPageComponent,
+  getCodeComponentImportName,
+  getCodeComponentHelperImportName,
+} from "@/wab/shared/core/components";
+import { isCodeComponentWithHelpers } from "@/wab/shared/code-components/code-components";
+import { componentToDeepReferenced } from "@/wab/shared/cached-selectors";
+import { tryGetOwnerSite } from "@/wab/shared/core/tpls";
+import { getSlotParams } from "@/wab/shared/SlotUtils";
+import { jsLiteral, toVarName } from "@/wab/shared/codegen/util";
+import {
+  makeComponentSkeletonIdFileName,
+  makeCodeComponentHelperSkeletonIdFileName,
+  makeGlobalContextsImport,
+  makeGlobalGroupImports,
+  makePlasmicIsPreviewRootComponent,
+  wrapGlobalProviderWithCustomValue,
+} from "@/wab/shared/codegen/react-p/serialize-utils";
+import { allGlobalVariantGroups } from "@/wab/shared/core/sites";
+import { getRawCode, ExprCtx } from "@/wab/shared/core/exprs";
+import { DEVFLAGS } from "@/wab/shared/devflags";
+import { getPlumeEditorPlugin } from "@/wab/shared/plume/plume-registry";
+import { isKnownPropParam } from "@/wab/shared/model/classes";
+import {
+  getMatchingPagePathParams,
+  substituteUrlParams,
+} from "@/wab/shared/utils/url-utils";
 import type { ExportOpts, ComponentExportOutput } from "@/wab/shared/codegen/types";
 
 let server: http.Server | null = null;
 let serverPort: number | null = null;
 
-/** Resolved platform host URL (e.g., https://integration.host.elasticpathdev.com). */
-let platformHostUrl: string | null = null;
-
-/** Cached host.html content from the platform host. */
+/** Cached host.html content from the Studio platform (hostless fallback). */
 let cachedHostHtml: string | null = null;
+
+/** Cached app-host HTML rewritten for same-origin iframe embedding.
+ *  Keyed by app host URL so switching projects doesn't reuse stale HTML. */
+const cachedAppHostHtml = new Map<string, string>();
+
+/** App host URL that was most recently served at /static/host.html. Used so
+ *  our fallback static proxy can forward unresolved paths like /_next/* to
+ *  the right upstream. */
+let activeAppHostOrigin: string | null = null;
+
+/** Last app-host fetch error (surfaced via /debug for diagnosis). */
+let lastAppHostFetchError: string | null = null;
 
 /** Commit hash extracted from host.html script URL. */
 let commitHash: string | null = null;
@@ -58,15 +95,54 @@ export function getPreviewPort(): number | null {
   return serverPort;
 }
 
-/** Get the full preview URL for a component, or null if server not running. */
-export function getPreviewUrl(componentName: string): string | null {
+/**
+ * Get the full preview URL for a component, or null if server not running.
+ *
+ * For page components, emits a Studio-style path URL: given route
+ * `/product/[slug]` and pageParams `{slug: "test-product"}`, returns
+ * `/preview/product/test-product`. Without explicit pageParams, substitutes
+ * the component's `pageMeta.params` defaults (matches Studio's PreviewCtx
+ * `mkPreviewRoute` behavior) — any unresolved `[x]` placeholders are kept.
+ *
+ * For non-page components, emits `/preview/<ComponentName>`.
+ *
+ * Query params are appended as `?key=value` when provided.
+ */
+export function getPreviewUrl(
+  component: { name: string; pageMeta?: { path?: string; params?: Record<string, string>; query?: Record<string, string> } },
+  opts?: { pageParams?: Record<string, string>; pageQuery?: Record<string, string> }
+): string | null {
   if (!serverPort) return null;
-  return `http://127.0.0.1:${serverPort}/preview/${encodeURIComponent(componentName)}`;
+  const base = `http://127.0.0.1:${serverPort}/preview`;
+
+  let pathSuffix: string;
+  if (component.pageMeta?.path) {
+    const params = { ...(component.pageMeta.params ?? {}), ...(opts?.pageParams ?? {}) };
+    const substituted = substituteUrlParams(component.pageMeta.path, params);
+    // substituteUrlParams keeps leading `/`; our base URL has /preview so the
+    // result is `/preview/<path>`. Strip the leading slash from the substituted
+    // path to avoid double slashes.
+    pathSuffix = substituted.replace(/^\/+/, "");
+  } else {
+    pathSuffix = encodeURIComponent(component.name);
+  }
+
+  const queryEntries = Object.entries({
+    ...(component.pageMeta?.query ?? {}),
+    ...(opts?.pageQuery ?? {}),
+  });
+  const queryString = queryEntries.length
+    ? "?" +
+      queryEntries
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&")
+    : "";
+  return `${base}/${pathSuffix}${queryString}`;
 }
 
 /**
  * Start the preview HTTP server on a random available port.
- * Resolves the platform host URL and caches host.html.
+ * Pre-fetches host.html from the Studio platform.
  * Stops any existing server first.
  */
 export async function startPreviewServer(
@@ -74,13 +150,7 @@ export async function startPreviewServer(
 ): Promise<number> {
   await stopPreviewServer();
 
-  // Resolve the platform host URL
-  await resolveHostUrl(apiClient);
-
-  // Pre-fetch and cache host.html
-  if (platformHostUrl) {
-    await fetchAndCacheHostHtml();
-  }
+  await fetchAndCacheHostHtml();
 
   apiClientRef = apiClient;
 
@@ -103,8 +173,7 @@ export async function startPreviewServer(
         serverPort = addr.port;
         server = srv;
         console.error(
-          `[plasmic-mcp] Preview server started on http://127.0.0.1:${serverPort}` +
-          (platformHostUrl ? ` (host: ${platformHostUrl})` : " (no host URL)")
+          `[plasmic-mcp] Preview server started on http://127.0.0.1:${serverPort} (host: ${getStudioOrigin()})`
         );
         resolve(serverPort);
       } else {
@@ -128,8 +197,9 @@ export async function stopPreviewServer(): Promise<void> {
       console.error("[plasmic-mcp] Preview server stopped");
       server = null;
       serverPort = null;
-      platformHostUrl = null;
       cachedHostHtml = null;
+      cachedAppHostHtml.clear();
+      activeAppHostOrigin = null;
       commitHash = null;
       apiClientRef = null;
       generatedModules.clear();
@@ -138,8 +208,9 @@ export async function stopPreviewServer(): Promise<void> {
     setTimeout(() => {
       server = null;
       serverPort = null;
-      platformHostUrl = null;
       cachedHostHtml = null;
+      cachedAppHostHtml.clear();
+      activeAppHostOrigin = null;
       commitHash = null;
       apiClientRef = null;
       generatedModules.clear();
@@ -158,60 +229,24 @@ function getStudioOrigin(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Host URL resolution
+// Host.html fetch
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the platform host URL using the same logic as Studio's getHostUrl():
- * 1. session.hostUrl (custom host from project settings)
- * 2. appConfig.defaultHostUrl (platform default for hostless projects)
- * 3. PLASMIC_PREVIEW_HOST_URL env var (manual override)
- */
-async function resolveHostUrl(apiClient: PlasmicApiClient): Promise<void> {
-  const session = getSession();
-
-  // Custom host projects already have the URL
-  if (session?.hostUrl) {
-    platformHostUrl = session.hostUrl.replace(/\/$/, "");
-    console.error(`[plasmic-mcp] Preview host: ${platformHostUrl} (project hostUrl)`);
-    return;
-  }
-
-  // Try env var override
-  if (process.env.PLASMIC_PREVIEW_HOST_URL) {
-    platformHostUrl = process.env.PLASMIC_PREVIEW_HOST_URL.replace(/\/$/, "");
-    console.error(`[plasmic-mcp] Preview host: ${platformHostUrl} (env var)`);
-    return;
-  }
-
-  // Fetch from app config (same as Studio's appConfig.defaultHostUrl)
-  try {
-    const appConfig = await apiClient.getAppConfig();
-    const defaultHost = (appConfig?.config as any)?.defaultHostUrl;
-    if (defaultHost) {
-      // defaultHostUrl may include /static/host.html — strip to base URL
-      const hostUrl = new URL(defaultHost);
-      platformHostUrl = `${hostUrl.protocol}//${hostUrl.host}`;
-      console.error(`[plasmic-mcp] Preview host: ${platformHostUrl} (appConfig.defaultHostUrl)`);
-      return;
-    }
-  } catch (err) {
-    console.error("[plasmic-mcp] Failed to fetch appConfig for defaultHostUrl:", err);
-  }
-
-  console.error("[plasmic-mcp] No platform host URL available for preview proxy");
-}
-
-/**
- * Fetch host.html from the platform host and cache it.
- * Extracts the commit hash from the script URL for use with other bundles.
+ * Fetch the host page HTML and cache it. Also fetch Studio's host.html for
+ * the commit hash (shared across bundles).
+ *
+ * We always need Studio's commit hash so we can load `react-web-bundle` and
+ * `live-frame` bundles from the Studio origin. When a project has an app
+ * host, we additionally fetch and serve the app-host HTML — rewritten to be
+ * same-origin with our preview server so the outer page can inject scripts
+ * into the iframe directly (browsers block cross-origin frame access).
  */
 async function fetchAndCacheHostHtml(): Promise<void> {
-  if (!platformHostUrl) return;
-
-  const hostHtmlUrl = `${platformHostUrl}/static/host.html`;
+  // Studio's host.html — used for the commit hash and as hostless fallback.
+  const studioHostUrl = `${getStudioOrigin()}/static/host.html`;
   try {
-    const response = await fetch(hostHtmlUrl, { redirect: "follow" });
+    const response = await fetch(studioHostUrl, { redirect: "follow" });
     if (!response.ok) {
       console.error(`[plasmic-mcp] Failed to fetch host.html: HTTP ${response.status}`);
       return;
@@ -227,8 +262,167 @@ async function fetchAndCacheHostHtml(): Promise<void> {
       console.error("[plasmic-mcp] Could not extract commit hash from host.html");
     }
   } catch (err) {
-    console.error(`[plasmic-mcp] Failed to fetch host.html from ${hostHtmlUrl}:`, err);
+    console.error(`[plasmic-mcp] Failed to fetch host.html from ${studioHostUrl}:`, err);
   }
+}
+
+/**
+ * Fetch the user's app-host page (e.g. http://localhost:3456/plasmic-host)
+ * server-side and rewrite it to be served from our preview origin without
+ * breaking relative URLs in the HTML.
+ *
+ * Strategy: inject `<base href="${upstreamOrigin}/">` at the top of <head>,
+ * so `/_next/static/chunks/*.js` and other relative URLs resolve against the
+ * user's dev server. Script tags load cross-origin without CORS because
+ * `<script src>` is exempt from same-origin policy. But `iframe.contentDocument`
+ * access from our outer page is now same-origin (iframe is at our origin),
+ * so script injection via `doc.head.appendChild(...)` works — matching the
+ * approach Studio uses in CanvasFrame.tsx (doc.open / doc.write into a
+ * sourceless iframe).
+ */
+async function fetchAndRewriteAppHost(appHostUrl: string): Promise<string | null> {
+  // Fetch the app-host HTML and serve it from our origin AS-IS. Relative URLs
+  // in the HTML (like `/_next/static/chunks/*.js`) will resolve against our
+  // origin — our `handleUpstreamProxy` forwards those requests to the user's
+  // dev server. This makes the iframe same-origin with our outer page (so
+  // direct `iframe.contentDocument` access works) while still serving real
+  // Next.js chunks from the user's dev server.
+  //
+  // We deliberately do NOT inject `<base href>`: that would break the History
+  // API because Next.js's router calls `history.replaceState(...)` with URLs
+  // resolved against baseURI, and the browser rejects cross-origin history
+  // states.
+  lastAppHostFetchError = null;
+  try {
+    const response = await fetch(appHostUrl, { redirect: "follow" });
+    if (!response.ok) {
+      lastAppHostFetchError = `HTTP ${response.status} ${response.statusText}`;
+      console.error(`[plasmic-mcp] App-host fetch failed: ${lastAppHostFetchError}`);
+      return null;
+    }
+    return await response.text();
+  } catch (err) {
+    lastAppHostFetchError = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    console.error(`[plasmic-mcp] Failed to fetch app-host from ${appHostUrl}:`, err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dependent-component module helpers (replicated from Studio's live-syncer.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk all components this root transitively depends on (deep references +
+ * super components + sub components). Excludes the root itself.
+ * Mirrors live-syncer.ts:337-373.
+ */
+function extractDependentComponents(component: any): Set<any> {
+  const referencedComps = new Set<any>();
+  const seen = new Set<any>();
+
+  const check = (comp: any) => {
+    if (seen.has(comp)) return;
+    seen.add(comp);
+
+    for (const dep of componentToDeepReferenced(comp)) {
+      check(dep);
+      referencedComps.add(dep);
+    }
+
+    if (comp.superComp) {
+      referencedComps.add(comp.superComp);
+      check(comp.superComp);
+    }
+
+    for (const subComp of comp.subComps ?? []) {
+      referencedComps.add(subComp);
+      check(subComp);
+    }
+  };
+
+  check(component);
+  return referencedComps;
+}
+
+/**
+ * Build a SystemJS module whose contents are a code component stub: the
+ * exported symbol is a runtime lookup into __PlasmicComponentRegistry,
+ * __PlasmicContextRegistry, and __PlasmicBuiltinRegistry. Matches the
+ * non-ccStubs branch of live-syncer.ts:430-482.
+ *
+ * Registration happens via the iframe's origin page (the user's app host)
+ * executing plasmic-init's registerComponent() calls, or (for builtins) via
+ * Studio's live-frame bundle.
+ */
+function createCodeComponentModule(
+  component: any,
+  opts?: { idFileNames?: boolean }
+): CodeModule {
+  const importName = getCodeComponentImportName(component);
+  const notFoundMsg = `[host-app-error] Code component '${component.name}' was not found in the current host app.`;
+  const body = `ensure(
+    ([
+      ...(window).__PlasmicComponentRegistry,
+      ...((window).__PlasmicContextRegistry ?? []),
+      ...((window).__PlasmicBuiltinRegistry ?? [])
+    ]).find(
+      ({meta}) => meta.name === ${jsLiteral(component.name)}
+    )
+  , ${jsLiteral(notFoundMsg)}).component`;
+
+  const source = `
+  const ensure = (x, msg) => {
+    if (x === undefined || x === null) {
+      throw new Error(msg);
+    }
+    return x;
+  };
+  ${component.codeComponentMeta.defaultExport ? "" : "export "}const ${importName} = ${body};
+  ${component.codeComponentMeta.defaultExport ? `export default ${importName}` : ""}
+  `;
+  const fileName = opts?.idFileNames
+    ? makeComponentSkeletonIdFileName(component)
+    : importName;
+  return { name: `./${fileName}.tsx`, lang: "tsx", source };
+}
+
+/**
+ * Companion to createCodeComponentModule for code components with helpers.
+ * Mirrors live-syncer.ts:395-424.
+ */
+function createCodeComponentHelperModule(
+  component: any,
+  opts?: { idFileNames?: boolean }
+): CodeModule {
+  const importName = getCodeComponentHelperImportName(component);
+  const body = `([...(window).__PlasmicComponentRegistry, ...((window).__PlasmicBuiltinRegistry ?? [])]).find(
+    ({meta}) => meta.name === ${jsLiteral(component.name)}
+  ).meta.componentHelpers?.helpers`;
+  const defaultExport = component.codeComponentMeta.helpers?.defaultExport;
+  const source = `
+  ${defaultExport ? "" : "export "}const ${importName} = ${body};
+  ${defaultExport ? `export default ${importName}` : ""}
+  `;
+  const fileName = opts?.idFileNames
+    ? makeCodeComponentHelperSkeletonIdFileName(component)
+    : importName;
+  return { name: `./${fileName}.tsx`, lang: "tsx", source };
+}
+
+/**
+ * Emit render + skeleton + css modules for a regular (non-code) component.
+ * Mirrors live-syncer.ts:375-393 createComponentModules.
+ */
+function createComponentModules(output: ComponentExportOutput): CodeModule[] {
+  const out: CodeModule[] = [
+    { name: `./${output.renderModuleFileName}`, source: output.renderModule, lang: "tsx" },
+    { name: `./${output.skeletonModuleFileName}`, source: output.skeletonModule, lang: "tsx" },
+  ];
+  if (output.cssRules) {
+    out.push({ name: `./${output.cssFileName}`, source: output.cssRules, lang: "css" });
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +436,65 @@ async function fetchAndCacheHostHtml(): Promise<void> {
  * Uses exportReactPresentational + SiteGenHelper + CssVarResolver directly
  * against the in-memory site model — no external API calls needed.
  */
-function generateComponentModules(component: any): CodeModule[] | { error: string } | null {
+/**
+ * Resolve a URL-style path like `product/test-product` or a bare component
+ * name / UUID to the page component + path params.
+ *
+ * Mirrors Studio's `getComponentByPath` at platform/wab/src/wab/client/
+ * components/live/PreviewCtx.tsx:701-763. When multiple page routes match,
+ * picks the one with fewest path params (so `/products/foo` wins over
+ * `/products/[slug]` when both match). Returns `pageParams` extracted from
+ * the path via `getMatchingPagePathParams` (shared with Studio).
+ *
+ * Falls through to component-name/UUID lookup for non-page components so
+ * the preview works for reusable components too.
+ */
+function resolveComponentByPath(
+  site: any,
+  rawPath: string
+): { component: any; pageParams: Record<string, string> } | null {
+  const normalized = "/" + rawPath.replace(/^\/+/, "");
+
+  const matches = (site.components ?? [])
+    .filter(
+      (c: any) =>
+        c.uuid === rawPath ||
+        (c.pageMeta &&
+          getMatchingPagePathParams(c.pageMeta.path, normalized))
+    )
+    .map((c: any) => {
+      const params = c.pageMeta
+        ? getMatchingPagePathParams(c.pageMeta.path, normalized) || {}
+        : {};
+      return {
+        component: c,
+        paramCount: Object.keys(params).length,
+        params,
+      };
+    })
+    .sort(
+      (a: any, b: any) => a.paramCount - b.paramCount
+    );
+
+  if (matches.length > 0) {
+    const best = matches[0];
+    return { component: best.component, pageParams: best.params };
+  }
+
+  // Not a page-path match — fall back to component name / UUID.
+  const byName = (site.components ?? []).find(
+    (c: any) => c.name === rawPath || c.uuid === rawPath
+  );
+  if (byName) {
+    return { component: byName, pageParams: {} };
+  }
+  return null;
+}
+
+function generateComponentModules(
+  component: any,
+  opts?: { pageParams?: Record<string, string>; pageQuery?: Record<string, string> }
+): CodeModule[] | { error: string } | null {
   const session = getSession();
   if (!session) return null;
 
@@ -274,6 +526,7 @@ function generateComponentModules(component: any): CodeModule[] | { error: strin
       useCustomFunctionsStub: true,
       isLivePreview: true,
       targetEnv: "preview",
+      relPathFromManagedToImplDir: ".",
     };
 
     // Step 1: Project config (same as Studio's exportProjectConfig call)
@@ -345,10 +598,14 @@ function generateComponentModules(component: any): CodeModule[] | { error: strin
     };
     pushProjectMods(projectConfig);
 
-    // 6c. Dependency project mods (live-syncer:168, createDepsProjectMods)
+    // 6c. Dependency project mods (live-syncer:168, createDepsProjectMods).
+    // Also build a site → projectConfig map so step 6g can codegen dependents
+    // that live in imported projects with the right per-project CSS config.
+    const depProjectConfigs = new Map<any, any>();
     try {
       for (const dep of walkDependencyTree(site, "all")) {
         const depConfig = exportProjectConfig(dep.site, dep.name, dep.projectId, 0, "dep", "latest", exportOpts);
+        depProjectConfigs.set(dep.site, depConfig);
         pushProjectMods(depConfig);
       }
     } catch (e) {
@@ -386,23 +643,88 @@ function generateComponentModules(component: any): CodeModule[] | { error: strin
       console.error("[plasmic-mcp] Global variant export failed (non-fatal):", e instanceof Error ? e.message : e);
     }
 
-    // Entry module: import the skeleton and render via setPlasmicRootNode
-    const entrySource = `
-      var React = window.__Sub.React;
-      var mod = require("./${output.skeletonModuleFileName}");
-      var Comp = mod.default || mod[Object.keys(mod).find(function(k) { return k !== '__esModule'; }) || ''];
-      window.__Sub.setPlasmicRootNode(
-        React.createElement(Comp, null)
-      );
-      window.parent.postMessage({ source: "plasmic-preview", type: "rendered" }, "*");
-    `;
+    // 6g. Dependent components (live-syncer:192-230). For every component the
+    // root transitively references, emit either a code-component stub (looks
+    // up __PlasmicComponentRegistry at runtime) or full render+skeleton+css
+    // modules for a regular Plasmic component.
+    //
+    // This is what unblocks `require("./comp__<uuid>")` resolution in the
+    // generated render module — without these, SystemJS would try to fetch
+    // them from the iframe origin (which has no such route) and fail.
+    try {
+      for (const dep of extractDependentComponents(component)) {
+        if (isCodeComponent(dep)) {
+          modules.push(createCodeComponentModule(dep, { idFileNames: true }));
+          if (isCodeComponentWithHelpers(dep)) {
+            modules.push(createCodeComponentHelperModule(dep, { idFileNames: true }));
+          }
+        } else {
+          // Use the owning site's projectConfig so imported components
+          // reference their own project's CSS (see live-syncer:205-210).
+          const ownerSite = tryGetOwnerSite(dep);
+          const depProjectConfig =
+            ownerSite === site || !ownerSite
+              ? projectConfig
+              : depProjectConfigs.get(ownerSite) ?? projectConfig;
+          const depOutput: ComponentExportOutput = exportReactPresentational(
+            compGenHelper,
+            dep,
+            site,
+            depProjectConfig,
+            imageAssetUriMap,
+            false,
+            false,
+            undefined,
+            exportOpts,
+            siteCtx
+          );
+          modules.push(...createComponentModules(depOutput));
+        }
+      }
+    } catch (e) {
+      console.error("[plasmic-mcp] Dependent component emission failed (non-fatal):", e instanceof Error ? e.message : e);
+    }
 
-    modules.push({
-      name: "./preview-entry.tsx",
-      source: entrySource,
-      lang: "tsx",
-      run: true,
-    });
+    // 6h. Global contexts (live-syncer:320-335 processGlobalContexts).
+    // Emit stubs for each global-context code component plus the bundle's
+    // wrapper module. Uses the shared `makeGlobalContextsImport` conventions:
+    // file is `./PlasmicGlobalContextsProvider.tsx`, default export is
+    // `GlobalContextsProvider` (matches react-p/global-context/index.ts:190).
+    const globalContextBundle = (projectConfig as any).globalContextBundle;
+    try {
+      if (globalContextBundle) {
+        const globalContexts = (site.globalContexts ?? []).map((tpl: any) => tpl.component);
+        for (const ctx of globalContexts) {
+          modules.push(createCodeComponentModule(ctx, { idFileNames: true }));
+        }
+        modules.push({
+          name: "./PlasmicGlobalContextsProvider.tsx",
+          source: globalContextBundle.contextModule,
+          lang: "tsx",
+        });
+      }
+    } catch (e) {
+      console.error("[plasmic-mcp] Global context emission failed (non-fatal):", e instanceof Error ? e.message : e);
+    }
+
+    // Entry module — mirrors Studio's createPreviewScript at
+    // platform/wab/src/wab/client/components/live/live-syncer.ts:498-670.
+    // SYNC POINT: on upstream merges, diff createPreviewScript and port any
+    // changes here. MCP drops Studio's mobx `untracked()` wrapping and uses
+    // empty defaults for variant/global/pageParams/currentAppUser.
+    modules.push(buildPreviewEntryScript({
+      output,
+      site,
+      component,
+      styleTokensProviderBundle:
+        (projectConfig as any).hasStyleTokenOverrides
+          ? (projectConfig as any).styleTokensProviderBundle
+          : undefined,
+      globalContextBundle,
+      projectConfig,
+      pageParams: opts?.pageParams ?? {},
+      pageQuery: opts?.pageQuery ?? {},
+    }));
 
     return modules;
   } catch (err) {
@@ -410,6 +732,204 @@ function generateComponentModules(component: any): CodeModule[] | { error: strin
     console.error(`[plasmic-mcp] Codegen failed for "${component.name}":`, msg);
     return { error: msg };
   }
+}
+
+/**
+ * Build the preview entry module — mirror of Studio's `createPreviewScript`
+ * (platform/wab/src/wab/client/components/live/live-syncer.ts:498-670).
+ *
+ * Studio's function takes `PreviewCtx`/`StudioCtx` (mobx-reactive); MCP has
+ * neither, so we take primitive inputs and use empty defaults where Studio
+ * would read user-selected state (variants, global variants, pageParams,
+ * pageQuery, currentAppUser). `untracked()` is dropped — no mobx in MCP.
+ *
+ * Wrapping chain (outer → inner):
+ *   StyleTokensProvider        — root project's token overrides
+ *     global variant providers — theme/screen etc
+ *       GlobalContextsProvider — EPCommerceProvider and other globalContexts
+ *         PageParamsProvider   — $ctx.params/query for page components
+ *           PlasmicDataSourceContextProvider — currentAppUser / authToken
+ *             div.live-root-container(--centered) — layout frame
+ *               Component(__plasmicIsPreviewRoot=true)
+ *
+ * Then optionally wraps in `<ph.DataProvider name="..."><Suspense>` when
+ * React 18+ is detected (so async data-source integrations don't suspend
+ * the whole iframe).
+ *
+ * SYNC POINT: on upstream merges, diff live-syncer.ts:498-670 and port any
+ * changes here. See also memory: project_upstream_merge_runbook.md.
+ */
+function buildPreviewEntryScript(opts: {
+  output: ComponentExportOutput;
+  site: any;
+  component: any;
+  styleTokensProviderBundle?: { id: string; fileName: string };
+  globalContextBundle?: any;
+  projectConfig: any;
+  pageParams: Record<string, string>;
+  pageQuery: Record<string, string>;
+}): CodeModule {
+  const {
+    output,
+    site,
+    component,
+    styleTokensProviderBundle,
+    globalContextBundle,
+    projectConfig,
+    pageParams,
+    pageQuery,
+  } = opts;
+  const componentName = output.componentName;
+  const componentPath = output.skeletonModuleFileName;
+
+  // Build the component-wrapping expression inside-out, same order as
+  // live-syncer.ts:507-565.
+  let content = `React.createElement(${componentName}, {
+    ...props,
+    ${makePlasmicIsPreviewRootComponent()}: true
+  })`;
+
+  const containerClass = `live-root-container ${
+    output.isPage ? "" : "live-root-container--centered"
+  }`;
+  content = `React.createElement("div", {className: "${containerClass}"}, ${content})`;
+
+  if (styleTokensProviderBundle) {
+    content = `<StyleTokensProvider>{${content}}</StyleTokensProvider>`;
+  }
+
+  const globalGroups = allGlobalVariantGroups(site, {
+    includeDeps: "all",
+    excludeEmpty: true,
+    excludeMediaQuery: true,
+  });
+  const globalGroupImports = makeGlobalGroupImports(globalGroups, {
+    idFileNames: true,
+  });
+  const globalContextsImports = globalContextBundle
+    ? makeGlobalContextsImport(projectConfig)
+    : "";
+
+  if (globalContextBundle) {
+    // Mirror of live-syncer.ts:1111-1117. Shared `wrapGlobalContexts` in
+    // serialize-utils.ts:464 inlines content as JSX children (used by the
+    // regular codegen pipeline where content is already a JSX element); here
+    // content can be a JS expression string like `React.createElement(...)`,
+    // so we wrap in `{...}` to keep Babel's JSX parser happy.
+    content = `<GlobalContextsProvider>{${content}}</GlobalContextsProvider>`;
+  }
+  for (const vg of globalGroups) {
+    content = wrapGlobalProviderWithCustomValue(
+      vg,
+      content,
+      true,
+      `global.${toVarName(vg.param.variable.name)}`
+    );
+  }
+
+  if (isPageComponent(component)) {
+    const path = JSON.stringify(component.pageMeta?.path ?? "/");
+    const params = JSON.stringify(pageParams);
+    const query = JSON.stringify(pageQuery);
+    content = `ph.PageParamsProvider ? (
+      <ph.PageParamsProvider route={${path}} params={${params}} query={${query}}>
+        {(${content})}
+      </ph.PageParamsProvider>
+    ) : (${content})`;
+  }
+
+  // wrapContentWithCurrentUserContext (live-syncer.ts:1119-1132) — 6 lines,
+  // inlined here because it's not shared.
+  content = `
+  <p.PlasmicDataSourceContextProvider value={${jsLiteral({
+    user: undefined,
+    userAuthToken: undefined,
+  })}}>
+    {(${content})}
+  </p.PlasmicDataSourceContextProvider>
+  `;
+
+  // Serialize initial props from component.params previewExprs + Plume
+  // plugin defaults (live-syncer.ts:571-602). Skip Studio's mobx untracked().
+  const serializedInitialProps: Record<string, string> = {};
+  const exprCtx: ExprCtx = {
+    component: null,
+    projectFlags: DEVFLAGS,
+    inStudio: false,
+  };
+  for (const param of component.params ?? []) {
+    if (!isKnownPropParam(param) || !param.previewExpr) continue;
+    serializedInitialProps[toVarName(param.variable.name)] = getRawCode(
+      param.previewExpr,
+      exprCtx
+    );
+  }
+  const plugin = getPlumeEditorPlugin(component);
+  if (plugin?.getArtboardRootDefaultProps) {
+    const defaults = plugin.getArtboardRootDefaultProps(component);
+    if (defaults) {
+      for (const [key, val] of Object.entries(defaults)) {
+        serializedInitialProps[key] = JSON.stringify(val);
+      }
+    }
+  }
+
+  const source = `
+      import React from "react";
+      import ReactDOM from "react-dom";
+      import * as ph from "@plasmicapp/host";
+      import * as p from "@plasmicapp/react-web";
+      ${globalGroupImports}
+      ${globalContextsImports}
+      ${
+        styleTokensProviderBundle
+          ? `import { StyleTokensProvider } from "./${styleTokensProviderBundle.fileName}";`
+          : ""
+      }
+      import ${componentName} from "./${componentPath}";
+      const Sub = (window as any).__Sub;
+
+      function PlasmicPreviewWrapper() {
+        const [props, setProps] = React.useState({
+          ${Object.entries(serializedInitialProps)
+            .map(([key, val]) => `${key}: ${val}`)
+            .join(",\n          ")}
+        });
+        const [global, setGlobal] = React.useState({});
+        (window as any).setPreviewComponentProps = (newProps) => {
+          setProps({...props, ...newProps});
+        };
+        (window as any).setPreviewGlobalVariants = setGlobal;
+        const reactMajorVersion = +React.version.split(".")[0];
+        const content = (${content});
+        if (reactMajorVersion >= 18 && !!ph.DataProvider) {
+          return (
+            <ph.DataProvider
+              name="plasmicInternalEnableLoadingBoundary"
+              hidden
+              data={true}
+            >
+              <React.Suspense fallback="Loading...">
+                {content}
+              </React.Suspense>
+            </ph.DataProvider>
+          );
+        }
+        return content;
+      }
+
+      export function __run() {
+        Sub.hostUtils.setPlasmicRootNode(React.createElement(PlasmicPreviewWrapper, {}));
+        window.parent.postMessage({ source: "plasmic-preview", type: "rendered" }, "*");
+      }
+    `;
+
+  return {
+    name: `./script_${componentName}.tsx`,
+    source,
+    lang: "tsx",
+    run: true,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -423,11 +943,17 @@ async function handleRequest(
   const parsed = url.parse(req.url || "/", true);
   const pathname = parsed.pathname || "/";
 
-  // GET /preview/:componentName
+  // GET /preview/<path-or-name>?key=value&... — Studio-style routing
+  // (matches PreviewCtx.tsx:701-763 `getComponentByPath`). The segment after
+  // `/preview/` is matched against every page's `pageMeta.path`: if the URL
+  // is `/preview/product/test-product`, we extract `{slug: "test-product"}`
+  // from the ProductDetail route `/product/[slug]`. Query string becomes
+  // pageQuery. Falls back to component name/UUID for non-page components.
   const previewMatch = pathname.match(/^\/preview\/(.+)$/);
   if (req.method === "GET" && previewMatch) {
-    const componentName = decodeURIComponent(previewMatch[1]);
-    handlePreview(componentName, res);
+    const rawPath = decodeURIComponent(previewMatch[1]);
+    const query = parsed.query as Record<string, string | string[] | undefined>;
+    await handlePreview(rawPath, query, res);
     return;
   }
 
@@ -461,13 +987,39 @@ async function handleRequest(
   // GET /health
   if (req.method === "GET" && pathname === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ status: "ok", port: serverPort, hostUrl: platformHostUrl }));
+    res.end(JSON.stringify({ status: "ok", port: serverPort, hostUrl: getStudioOrigin() }));
+    return;
+  }
+
+  // GET /debug — internal state inspection (developer-only)
+  if (req.method === "GET" && pathname === "/debug") {
+    const sess = getSession();
+    const appHostUrls = Array.from(cachedAppHostHtml.keys());
+    const appHostSizes = appHostUrls.map(k => ({ origin: k, size: cachedAppHostHtml.get(k)?.length ?? 0 }));
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      sessionHostUrl: sess?.hostUrl ?? null,
+      activeAppHostOrigin,
+      cachedAppHosts: appHostSizes,
+      lastAppHostFetchError,
+      cachedHostHtmlLength: cachedHostHtml?.length ?? 0,
+      commitHash,
+    }, null, 2));
     return;
   }
 
   // GET / — component index
   if (req.method === "GET" && pathname === "/") {
     handleIndex(res);
+    return;
+  }
+
+  // Catch-all: proxy anything else to the active app host (the user's dev
+  // server). This covers `/_next/static/chunks/*.js` and other relative URLs
+  // referenced inside the rewritten app-host HTML we serve at
+  // /static/host.html. Without this the iframe 404s on every Next.js chunk.
+  if (activeAppHostOrigin) {
+    await handleUpstreamProxy(req, res, activeAppHostOrigin);
     return;
   }
 
@@ -480,7 +1032,14 @@ async function handleRequest(
 // ---------------------------------------------------------------------------
 
 function handleHostHtml(res: http.ServerResponse): void {
-  if (!cachedHostHtml) {
+  // Prefer the project's app-host HTML (rewritten for same-origin embedding)
+  // when one was fetched during the most recent /preview request. Fall back
+  // to Studio's host.html for hostless projects.
+  console.error(`[plasmic-mcp/host.html] activeAppHostOrigin=${activeAppHostOrigin} hasCached=${activeAppHostOrigin ? cachedAppHostHtml.has(activeAppHostOrigin) : "n/a"}`);
+  const html = activeAppHostOrigin
+    ? cachedAppHostHtml.get(activeAppHostOrigin) ?? cachedHostHtml
+    : cachedHostHtml;
+  if (!html) {
     res.writeHead(503, { "Content-Type": "text/html" });
     res.end(errorPage("Host Not Available", "host.html not loaded. Check platform host URL."));
     return;
@@ -490,20 +1049,14 @@ function handleHostHtml(res: http.ServerResponse): void {
     "Content-Type": "text/html; charset=utf-8",
     "Cache-Control": "no-cache",
   });
-  res.end(cachedHostHtml);
+  res.end(html);
 }
 
 async function handleStaticProxy(
   pathname: string,
   res: http.ServerResponse
 ): Promise<void> {
-  if (!platformHostUrl) {
-    res.writeHead(503, { "Content-Type": "text/plain" });
-    res.end("No platform host URL configured");
-    return;
-  }
-
-  const targetUrl = `${platformHostUrl}${pathname}`;
+  const targetUrl = `${getStudioOrigin()}${pathname}`;
   try {
     const proxyRes = await fetch(targetUrl, { redirect: "follow" });
     if (!proxyRes.ok) {
@@ -527,10 +1080,43 @@ async function handleStaticProxy(
   }
 }
 
-function handlePreview(
-  componentName: string,
+/**
+ * Transparent reverse proxy: forward a request to the user's dev server.
+ * Used for `/_next/*` and any other path the rewritten app-host HTML
+ * references relatively — those must come from the user's dev server but
+ * be served at our origin to stay same-origin with the iframe.
+ */
+async function handleUpstreamProxy(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  upstreamOrigin: string
+): Promise<void> {
+  const target = `${upstreamOrigin}${req.url || "/"}`;
+  try {
+    const proxyRes = await fetch(target, {
+      method: req.method,
+      redirect: "follow",
+      // Don't forward hop-by-hop or host-specific headers; let fetch set its own
+    });
+    const contentType = proxyRes.headers.get("content-type") || "application/octet-stream";
+    const body = Buffer.from(await proxyRes.arrayBuffer());
+    res.writeHead(proxyRes.status, {
+      "Content-Type": contentType,
+      "Cache-Control": proxyRes.headers.get("cache-control") || "no-cache",
+    });
+    res.end(body);
+  } catch (err: any) {
+    console.error(`[plasmic-mcp] Upstream proxy error for ${req.url}:`, err.message);
+    res.writeHead(502, { "Content-Type": "text/plain" });
+    res.end(`Upstream proxy failed: ${err.message}`);
+  }
+}
+
+async function handlePreview(
+  rawPath: string,
+  rawQuery: Record<string, string | string[] | undefined>,
   res: http.ServerResponse
-): void {
+): Promise<void> {
   const session = getSession();
   if (!session) {
     res.writeHead(503, { "Content-Type": "text/html" });
@@ -544,20 +1130,34 @@ function handlePreview(
     return;
   }
 
-  // Resolve component by name or UUID
-  const component = session.site.components?.find(
-    (c: any) => c.name === componentName || c.uuid === componentName
-  );
-  if (!component) {
+  // Resolve using Studio's path-matching rules. `rawPath` may be:
+  //   - `product/test-product` → matches a page with pageMeta.path `/product/[slug]`
+  //   - `ProductDetail`        → matches by component name
+  //   - `03EbS1cxqctg`         → matches by UUID
+  const resolved = resolveComponentByPath(session.site, rawPath);
+  if (!resolved) {
     const names = (session.site.components || []).map((c: any) => c.name).join(", ");
     res.writeHead(404, { "Content-Type": "text/html" });
-    res.end(errorPage("Component Not Found", `"${componentName}" not found. Available: ${names}`));
+    res.end(errorPage("Component Not Found", `"${rawPath}" didn't match any page path or component. Available components: ${names}`));
     return;
+  }
+  const { component, pageParams: pathParams } = resolved;
+
+  // Merge path-derived params with pageMeta defaults (path wins) and
+  // derive pageQuery from the query string, falling back to pageMeta.query
+  // defaults when a key is absent (mirrors Studio's PreviewCtx.tsx:390-395).
+  const pageMetaParams: Record<string, string> = component.pageMeta?.params ?? {};
+  const pageMetaQuery: Record<string, string> = component.pageMeta?.query ?? {};
+  const pageParams: Record<string, string> = { ...pageMetaParams, ...pathParams };
+  const pageQuery: Record<string, string> = { ...pageMetaQuery };
+  for (const [k, v] of Object.entries(rawQuery)) {
+    if (v === undefined) continue;
+    pageQuery[k] = Array.isArray(v) ? (v[0] ?? "") : v;
   }
 
   // Generate component code using the same codegen pipeline as Studio's live preview
   let modules: CodeModule[];
-  const result = generateComponentModules(component);
+  const result = generateComponentModules(component, { pageParams, pageQuery });
 
   if (result && !("error" in result)) {
     modules = result;
@@ -581,7 +1181,7 @@ function handlePreview(
         source: `
           var React = window.__Sub.React;
           var el = React.createElement;
-          window.__Sub.setPlasmicRootNode(
+          window.__Sub.hostUtils.setPlasmicRootNode(
             el("div", { style: { padding: "40px", fontFamily: "system-ui" } },
               el("h1", {}, ${JSON.stringify(component.name)}),
               el("p", { style: { color: "#c00" } }, "Codegen failed:"),
@@ -597,7 +1197,26 @@ function handlePreview(
   }
 
   const studioOrigin = getStudioOrigin();
-  const previewHtml = generatePreviewPage(component.name, modules, commitHash, studioOrigin);
+
+  // Track the active app host origin so the catch-all proxy forwards
+  // `/_next/*` etc. to the right upstream. The iframe loads the user's host
+  // page at its real pathname (e.g. `/plasmic-host`) through our origin,
+  // which makes it same-origin with the outer preview page (so script
+  // injection into the iframe works) while still hitting the real Next.js
+  // app for HTML/JS/CSS. Hostless projects fall back to /static/host.html
+  // (served from Studio's cached host.html).
+  const appHostPathname =
+    session.hostUrl != null ? new URL(session.hostUrl).pathname : null;
+  activeAppHostOrigin =
+    session.hostUrl != null ? new URL(session.hostUrl).origin : null;
+
+  const previewHtml = generatePreviewPage(
+    component.name,
+    modules,
+    commitHash,
+    studioOrigin,
+    appHostPathname
+  );
 
   res.writeHead(200, {
     "Content-Type": "text/html; charset=utf-8",
@@ -647,12 +1266,17 @@ function generatePreviewPage(
   componentName: string,
   modules: CodeModule[],
   hash: string,
-  studioOrigin: string
+  studioOrigin: string,
+  appHostPathname: string | null
 ): string {
   const modulesJson = JSON.stringify(modules);
-  // The iframe src must be /static/host.html (sub/index.tsx checks location.pathname)
-  // The origin param tells PlasmicCanvasHost where to load getlibs.js (SystemJS) from
-  const iframeSrc = `/static/host.html#live=true&origin=${encodeURIComponent(studioOrigin)}`;
+  // Iframe loads the app host's pathname (e.g. `/plasmic-host`) or, for
+  // hostless projects, Studio's `/static/host.html`. Either way the URL is on
+  // OUR origin so the outer page can inject scripts directly into the iframe
+  // document. The catch-all proxy forwards any unmatched paths (e.g.
+  // `/_next/static/chunks/*.js`) to the upstream.
+  const iframeBase = appHostPathname ?? "/static/host.html";
+  const iframeSrc = `${iframeBase}#live=true&origin=${encodeURIComponent(studioOrigin)}`;
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/packages/plasmic-mcp/src/save-manager.ts
+++ b/packages/plasmic-mcp/src/save-manager.ts
@@ -18,6 +18,10 @@ import { mergeRecordedChanges, type RecordedChanges } from "@/wab/shared/core/ob
 import { requireSession } from "./session.js";
 import { modelSchemaHash } from "@/wab/shared/model/classes-metas";
 import { assertSiteInvariants } from "@/wab/shared/site-invariants";
+import {
+  checkExistingReferences,
+  checkRefsInBundle,
+} from "@/wab/shared/bundler";
 
 export interface SaveResult {
   revisionNum: number;
@@ -88,12 +92,38 @@ export class SaveManager {
 
     const newRevisionNum = revisionNum + 1;
 
-    // Validate site invariants before saving (matches Studio's StudioCtx.trySave())
+    // Validate site invariants before saving (matches Studio's StudioCtx.trySave()).
+    // Uses shared checkers from @/wab/shared — zero duplicated logic.
+    //   assertSiteInvariants    — Site-model invariants (duplicate names,
+    //                             arena/frame integrity, arrayType conflicts,
+    //                             style-token validity).
+    //   checkExistingReferences — every `__ref` in the bundle points to an
+    //                             existing IID in bundle.map. Catches dangling
+    //                             references left over by a mutation path that
+    //                             failed to clean up (gap #71 class).
+    //   checkRefsInBundle       — weak/strong-ref consistency across the full
+    //                             reachable graph; surfaces unreachable
+    //                             instances that still carry parent refs.
+    // We validate against `bundler.cachedBundle()` (the post-fastBundle full
+    // bundle state) rather than the incremental delta — the corruption we
+    // want to catch is cross-instance, not delta-local.
     try {
       assertSiteInvariants(site);
+      // `cachedBundle()` is a FastBundler method; fall back gracefully for
+      // test stubs or any bundler variant that doesn't expose it.
+      const fullBundle =
+        typeof (bundler as { cachedBundle?: () => unknown }).cachedBundle ===
+        "function"
+          ? (bundler as { cachedBundle: () => unknown }).cachedBundle()
+          : undefined;
+      if (fullBundle) {
+        checkExistingReferences(fullBundle as never);
+        checkRefsInBundle(fullBundle as never);
+      }
     } catch (err: unknown) {
       throw new Error(
-        `Site invariant violation: ${err instanceof Error ? err.message : String(err)} ` +
+        `Pre-save bundle validation failed: ${err instanceof Error ? err.message : String(err)} ` +
+          `This prevents a corrupt bundle from being persisted (gap #71). ` +
           `Use refresh-project to reload the latest valid version, then retry your edit.`
       );
     }
@@ -216,12 +246,38 @@ export class SaveManager {
     const bundle = bundler.bundle(site, projectId, freshBundleVersion);
     const newRevisionNum = revisionNum + 1;
 
-    // Validate site invariants before saving (matches Studio's StudioCtx.trySave())
+    // Validate site invariants before saving (matches Studio's StudioCtx.trySave()).
+    // Uses shared checkers from @/wab/shared — zero duplicated logic.
+    //   assertSiteInvariants    — Site-model invariants (duplicate names,
+    //                             arena/frame integrity, arrayType conflicts,
+    //                             style-token validity).
+    //   checkExistingReferences — every `__ref` in the bundle points to an
+    //                             existing IID in bundle.map. Catches dangling
+    //                             references left over by a mutation path that
+    //                             failed to clean up (gap #71 class).
+    //   checkRefsInBundle       — weak/strong-ref consistency across the full
+    //                             reachable graph; surfaces unreachable
+    //                             instances that still carry parent refs.
+    // We validate against `bundler.cachedBundle()` (the post-fastBundle full
+    // bundle state) rather than the incremental delta — the corruption we
+    // want to catch is cross-instance, not delta-local.
     try {
       assertSiteInvariants(site);
+      // `cachedBundle()` is a FastBundler method; fall back gracefully for
+      // test stubs or any bundler variant that doesn't expose it.
+      const fullBundle =
+        typeof (bundler as { cachedBundle?: () => unknown }).cachedBundle ===
+        "function"
+          ? (bundler as { cachedBundle: () => unknown }).cachedBundle()
+          : undefined;
+      if (fullBundle) {
+        checkExistingReferences(fullBundle as never);
+        checkRefsInBundle(fullBundle as never);
+      }
     } catch (err: unknown) {
       throw new Error(
-        `Site invariant violation: ${err instanceof Error ? err.message : String(err)} ` +
+        `Pre-save bundle validation failed: ${err instanceof Error ? err.message : String(err)} ` +
+          `This prevents a corrupt bundle from being persisted (gap #71). ` +
           `Use refresh-project to reload the latest valid version, then retry your edit.`
       );
     }

--- a/packages/plasmic-mcp/src/server.ts
+++ b/packages/plasmic-mcp/src/server.ts
@@ -147,6 +147,22 @@ import { emitEditPresence, clearEditPresence, emitInspectPresence } from "./tool
 import { undoChanges } from "@/wab/shared/core/undo-util";
 import type { TreeReadOptions } from "./types.js";
 
+/**
+ * Strip the internal-only `recordedChanges` field from the ingestion object
+ * before it goes into a tool response. `recordedChanges` holds live Plasmic
+ * model references (TplSlot ↔ TplTag cycles etc.) that break JSON.stringify.
+ * The field is only meant to flow from `syncFromDevHost` → `SaveManager`
+ * internally; callers get the summary shape instead.
+ */
+function publicIngestion(
+  ingestion: NonNullable<
+    Awaited<ReturnType<typeof import("./devhost-sync.js").syncFromDevHost>>["ingestion"]
+  >
+) {
+  const { recordedChanges: _recordedChanges, ...rest } = ingestion;
+  return rest;
+}
+
 // ---------------------------------------------------------------------------
 // PlasmicElement schema — strict top level, z.any() for recursive children.
 //
@@ -394,12 +410,13 @@ export function createServer(): McpServer {
     "project",
     {
       description: "Project session lifecycle, persistence, batch operations, undo, and package management.\n" +
-        "Actions: set, list, get-meta, save, refresh, begin-batch, end-batch, undo, list-packages, list-available-packages, list-package-components, add-package, remove-package, upgrade-package.\n" +
-        "- set: Load a project into memory (required before other tools). Example: {action:\"set\",projectId:\"pId123\"} → {success:true,projectName:\"My App\"}\n" +
+        "Actions: set, list, get-meta, save, refresh, sync-dev-host, begin-batch, end-batch, undo, list-packages, list-available-packages, list-package-components, add-package, remove-package, upgrade-package.\n" +
+        "- set: Load a project into memory (required before other tools). Default syncMode='full' auto-ingests newly-registered dev-host code components into site.components (runs under ChangeRecorder so new instances broadcast via live-sync to Studio). Example: {action:\"set\",projectId:\"pId123\"} → {success:true,projectName:\"My App\",ingestion:{addedComponents:[...]}}\n" +
         "- list: List all accessible projects. Example: {action:\"list\"} → {projects:[{id:\"pId123\",name:\"My App\"}]}\n" +
         "- get-meta: Get project metadata (name, counts, pages, components). Example: {action:\"get-meta\"} → {name:\"My App\",pageCount:3,componentCount:5}\n" +
         "- save: Force full save to server\n" +
         "- refresh: Reload project from server\n" +
+        "- sync-dev-host: Re-fetch the dev host registry and re-run ingestion without reloading the project. Use after registering a new code component on the dev host mid-session. Example: {action:\"sync-dev-host\"} → {ingestion:{addedComponents:[\"my-comp\"]}}\n" +
         "- begin-batch: Start accumulating edits. Example: {action:\"begin-batch\"} → {batchId:\"batch-1\"}\n" +
         "- end-batch: Save accumulated edits in one revision. Example: {action:\"end-batch\",batchId:\"batch-1\"} → {success:true,revision:42}\n" +
         "- undo: Revert most recent edit\n" +
@@ -411,16 +428,22 @@ export function createServer(): McpServer {
         "- upgrade-package: Upgrade one or all packages to latest version\n" +
         "- health-check: Check server status, version, and authentication state (works without auth)",
       inputSchema: {
-        action: z.enum(["set", "list", "get-meta", "save", "refresh", "begin-batch", "end-batch", "undo", "list-packages", "list-available-packages", "list-package-components", "add-package", "remove-package", "upgrade-package", "health-check"]),
+        action: z.enum(["set", "list", "get-meta", "save", "refresh", "sync-dev-host", "begin-batch", "end-batch", "undo", "list-packages", "list-available-packages", "list-package-components", "add-package", "remove-package", "upgrade-package", "health-check"]),
         projectId: z.string().optional().describe("The Plasmic project ID (required for 'set' and 'add-package')"),
         branchId: z.string().optional().describe("Branch ID to load (omit for main branch). Use branch.list to get available branch IDs."),
         batchId: z.string().optional().describe("Optional batch ID for verification (used by 'end-batch')"),
         pkgId: z.string().optional().describe("Package ID for 'remove-package' and 'upgrade-package' (optional for upgrade-all)"),
         packageName: z.string().optional().describe("Package name filter for 'list-package-components'"),
+        syncMode: z
+          .enum(["full", "variants-only"])
+          .optional()
+          .describe(
+            "Dev-host sync behavior on 'set' / 'refresh' / 'sync-dev-host'. Default 'full' ingests newly-registered code components into site.components. 'variants-only' skips ingestion (faster, preserves legacy behavior). Overrides the PLASMIC_MCP_SKIP_DEV_HOST_INGESTION env var."
+          ),
       },
       annotations: { idempotentHint: true },
     },
-    async ({ action, projectId, branchId, batchId, pkgId, packageName }) => {
+    async ({ action, projectId, branchId, batchId, pkgId, packageName, syncMode }) => {
       try {
         switch (action) {
           case "set": {
@@ -446,8 +469,24 @@ export function createServer(): McpServer {
               projectApiToken,
             } = await loadProject(getClient(), pid, branchId);
 
-            // Sync code component variants from the dev host (non-fatal)
-            const syncResult = await syncFromDevHost(site, hostUrl);
+            // Tracker must exist BEFORE syncFromDevHost's ingestion pass so
+            // its internal `ctx.change` mutations are captured. We bypass the
+            // session for the tracker's isExternalRef plumbing so we can init
+            // the tracker before setSession — avoids a double-setSession that
+            // would reset transient session fields like `pendingSavedRevisionNum`.
+            initChangeTracker(site, { bundler, projectUuid: pid });
+            const tracker = getChangeTracker();
+
+            // Sync from dev host. When mode is 'full' (default), ingestion
+            // runs under the tracker — any new Component / Param / State
+            // instances get captured in
+            // `syncResult.ingestion.recordedChanges` for us to save+broadcast
+            // via the normal SaveManager path (same pipeline as every other
+            // edit, so Studio sees the ingestion via live sync).
+            const syncResult = await syncFromDevHost(site, hostUrl, {
+              syncMode,
+              tracker,
+            });
 
             setSession({
               projectId: pid,
@@ -467,9 +506,6 @@ export function createServer(): McpServer {
               projectApiToken,
             });
 
-            // Initialize change tracking for incremental saves (M2)
-            initChangeTracker(site);
-
             // Phase 2: Persist variant metadata inside change tracker so it's
             // included in the save delta (codeComponentMeta.variants with cssSelector).
             if (syncResult.registryData) {
@@ -477,7 +513,6 @@ export function createServer(): McpServer {
                 (c) => c.variants && Object.keys(c.variants).length > 0
               );
               if (variantComponents.length > 0) {
-                const tracker = getChangeTracker();
                 const changes = tracker.withRecording(() => {
                   recordVariantMetadataSync(site, variantComponents);
                 });
@@ -486,6 +521,30 @@ export function createServer(): McpServer {
                   await saveManager.saveChanges(changes);
                   console.error("[plasmic-mcp] Persisted variant metadata to server");
                 }
+              }
+            }
+
+            // Persist ingestion changes (new code components + their params +
+            // states) via the normal incremental-save path. This broadcasts
+            // to Studio via socket so its UI updates in real time.
+            const ingestionChanges = (syncResult.ingestion as any)?.recordedChanges;
+            if (
+              ingestionChanges &&
+              (ingestionChanges.changes?.length > 0 ||
+                ingestionChanges.removedInsts?.length > 0)
+            ) {
+              try {
+                const saveManager = new SaveManager(getClient());
+                await saveManager.saveChanges(ingestionChanges);
+                console.error(
+                  `[plasmic-mcp] Persisted dev-host ingestion to server: +${syncResult.ingestion?.addedComponents.length ?? 0} components`
+                );
+              } catch (err) {
+                console.error(
+                  `[plasmic-mcp] Persisting dev-host ingestion failed: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`
+                );
               }
             }
 
@@ -534,6 +593,7 @@ export function createServer(): McpServer {
                           traitCount: syncResult.registryData.traits?.length ?? 0,
                         },
                       }),
+                      ...(syncResult.ingestion && { ingestion: publicIngestion(syncResult.ingestion) }),
                     }),
                   }),
                 },
@@ -685,8 +745,22 @@ export function createServer(): McpServer {
             // Clear registry cache to force fresh fetch on explicit refresh
             clearRegistryCache(hostUrl);
 
-            // Re-sync code component variants from the dev host (non-fatal)
-            const syncResult = await syncFromDevHost(site, hostUrl);
+            // Tracker must exist BEFORE syncFromDevHost so the ingestion
+            // pass captures mutations through ChangeRecorder (required for
+            // live-sync socket broadcasts to Studio). Bypasses session here
+            // to avoid a double-setSession pattern.
+            initChangeTracker(site, {
+              bundler,
+              projectUuid: session.projectId,
+            });
+            const tracker = getChangeTracker();
+
+            // Re-sync code component variants + ingestion from the dev host
+            // (non-fatal). Under the tracker so mutations flow to Studio.
+            const syncResult = await syncFromDevHost(site, hostUrl, {
+              syncMode,
+              tracker,
+            });
 
             setSession({
               projectId: session.projectId,
@@ -706,16 +780,12 @@ export function createServer(): McpServer {
               projectApiToken: refreshedToken,
             });
 
-            // Re-initialize change tracking
-            initChangeTracker(site);
-
             // Phase 2: Persist variant metadata inside change tracker
             if (syncResult.registryData) {
               const variantComponents = syncResult.registryData.components.filter(
                 (c) => c.variants && Object.keys(c.variants).length > 0
               );
               if (variantComponents.length > 0) {
-                const tracker = getChangeTracker();
                 const changes = tracker.withRecording(() => {
                   recordVariantMetadataSync(site, variantComponents);
                 });
@@ -724,6 +794,28 @@ export function createServer(): McpServer {
                   await saveManager.saveChanges(changes);
                   console.error("[plasmic-mcp] Persisted variant metadata to server");
                 }
+              }
+            }
+
+            // Persist ingestion changes via the normal incremental-save path.
+            const ingestionChanges = (syncResult.ingestion as any)?.recordedChanges;
+            if (
+              ingestionChanges &&
+              (ingestionChanges.changes?.length > 0 ||
+                ingestionChanges.removedInsts?.length > 0)
+            ) {
+              try {
+                const saveManager = new SaveManager(getClient());
+                await saveManager.saveChanges(ingestionChanges);
+                console.error(
+                  `[plasmic-mcp] Persisted dev-host ingestion to server: +${syncResult.ingestion?.addedComponents.length ?? 0} components`
+                );
+              } catch (err) {
+                console.error(
+                  `[plasmic-mcp] Persisting dev-host ingestion failed: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`
+                );
               }
             }
 
@@ -762,9 +854,47 @@ export function createServer(): McpServer {
                             traitCount: syncResult.registryData.traits?.length ?? 0,
                           },
                         }),
+                        ...(syncResult.ingestion && { ingestion: publicIngestion(syncResult.ingestion) }),
                       }),
                     }
                   ),
+                },
+              ],
+            };
+          }
+
+          case "sync-dev-host": {
+            const session = requireSession();
+            if (!session.hostUrl) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: JSON.stringify({
+                      success: false,
+                      message:
+                        "No dev host URL configured on this project. Set a dev host URL on the project in Plasmic first.",
+                    }),
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const { clearRegistryCache } = await import("./devhost-sync.js");
+            clearRegistryCache(session.hostUrl);
+            const syncResult = await syncFromDevHost(session.site, session.hostUrl, {
+              syncMode,
+            });
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    success: true,
+                    devHostSynced: syncResult.devHostSynced,
+                    syncedVariantComponents: syncResult.syncedVariantComponents,
+                    ...(syncResult.ingestion && { ingestion: syncResult.ingestion }),
+                  }),
                 },
               ],
             };
@@ -1045,7 +1175,7 @@ export function createServer(): McpServer {
         "- subtree: Tree from a specific node downward. Example: {action:\"subtree\",componentUuid:\"abc\",nodeRef:\"card-container\"} → {type:\"tag\",tag:\"div\",children:[...]}\n" +
         "- export: Write full tree to temp file. Example: {action:\"export\",componentUuid:\"abc\"} → {filePath:\"/tmp/tree-abc.json\"}\n" +
         "- style-properties: List valid CSS property names. Example: {action:\"style-properties\",filter:\"flex\"} → [\"flex\",\"flexDirection\",\"flexGrow\",...]\n" +
-        "- preview-url: Get navigable preview URL for visual feedback via Playwright MCP. Returns navigateUrl (local SSR preview server), devHostUrl (if custom host), studioUrl, and viewport presets. After edits, use navigateUrl with Playwright browser_navigate + browser_take_screenshot for visual verification. Example: {action:\"preview-url\",componentUuid:\"abc\"} → {navigateUrl:\"http://127.0.0.1:PORT/preview/Name\",studioUrl:\"https://...\"}\n" +
+        "- preview-url: Get navigable preview URL for visual feedback via Playwright MCP. Pages use a path-based URL that matches the component's pageMeta.path — e.g. /product/[slug] becomes /preview/product/<slug>. Pass pageParams to substitute path segments (e.g. {slug:\"test-product\"}); defaults from pageMeta.params fill in any missing ones. pageQuery is appended as ?k=v. Non-page components use /preview/<Name>. Returns navigateUrl, devHostUrl, studioUrl, viewport presets. After edits, use navigateUrl with Playwright browser_navigate + browser_take_screenshot for visual verification. Example: {action:\"preview-url\",componentUuid:\"abc\",pageParams:{slug:\"test-product\"}} → {navigateUrl:\"http://127.0.0.1:PORT/preview/product/test-product\"}\n" +
         "- page-meta: Read page SEO metadata. Example: {action:\"page-meta\",componentUuid:\"abc\"} → {title:\"Home\",path:\"/\",description:\"...\"}\n" +
         "- list-design-system: Consolidated summary of all design tokens, mixins, and themes. Example: {action:\"list-design-system\"} → {tokens:{Color:[...],Spacing:[...]},mixins:[...],themes:[...]}\n" +
         "- list-global-contexts: List all global context providers configured on the project with their component names, source packages, and configured prop values. Example: {action:\"list-global-contexts\"} → {contexts:[{name:\"Provider\",props:{apiKey:\"...\"}}]}\n" +
@@ -1060,6 +1190,8 @@ export function createServer(): McpServer {
         summaryOnly: z.boolean().optional().describe("Return compact outline (same as summary action)"),
         format: z.enum(["concise", "full"]).optional().describe('Response format. "concise" strips UUIDs (except root), abbreviates keys (childCount→cc, componentName→comp), replaces detail fields with booleans. ~70% token reduction for orientation. Default: "full".'),
         filter: z.string().optional().describe("Filter string for style-properties action"),
+        pageParams: z.record(z.string()).optional().describe('For preview-url on page components: path-param values to substitute into the pageMeta.path template. e.g. {slug:"test-product"} on route /product/[slug] → /preview/product/test-product. Unspecified keys fall back to pageMeta.params defaults.'),
+        pageQuery: z.record(z.string()).optional().describe('For preview-url on page components: query-string values appended as ?k=v. Merged over pageMeta.query defaults.'),
       },
       outputSchema: {
         // Union of output shapes per action. All fields optional since each action
@@ -1086,7 +1218,7 @@ export function createServer(): McpServer {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ action, componentUuid, nodeRef, maxDepth, maxChars, excludeStyles, summaryOnly, format, filter }) => {
+    async ({ action, componentUuid, nodeRef, maxDepth, maxChars, excludeStyles, summaryOnly, format, filter, pageParams, pageQuery }) => {
       try {
         // Emit inspect presence so Studio users see which component the agent is viewing
         if (componentUuid) {
@@ -1439,7 +1571,7 @@ export function createServer(): McpServer {
             };
 
             // Local preview server URL (SSR, works for all project types)
-            const localUrl = getPreviewUrl(component.name);
+            const localUrl = getPreviewUrl(component, { pageParams, pageQuery });
             if (localUrl) {
               result.navigateUrl = localUrl;
               result.usage = "To capture a visual preview, use the Playwright MCP tools: " +
@@ -4990,6 +5122,7 @@ export function createServer(): McpServer {
         "- set-data-cond: Conditional rendering expression (null to remove). Example: {action:\"set-data-cond\",componentUuid:\"abc\",nodeRef:\"banner\",condition:\"$ctx.showBanner === true\"} → {success:true}\n" +
         "- set-data-rep: Repeat element for each item in collection (null to remove). Example: {action:\"set-data-rep\",componentUuid:\"abc\",nodeRef:\"card\",collection:\"$ctx.items\",elementVariable:\"item\",indexVariable:\"idx\"} → {success:true}\n" +
         "- Queries: Manage component data queries. Example: {action:\"add-query\",componentUuid:\"abc\",name:\"fetchUsers\",queryType:\"dataQuery\"} → {success:true,queryUuid:\"q1\"}\n" +
+        "- update-query binds a serverQuery to a registered custom function via `functionCall`. Example: {action:\"update-query\",componentUuid:\"abc\",queryRef:\"product\",functionCall:{namespace:\"ep\",name:\"getProduct\",args:{input:\"{id: $ctx.params.slug}\"}}} → {success:true}. Rename by passing `name`. Pass `functionCall:null` to clear the op. Function must exist in site.customFunctions (run project.sync-dev-host after registering).\n" +
         "- Data tokens: Site-level JSON values ($ctx.tokenName). Example: {action:\"create-data-token\",name:\"apiUrl\",value:\"\\\"https://api.example.com\\\"\"} → {success:true}\n" +
         "- Splits: A/B tests and segments. Example: {action:\"create-split\",name:\"CTATest\",splitType:\"experiment\",slices:[{name:\"Control\",prob:50},{name:\"Variant\",prob:50}]} → {success:true}\n" +
         "- get-code-meta/list-functions: Code component introspection. Example: {action:\"list-functions\",componentUuid:\"abc\"} → {functions:[{name:\"handleSubmit\",params:[...]}]}",
@@ -5011,6 +5144,19 @@ export function createServer(): McpServer {
       name: z.string().optional().describe("Name for create/rename operations"),
       queryRef: z.string().optional().describe("Query reference (name or UUID)"),
       queryType: z.enum(["dataQuery", "serverQuery"]).optional().describe("Query type"),
+      functionCall: z
+        .union([
+          z.object({
+            namespace: z.string().optional(),
+            name: z.string(),
+            args: z.record(z.string(), z.string()),
+          }),
+          z.null(),
+        ])
+        .optional()
+        .describe(
+          "For update-query on a serverQuery: bind the query's op to a registered custom function. Shape: {namespace, name, args: {argName: jsExpressionString}}. Pass null to clear the op (detach). The function must exist in site.customFunctions — run project.sync-dev-host if the dev host was just updated."
+        ),
       tokenRef: z.string().optional().describe("Data token reference (UUID or name)"),
       value: z.string().optional().describe("Value for data token or token update"),
       splitRef: z.string().optional().describe("Split reference (UUID or name)"),
@@ -5228,11 +5374,20 @@ export function createServer(): McpServer {
           case "update-query": {
             const cuuid = requireParam(params.componentUuid, "componentUuid", "data.update-query");
             const qRef = requireParam(params.queryRef, "queryRef", "data.update-query");
-            const qName = requireParam(params.name, "name", "data.update-query");
+            // `name` and `functionCall` are each optional, but at least one
+            // must be provided — updateQuery() enforces this.
+            const qName = params.name as string | undefined;
+            const hasFunctionCallField = Object.prototype.hasOwnProperty.call(
+              params,
+              "functionCall"
+            );
+            const options = hasFunctionCallField
+              ? { functionCall: params.functionCall as any }
+              : undefined;
 
             if (params.dryRun) {
               const result = await withDryRun(() =>
-                updateQuery(getClient(), cuuid, qRef, qName)
+                updateQuery(getClient(), cuuid, qRef, qName, options)
               );
               return {
                 content: [
@@ -5252,7 +5407,7 @@ export function createServer(): McpServer {
               };
             }
 
-            const result = await updateQuery(getClient(), cuuid, qRef, qName);
+            const result = await updateQuery(getClient(), cuuid, qRef, qName, options);
             return {
               content: [
                 {

--- a/packages/plasmic-mcp/src/wab.d.ts
+++ b/packages/plasmic-mcp/src/wab.d.ts
@@ -38,7 +38,24 @@ declare module "@/wab/shared/bundler" {
     /** Maps address key string to live instance.
      *  Public for tests and defensive access. Populated during unbundle(). */
     _addr2inst: Map<string, any>;
+
+    /** Returns the cached full bundle snapshot from the last bundle pass.
+     *  Used by save-manager's pre-save validators (gap #71) to walk the
+     *  entire bundle graph for reference integrity checks. */
+    cachedBundle(): { map: Record<string, any>; root: string; deps: string[] } | undefined;
   }
+
+  /** Pre-save validator — walks every IID in the bundle map and asserts
+   *  each `{__ref: iid}` points to an existing entry. Throws on dangling
+   *  refs. Used by save-manager to reject corrupt bundles before they
+   *  reach the server (gap #71). */
+  export function checkExistingReferences(bundle: unknown): void;
+
+  /** Pre-save validator — walks the reachable graph from bundle.root and
+   *  asserts weak/strong-ref consistency. Throws on weak refs to
+   *  unreachable instances (the classic parentKey-orphan corruption
+   *  pattern from gap #70). */
+  export function checkRefsInBundle(bundle: unknown, opts?: unknown): void;
 }
 
 declare module "@/wab/shared/model/classes-metas" {
@@ -364,6 +381,27 @@ declare module "@/wab/shared/model/classes" {
     uuid: string;
     name: string;
     op: any;
+  }
+
+  /** Model class for CustomFunctionExpr — an expression that calls a
+   *  registered CustomFunction. Used as the `op` of a serverQuery to bind
+   *  the query to `ep.getProduct` etc. Mirrors Studio's
+   *  `ServerQueryOpPicker` construction pattern — `func` is the
+   *  CustomFunction reference, `args` is the array of FunctionArgs. */
+  export class CustomFunctionExpr {
+    constructor(args: { func: any; args: any[] });
+    func: any;
+    args: any[];
+  }
+
+  /** Model class for FunctionArg — a single argument of a CustomFunctionExpr.
+   *  `argType` is a WeakRef to the ArgType in `func.params`; `expr` is
+   *  typically a CustomCode or ObjectPath carrying the argument value. */
+  export class FunctionArg {
+    constructor(args: { uuid: string; expr: any; argType: any });
+    uuid: string;
+    expr: any;
+    argType: any;
   }
 
   /** Model class for EventHandler — event handler expression containing interactions. */
@@ -762,6 +800,26 @@ declare module "@/wab/shared/core/tpls" {
   /** Register a component → site mapping in the COMPONENT_TO_SITE WeakMap.
    *  Required for getOwnerSite() lookups. */
   export function trackComponentSite(component: any, site: any): void;
+
+  /** Walk every expression (CustomCode, ObjectPath, TemplatedString, etc.)
+   *  referenced anywhere in a component's tplTree, styles, data queries,
+   *  params, and interactions. Used by `data.remove-query`'s pre-flight
+   *  reference check (gap #70) to detect `$queries.<name>` bindings
+   *  before deleting the query. */
+  export function findExprsInComponent(component: any): Array<{ expr: any; [key: string]: any }>;
+}
+
+declare module "@/wab/shared/refactoring" {
+  /** Returns true if the given expression references the named query
+   *  (`$queries.<name>`). Used alongside a regex fallback for MCP's
+   *  pre-flight check before `data.remove-query` — Studio's primary
+   *  source of truth for query reference detection. */
+  export function isQueryUsedInExpr(queryName: string, expr: any): boolean;
+
+  /** Returns true if the given expression references the named data
+   *  token (`$dataTokens.<name>`). Mirror helper to `isQueryUsedInExpr`
+   *  for the token-deletion pre-flight path. */
+  export function isDataTokenUsedInExpr(tokenName: string, expr: any): boolean;
 }
 
 declare module "@/wab/shared/RuleSetHelpers" {

--- a/packages/plasmic-mcp/src/wab.d.ts
+++ b/packages/plasmic-mcp/src/wab.d.ts
@@ -1214,6 +1214,7 @@ declare module "@/wab/shared/codegen/types" {
     isLivePreview?: boolean;
     targetEnv: string;
     localization?: any;
+    relPathFromManagedToImplDir?: string;
   }
 
   export interface ComponentExportOutput {
@@ -1346,4 +1347,110 @@ declare module "@/wab/shared/core/styles" {
       opts?: { keepAssetRefs?: boolean; useCssVariables?: boolean }
     );
   }
+}
+
+// --- Preview-script mirror dependencies (live-syncer.ts:498-670) ---
+
+declare module "@/wab/shared/codegen/util" {
+  /** JSON.stringify-equivalent string literal emitter used by code generators. */
+  export function jsLiteral(value: any): string;
+  /** Converts an identifier to a valid JS variable name (camelCase, safe chars). */
+  export function toVarName(name: string): string;
+}
+
+declare module "@/wab/shared/codegen/react-p/serialize-utils" {
+  import type { ProjectConfig } from "@/wab/shared/codegen/types";
+
+  export function makeComponentSkeletonIdFileName(component: any): string;
+  export function makeCodeComponentHelperSkeletonIdFileName(component: any): string;
+  /** `import GlobalContextsProvider from "./PlasmicGlobalContextsProvider"` */
+  export function makeGlobalContextsImport(projectConfig: ProjectConfig): string;
+  /** Wraps content in `<GlobalContextsProvider>{...}</GlobalContextsProvider>` */
+  export function wrapGlobalContexts(content: string): string;
+  /** `import {<ProviderName>} from "./<filename>"` per global variant group. */
+  export function makeGlobalGroupImports(
+    globalGroups: any[],
+    opts?: { idFileNames?: boolean }
+  ): string;
+  /** Prop name Studio sets on the root preview component (`__plasmicIsPreviewRoot`). */
+  export function makePlasmicIsPreviewRootComponent(): string;
+  /** Wraps content in the group's variant provider binding to an expression. */
+  export function wrapGlobalProviderWithCustomValue(
+    vg: any,
+    content: string,
+    curlyBrackets: boolean,
+    value: string
+  ): string;
+}
+
+declare module "@/wab/shared/core/sites" {
+  /** Returns global variant groups active for preview, optionally including deps. */
+  export function allGlobalVariantGroups(
+    site: any,
+    opts?: {
+      includeDeps?: "all" | "direct";
+      excludeEmpty?: boolean;
+      excludeMediaQuery?: boolean;
+      excludeInactiveScreenVariants?: boolean;
+      includeActiveScreenVariantsFromDeps?: boolean;
+    }
+  ): any[];
+}
+
+declare module "@/wab/shared/core/exprs" {
+  export interface ExprCtx {
+    component: any | null;
+    projectFlags: any;
+    inStudio: boolean;
+  }
+  /** Serializes a Plasmic expression node back to raw JS source. */
+  export function getRawCode(expr: any, ctx: ExprCtx): string;
+}
+
+declare module "@/wab/shared/devflags" {
+  /** Runtime dev-flags bag. Treat fields as optional booleans. */
+  export const DEVFLAGS: Record<string, any>;
+}
+
+declare module "@/wab/shared/plume/plume-registry" {
+  interface PlumeEditorPlugin {
+    getArtboardRootDefaultProps?(component: any): Record<string, any> | undefined;
+  }
+  /** Returns the Plume editor plugin for a component, if any (Select, Button, etc.). */
+  export function getPlumeEditorPlugin(component: any): PlumeEditorPlugin | undefined;
+}
+
+// --- Dev-host ingestion dependencies (mirrors Studio's
+// server/code-components/code-components.ts usage pattern) ---
+
+declare module "@/wab/shared/code-components/code-components" {
+  /** Reads registered components/contexts/tokens/traits/functions/libs from
+   *  a Window-like object's `__Plasmic*Registry` globals. */
+  export class CodeComponentsRegistry {
+    constructor(win: unknown, builtins: Record<string, unknown>);
+  }
+  /** Master orchestrator: type-checks, adds new, fixes missing, refreshes
+   *  metas, upserts tokens/functions/libs. Returns a failable result. */
+  export function syncCodeComponents(
+    ctx: unknown,
+    callbacks: unknown,
+    opts?: { force?: boolean }
+  ): Promise<unknown>;
+}
+
+declare module "@/wab/shared/utils/url-utils" {
+  /** Substitutes [slug] / [[...catchall]] placeholders in a page path template. */
+  export function substituteUrlParams(
+    template: string,
+    params: Record<string, string>
+  ): string;
+  /**
+   * Matches a URL path against a page path template.
+   * `getMatchingPagePathParams("/product/[slug]", "/product/foo")` →
+   * `{slug: "foo"}`. Returns `false` when the template doesn't match.
+   */
+  export function getMatchingPagePathParams(
+    pagePath: string,
+    lookup: string
+  ): Record<string, string> | false;
 }

--- a/packages/plasmic-mcp/vitest.config.integration.ts
+++ b/packages/plasmic-mcp/vitest.config.integration.ts
@@ -159,6 +159,7 @@ export default defineConfig({
       "src/__tests__/real-integration.test.ts",
       "src/__tests__/devhost-sync-integration.test.ts",
       "src/__tests__/package-manager.integration.test.ts",
+      "src/__tests__/devhost-ingestion.integration.test.ts",
     ],
     testTimeout: 30_000,
     hookTimeout: 30_000,

--- a/packages/plasmic-mcp/vitest.config.unit.ts
+++ b/packages/plasmic-mcp/vitest.config.unit.ts
@@ -59,6 +59,10 @@ export default defineConfig({
         replacement: path.resolve(__dirname, "src/__mocks__/wab-tpl-mgr"),
       },
       {
+        find: /^@\/wab\/shared\/refactoring$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-refactoring"),
+      },
+      {
         find: /^@\/wab\/shared\/site-invariants$/,
         replacement: path.resolve(
           __dirname,
@@ -216,6 +220,35 @@ export default defineConfig({
         find: /^@\/wab\/shared\/codegen\/image-assets$/,
         replacement: path.resolve(__dirname, "src/__mocks__/wab-codegen-image-assets"),
       },
+      // Preview-server + devhost-ingestion transitive shared imports
+      {
+        find: /^@\/wab\/shared\/codegen\/util$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-codegen-util"),
+      },
+      {
+        find: /^@\/wab\/shared\/codegen\/react-p\/serialize-utils$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-serialize-utils"),
+      },
+      {
+        find: /^@\/wab\/shared\/core\/sites$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-core-sites"),
+      },
+      {
+        find: /^@\/wab\/shared\/core\/exprs$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-core-exprs"),
+      },
+      {
+        find: /^@\/wab\/shared\/devflags$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-devflags"),
+      },
+      {
+        find: /^@\/wab\/shared\/plume\/plume-registry$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-plume-registry"),
+      },
+      {
+        find: /^@\/wab\/shared\/utils\/url-utils$/,
+        replacement: path.resolve(__dirname, "src/__mocks__/wab-url-utils"),
+      },
     ],
     extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
   },
@@ -226,6 +259,7 @@ export default defineConfig({
       "src/__tests__/real-integration.test.ts",
       "src/__tests__/devhost-sync-integration.test.ts",
       "src/__tests__/package-manager.integration.test.ts",
+      "src/__tests__/devhost-ingestion.integration.test.ts",
     ],
     environment: "node",
   },


### PR DESCRIPTION
## Summary

Closes MCP gaps **#70, #71, #73, #74** discovered during EP PDP work. All four fixes mirror Studio's shared behaviour rather than re-implementing model logic — paths documented in commit message.

- **Gap #70** — `data.remove-query` now pre-flight-checks `$queries.<name>` bindings in the component tree and refuses to delete a query that's still referenced (mirrors Studio's `site-ops.removeComponentServerQuery`).
- **Gap #71** — `save-manager` runs `assertSiteInvariants` + `checkExistingReferences` + `checkRefsInBundle` (all shared Studio validators from `@/wab/shared/...`) before POSTing; corrupt bundles never reach the server.
- **Gap #73** — `devhost-sync-shim` wraps `__PlasmicFunctionsRegistry` entries as `{fn, meta}` pairs to match what `CodeComponentsRegistry.getRegisteredFunctions` expects. Without this, `project.sync-dev-host` crashes with `Cannot read properties of undefined (reading 'namespace')` on any project with registered custom functions.
- **Gap #74** — `data.update-query` gains a `functionCall: {namespace, name, args}` parameter to bind a `serverQuery`'s op to a registered `CustomFunction`. Mirrors `ServerQueryOpPicker`'s construction pattern. Pass `null` to clear the op.
- **Paren-wrapped CustomCode** — `createAttrExpr` and `buildCustomFunctionExpr` now wrap dynamic code strings in parens to match Studio's `createExprForDataPickerValue`. Without the parens, `isRealCodeExpr` returns false and Plasmic's codegen emits bare `$q` / `$queries` / `$ctx` references that fail at runtime because the safe-IIFE wrapper is skipped.
- **Registry** — `plasmic-mcp-registry/next.ts` uses selective server externalization: workspace/monorepo packages without `"use client"` (`@plasmicpkgs/*`, `@elasticpath/plasmic-*`) stay externalized; published `@plasmicapp/host` + `@plasmicapp/query` stay bundled so Next's `react$` alias keeps one React instance end-to-end.

## Test plan

- [x] `yarn test:unit` — 2180 passing (net +16 new: gap #74 ×8, save-manager validators ×6, devhost-sync-shim ×1, paren-wrap updates ×existing tests)
- [x] `yarn test:integration -t "gap #7"` — 3 integration regressions green: gap #70 refuse-when-referenced, gap #70 unreferenced-round-trip, gap #71 save rejects corrupt bundle
- [x] Live verified on a real project with `ep.getProduct$dev` registered: `project.sync-dev-host` completes cleanly, `data.update-query` with `functionCall` compiles to `execParams: () => [{...}]` + `product: v.product.data` (valid scope-resolved codegen), Studio's UI reads the arg correctly.