### PR TITLE
fix(plasmic-mcp-registry): eval-require @plasmicapp/host + drop from server externals

### DIFF
--- a/packages/plasmic-mcp-registry/src/capture.ts
+++ b/packages/plasmic-mcp-registry/src/capture.ts
@@ -8,20 +8,25 @@
  *
  * Solution: Wrap the PLASMIC loader object so that each registration call ALSO
  * invokes @plasmicapp/host's corresponding function, which writes to globalThis.
- * This is safe on the server — the host functions just push to arrays, no React hooks.
+ *
+ * Why eval-require for @plasmicapp/host:
+ *   The published @plasmicapp/host dist carries a `"use client"` directive. If
+ *   webpack bundles it, Next's RSC runtime treats every export as a client
+ *   reference — making `registerFunction`/`registerComponent` uncallable from
+ *   server API routes. The natural fix (add the package to serverExternalPackages)
+ *   forces Node's require to load a separate copy of React; that second React
+ *   has its own dispatcher slot, which Next never sets during SSR → calls like
+ *   `useContext` in globalContext components return null mid-render.
+ *   The `eval("require")` trick sidesteps webpack's static analysis at THIS
+ *   call site only — the host module is loaded via plain Node require at
+ *   runtime (directive becomes a no-op string), while the rest of the app
+ *   keeps webpack-bundled @plasmicapp/host so SSR renders use one React
+ *   instance with a properly-set dispatcher.
  *
  * Usage (in plasmic-register.ts):
  *   import { withRegistryCapture } from "@elasticpath/plasmic-mcp-registry";
  *   const CAPTURED = typeof window === "undefined" ? withRegistryCapture(PLASMIC) : PLASMIC;
- *   // Then register packages with CAPTURED instead of PLASMIC
  */
-import {
-  registerComponent,
-  registerGlobalContext,
-  registerFunction,
-  registerToken,
-  registerTrait,
-} from "@plasmicapp/host";
 
 /**
  * Minimal interface for a PLASMIC-like object that has registration methods.
@@ -34,6 +39,30 @@ interface PlasmicLike {
   registerToken?: (token: unknown) => void;
   registerTrait?: (trait: string, meta: unknown) => void;
   [key: string]: unknown;
+}
+
+interface HostRegistration {
+  registerComponent: (component: unknown, meta: unknown) => void;
+  registerGlobalContext: (component: unknown, meta: unknown) => void;
+  registerFunction: (fn: unknown, meta: unknown) => void;
+  registerToken: (token: unknown) => void;
+  registerTrait: (trait: string, meta: unknown) => void;
+}
+
+let _host: HostRegistration | undefined;
+
+function host(): HostRegistration {
+  if (!_host) {
+    // eval("require") avoids webpack's static-import analysis. Webpack
+    // would otherwise see this as an import of @plasmicapp/host, read the
+    // package's `"use client"` directive, and mark every export as a
+    // client reference — which would make these functions uncallable
+    // from server routes.
+    // eslint-disable-next-line no-eval
+    const nodeRequire = eval("require") as NodeRequire;
+    _host = nodeRequire("@plasmicapp/host") as HostRegistration;
+  }
+  return _host;
 }
 
 /**
@@ -51,23 +80,23 @@ export function withRegistryCapture<T extends PlasmicLike>(plasmic: T): T {
     ...plasmic,
     registerComponent(component: unknown, meta: unknown) {
       plasmic.registerComponent(component, meta);
-      registerComponent(component as any, meta as any);
+      host().registerComponent(component, meta);
     },
     registerGlobalContext(component: unknown, meta: unknown) {
       plasmic.registerGlobalContext?.(component, meta);
-      registerGlobalContext(component as any, meta as any);
+      host().registerGlobalContext(component, meta);
     },
     registerFunction(fn: unknown, meta: unknown) {
       plasmic.registerFunction?.(fn, meta);
-      registerFunction(fn as any, meta as any);
+      host().registerFunction(fn, meta);
     },
     registerToken(token: unknown) {
       plasmic.registerToken?.(token);
-      registerToken(token as any);
+      host().registerToken(token);
     },
     registerTrait(trait: string, meta: unknown) {
       plasmic.registerTrait?.(trait, meta);
-      registerTrait(trait, meta as any);
+      host().registerTrait(trait, meta);
     },
   } as T;
 }

--- a/packages/plasmic-mcp-registry/src/next.ts
+++ b/packages/plasmic-mcp-registry/src/next.ts
@@ -43,36 +43,41 @@ interface WebpackContext {
 /**
  * Package patterns for `serverExternalPackages`.
  *
- * We ONLY externalise workspace/monorepo packages that (a) register code
- * components and (b) do not carry a `"use client"` directive at their entry.
- * The Next.js RSC runtime replaces `react` with `react.shared-subset` (no
- * `createContext`), so modules that touch `React.createContext` at the top
- * level blow up during server evaluation of API routes that import them.
- * Externalising forces Node's `require` to load them outside the RSC graph
- * using the consumer's full React from `node_modules`.
+ * We externalise two categories:
  *
- * Explicitly NOT externalised:
- *   - `@plasmicapp/host` and `@plasmicapp/query` — published dists that
- *     carry `"use client"` directives. Externalising them makes Node's
- *     `require` load their React from the consumer's node_modules, which
- *     is a different instance than Next's internally-bundled React →
- *     "Invalid hook call / useContext is null" under the iframe runtime.
- *     Bundling lets Next's webpack `react$` alias point both server and
- *     client at Next's internal React, giving one dispatcher end-to-end.
+ *   - `@plasmicapp/host` + `@plasmicapp/query` — these carry `"use client"`
+ *     at their dist entry (good for RSC client-boundary detection) but
+ *     their server-side helpers (`registerFunction`, `registerComponent`,
+ *     etc.) need to be callable from server API routes (e.g. for
+ *     MCP dev-host registration). Externalising forces Node's `require`
+ *     to load them outside the RSC graph where the `"use client"` directive
+ *     is simply a no-op string — the functions remain callable.
  *
- * A consumer who hits a genuine RSC failure from some other package can
- * still externalise it by passing `serverExternalPackages: ["…"]` in
- * their own config; this wrapper merges the lists.
+ *   - `@plasmicpkgs/*` — upstream packages that call React hooks
+ *     (`createContext`, `useState`) at module top level without carrying
+ *     their own `"use client"`. Bundled into the RSC runtime they crash on
+ *     `react.shared-subset`; externalised, Node require loads them with
+ *     full React from the consumer's `node_modules`.
+ *
+ * Consumer packages (`@elasticpath/plasmic-*`) that DO carry `"use client"`
+ * at their dist entry are deliberately NOT externalised — we want Next's
+ * webpack to read the directive and create proper client boundaries so
+ * SSR avoids rendering the components. See
+ * `plasmicpkgs/commerce-providers/elastic-path/build-server.mjs` for the
+ * post-build directive-injection pattern.
  */
 const PLASMIC_PACKAGE_PATTERNS: RegExp[] = [
   /^@plasmicpkgs\//,
-  /^@elasticpath\/plasmic-/,
 ];
 
-/** Webpack externals mirror the same set — needed for monorepo packages. */
+/**
+ * Webpack externals — smaller set. `@plasmicapp/*` packages resolve via
+ * normal node_modules so `serverExternalPackages` alone handles them.
+ * `@plasmicpkgs/*` may need the webpack externals fallback when resolved
+ * via monorepo symlinks (Next issue #48739).
+ */
 const WEBPACK_EXTERNAL_PATTERNS: RegExp[] = [
   /^@plasmicpkgs\//,
-  /^@elasticpath\/plasmic-/,
 ];
 
 /**

--- a/packages/plasmic-mcp-registry/src/next.ts
+++ b/packages/plasmic-mcp-registry/src/next.ts
@@ -43,42 +43,23 @@ interface WebpackContext {
 /**
  * Package patterns for `serverExternalPackages`.
  *
- * We externalise two categories:
+ * Empty by default — with the `eval("require")` handling in capture.ts
+ * for `@plasmicapp/host`, there's no remaining reason to externalise
+ * Plasmic-related packages at the Next config level. Externalisation
+ * forces Node to load modules with a separate React instance, which
+ * breaks SSR of client components whose hooks then hit a null
+ * dispatcher. Empty patterns let webpack bundle everything into Next's
+ * graph where `"use client"` directives correctly trigger client-boundary
+ * handling and one React instance runs end-to-end.
  *
- *   - `@plasmicapp/host` + `@plasmicapp/query` — these carry `"use client"`
- *     at their dist entry (good for RSC client-boundary detection) but
- *     their server-side helpers (`registerFunction`, `registerComponent`,
- *     etc.) need to be callable from server API routes (e.g. for
- *     MCP dev-host registration). Externalising forces Node's `require`
- *     to load them outside the RSC graph where the `"use client"` directive
- *     is simply a no-op string — the functions remain callable.
- *
- *   - `@plasmicpkgs/*` — upstream packages that call React hooks
- *     (`createContext`, `useState`) at module top level without carrying
- *     their own `"use client"`. Bundled into the RSC runtime they crash on
- *     `react.shared-subset`; externalised, Node require loads them with
- *     full React from the consumer's `node_modules`.
- *
- * Consumer packages (`@elasticpath/plasmic-*`) that DO carry `"use client"`
- * at their dist entry are deliberately NOT externalised — we want Next's
- * webpack to read the directive and create proper client boundaries so
- * SSR avoids rendering the components. See
- * `plasmicpkgs/commerce-providers/elastic-path/build-server.mjs` for the
- * post-build directive-injection pattern.
+ * A consumer who hits a genuine RSC failure from some other package can
+ * still externalise it by passing `serverExternalPackages: ["…"]` in
+ * their own config; this wrapper merges the lists.
  */
-const PLASMIC_PACKAGE_PATTERNS: RegExp[] = [
-  /^@plasmicpkgs\//,
-];
+const PLASMIC_PACKAGE_PATTERNS: RegExp[] = [];
 
-/**
- * Webpack externals — smaller set. `@plasmicapp/*` packages resolve via
- * normal node_modules so `serverExternalPackages` alone handles them.
- * `@plasmicpkgs/*` may need the webpack externals fallback when resolved
- * via monorepo symlinks (Next issue #48739).
- */
-const WEBPACK_EXTERNAL_PATTERNS: RegExp[] = [
-  /^@plasmicpkgs\//,
-];
+/** Webpack externals mirror the same set. Empty — see comment block above. */
+const WEBPACK_EXTERNAL_PATTERNS: RegExp[] = [];
 
 /**
  * Auto-detects Plasmic-related packages from the consumer's package.json


### PR DESCRIPTION
## Summary

Untangles a Next 15 App Router SSR deadlock when \`@plasmicapp/host\` is reached via \`serverExternalPackages\`:

- Prior configuration externalised \`@plasmicapp/host\` so server API routes could call \`registerFunction\` without hitting Next's "use client" boundary rejection. But Node's \`require\` then loaded a second copy of the module with its own React instance, and during SSR of client components any \`useContext\`/\`useMemo\` call inside \`@plasmicapp/host\` returned \`null\` on that React's dispatcher — Next had only set the dispatcher on its bundled React.
- New configuration: webpack bundles \`@plasmicapp/host\` normally (one React end-to-end, no dispatcher mismatch), and \`capture.ts\` loads the package via \`eval("require")(...)\` at the single call site where we need the register* functions callable server-side. Webpack can't statically analyse the eval so it doesn't apply the client-reference wrapping; Node require at runtime yields a full module with the directive treated as a no-op string.

Net effect: server routes still populate the Plasmic registry for MCP dev-host sync, AND SSR of client components no longer crashes with \`Cannot read properties of null (reading 'useContext')\`.

## Test plan

- [x] \`/api/plasmic-registry\` returns 200 + full registry payload on the EP commerce example app
- [x] PDP on the EP commerce example app returns 200 (pre-fix: 500 with \`useContext null\`)
- [ ] MCP \`project.sync-dev-host\` round-trip still works for components + functions (manual verify needed post-merge)

Related: [#268](https://github.com/elasticpath/plasmic/issues/268) — the EP commerce package side uses a complementary \`"use client"\` prepend via \`build-server.mjs\` (separate change on \`feat/server-cart-shopper-context\`).