### PR TITLE
feat(ep-commerce): ALS-based session context for EP Server Queries (#272)

### DIFF
--- a/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
+++ b/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
@@ -2,8 +2,10 @@ import { PLASMIC } from "@/plasmic-init";
 import "@/plasmic-register";
 import { PlasmicClientRootProvider } from "@/plasmic-init-client";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
-import { DataProvider } from "@plasmicapp/host";
-import { buildEpCtx } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import {
+  buildEpCtx,
+  withEpSession,
+} from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
 import { notFound } from "next/navigation";
 import { cookies } from "next/headers";
 import { epAuth, epProviderHeaders } from "@/lib/ep-auth";
@@ -63,7 +65,7 @@ export default async function PlasmicLoaderPage({
   } catch {}
 
   // ---------------------------------------------------------------------------
-  // Build $ctx.ep + run Studio Server Queries (PRD #262)
+  // Build EP session context + run Studio Server Queries (PRD #262 / #272)
   // ---------------------------------------------------------------------------
   const epCtx = buildEpCtx(prefetchedData, {
     session: {
@@ -78,13 +80,13 @@ export default async function PlasmicLoaderPage({
     pagePath: plasmicPath,
     params: pageMeta.params ?? {},
     query: resolvedSearchParams,
-    ep: epCtx,
   };
-  // When a page has no Server Queries defined, `unstable__getServerQueriesData`
-  // returns `{}` and client-side SWR falls through (backward compatible).
-  const prefetchedQueryData = await PLASMIC.unstable__getServerQueriesData(
-    prefetchedData,
-    queryCtx
+  // EP session flows via AsyncLocalStorage (PRD #272). Each `ep.*` server
+  // function reads the active session via `getCurrentEpSession()` — no
+  // `auth: $ctx.ep` binding needed in Studio Server Queries, no
+  // `<DataProvider name="ep">` wrap needed for SWR cache-key parity.
+  const prefetchedQueryData = await withEpSession(epCtx, () =>
+    PLASMIC.unstable__getServerQueriesData(prefetchedData, queryCtx)
   );
 
   const globalContextsProps = {
@@ -99,13 +101,7 @@ export default async function PlasmicLoaderPage({
       pageParams={pageMeta.params}
       pageQuery={queryCtx.query}
     >
-      {/* Expose $ctx.ep to the client-side render. Studio Server Queries
-          build a cache key that includes $ctx.ep — the client must see the
-          same object so its SWR key matches `prefetchedQueryData` and avoids
-          an unauthenticated refetch. */}
-      <DataProvider name="ep" data={epCtx}>
-        <PlasmicComponent component={pageMeta.displayName} />
-      </DataProvider>
+      <PlasmicComponent component={pageMeta.displayName} />
     </PlasmicClientRootProvider>
   );
 }

--- a/packages/plasmic-mcp-registry/src/capture.ts
+++ b/packages/plasmic-mcp-registry/src/capture.ts
@@ -76,26 +76,30 @@ function host(): HostRegistration {
  * @returns A wrapped object with the same interface
  */
 export function withRegistryCapture<T extends PlasmicLike>(plasmic: T): T {
+  // Forwarding to `plasmic.register*` is intentionally omitted: the loader's
+  // own register methods are noops server-side, AND with `@plasmicapp/host`
+  // now bundled into Next's RSC graph (no longer in serverExternalPackages),
+  // those methods carry the package's `"use client"` marker — invoking them
+  // from a server route trips Next's RSC boundary protection
+  // ("registerFunction is on the client"). The capture wrapper exists solely
+  // to populate `@plasmicapp/host`'s globalThis registries via the
+  // eval-required `host()` reference, which is what the MCP / API route
+  // reads back via `getFullRegistry()`.
   return {
     ...plasmic,
     registerComponent(component: unknown, meta: unknown) {
-      plasmic.registerComponent(component, meta);
       host().registerComponent(component, meta);
     },
     registerGlobalContext(component: unknown, meta: unknown) {
-      plasmic.registerGlobalContext?.(component, meta);
       host().registerGlobalContext(component, meta);
     },
     registerFunction(fn: unknown, meta: unknown) {
-      plasmic.registerFunction?.(fn, meta);
       host().registerFunction(fn, meta);
     },
     registerToken(token: unknown) {
-      plasmic.registerToken?.(token);
       host().registerToken(token);
     },
     registerTrait(trait: string, meta: unknown) {
-      plasmic.registerTrait?.(trait, meta);
       host().registerTrait(trait, meta);
     },
   } as T;

--- a/plasmicpkgs/commerce-providers/elastic-path/COMPONENTS.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/COMPONENTS.md
@@ -788,11 +788,12 @@ Browser                          Server (Next.js)              Elastic Path
                                  catch-all page.tsx
                                    buildEpCtx() ----- mints ---> /oauth/access_token
                                                                  /pcm/catalog/products
-                                   PLASMIC.unstable__getServerQueriesData
-                                     ↓ executes ep.getProduct({id, auth})
-                                     ↓ result keyed by SWR cache key
-                                   prefetchedQueryData ------> RSC payload
-                                                              + DataProvider("ep")
+                                   withEpSession(epCtx, () =>
+                                     PLASMIC.unstable__getServerQueriesData
+                                       ↓ executes ep.getProduct({id})
+                                       ↓ each ep.* fn reads session
+                                       ↓ via getCurrentEpSession() (ALS)
+                                   ) prefetchedQueryData ------> RSC payload
 PlasmicClientRootProvider <-------- prefetchedQueryData
   $q.product.data hydrated from cache, no client refetch
 ```
@@ -801,36 +802,37 @@ PlasmicClientRootProvider <-------- prefetchedQueryData
 
 | Function | Args | Returns |
 |---|---|---|
-| `ep.getProduct` | `{ id, auth }` | `Product \| null` — single product by EP UUID |
-| `ep.getCart` | `{ auth }` | `Cart \| null` — current cart contents |
-| `ep.getProductList` | `{ limit?, search?, categoryId?, sort?, auth }` | `Product[]` — paginated list |
-| `ep.getRelatedProducts` | `{ productId, relationshipSlug, limit?, auth }` | `Product[]` — products linked by EP custom relationship |
+| `ep.getProduct` | `{ id }` | `Product \| null` — single product by EP UUID |
+| `ep.getCart` | `{}` | `Cart \| null` — current cart contents |
+| `ep.getProductList` | `{ limit?, search?, categoryId?, sort? }` | `Product[]` — paginated list |
+| `ep.getRelatedProducts` | `{ productId, relationshipSlug, limit? }` | `Product[]` — products linked by EP custom relationship |
 
-`auth` is the resolved `$ctx.ep` shape — a normalised payload of `{ accessToken, host, clientId, cartId?, accountId?, locale? }` produced by `buildEpCtx(prefetchedData, { session })`.
+The session (`accessToken`, `host`, `clientId`, `cartId?`, `accountId?`, `locale?`) is **not** an argument. `withEpSession(epCtx, callback)` establishes a per-request `AsyncLocalStorage` scope; each `ep.*` function reads the active session via `getCurrentEpSession()` internally. Outside any `withEpSession` scope (Studio canvas, mistakes), functions fail-soft to `null` / `[]` without calling EP.
 
 ### Studio binding
 
 For each Server Query in the Plasmic UI:
 
 - **Function:** `ep.getProduct` (or `getCart`/`getProductList`/`getRelatedProducts`)
-- **Arguments (object editor):** `{ id: $ctx.params.slug, auth: $ctx.ep }` — note `$q` (server queries) vs `$queries` (client data queries) when binding the result.
+- **Arguments (object editor):** `{ id: $ctx.params.slug }` — note `$q` (server queries) vs `$queries` (client data queries) when binding the result.
 
 Then bind the consuming component's `product` / `cart` / `products` prop (advanced section) to `$q.<queryName>.data`.
 
 ### Required Next.js setup
 
 1. **`platformOptions: { nextjs: { appDir: true } }`** in `plasmic-init.ts`. Without this the loader fetches the Pages Router bundle which omits `serverQueriesExecFuncFileName` per-page metadata.
-2. **`<DataProvider name="ep" data={epCtx}>`** wrap around `<PlasmicComponent>` in the catch-all page. Without it, server and client compute different SWR cache keys and the client refetches unauthenticated. Tracked for follow-up retirement in #272 (ALS-based session context).
+2. **Wrap `unstable__getServerQueriesData` in `withEpSession(epCtx, ...)`** in the catch-all page. Without it, the EP functions run outside any session scope and return `null` / `[]`.
 3. **Resolve a real page path for the API route's `epProviderHeaders()`** — use `PLASMIC.fetchPages()` rather than hardcoding `/`. Projects without a homepage route otherwise return `null` from `maybeFetchComponentData("/")` and the credentials-extraction path silently fails.
 
 ### Common gotchas
 
 | Symptom | Likely cause |
 |---|---|
-| Page renders `Product not found` despite valid product UUID | `auth: $ctx.ep` reaching the function as `undefined` — missing `<DataProvider name="ep">` wrap |
+| Queries return `null` / `[]` despite valid arguments | Missing `withEpSession(epCtx, …)` wrap around `unstable__getServerQueriesData` |
 | `prefetchedQueryData: "$undefined"` in the SSR HTML | `appDir: true` missing from loader config |
 | `EP OAuth failed (401)` in dev log | Override headers (`x-ep-client-id`/`x-ep-host`) returned empty — usually because `getEpProviderConfig` hardcoded `/` and the project has no homepage |
 | Auth works on the page but `/api/ep/cart` returns 500 | Pre-fix: `toNextJsHandler` was passing the native Next `Request` directly; resolved by the Request adapter committed in `a363aaf23` |
+| Studio binding still references `auth: $ctx.ep` | Project predates PRD #272 — drop `auth` from each Server Query argument |
 
 ## 8. Utility Components
 

--- a/plasmicpkgs/commerce-providers/elastic-path/README.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/README.md
@@ -308,20 +308,24 @@ registerEpCustomFunctions(PLASMIC);
 
 This registers four functions in the `ep` namespace, callable from Studio's Server Query builder:
 
-- `ep.getProduct({ id, auth })` — single product by EP product UUID.
-- `ep.getCart({ auth })` — current cart contents.
-- `ep.getProductList({ limit?, search?, categoryId?, sort?, auth })` — paginated product list.
-- `ep.getRelatedProducts({ productId, relationshipSlug, limit?, auth })` — products linked by an EP custom relationship.
+- `ep.getProduct({ id })` — single product by EP product UUID.
+- `ep.getCart()` — current cart contents.
+- `ep.getProductList({ limit?, search?, categoryId?, sort? })` — paginated product list.
+- `ep.getRelatedProducts({ productId, relationshipSlug, limit? })` — products linked by an EP custom relationship.
 
-### 3. Build `$ctx.ep` in the catch-all page
+Auth is **not** an argument. The session (`accessToken`, `clientId`, `host`, `cartId`, …) is propagated through `AsyncLocalStorage` — see step 3.
+
+### 3. Wrap Server Queries in `withEpSession`
 
 ```ts
 // app/[[...catchall]]/page.tsx
 import { PLASMIC } from "@/plasmic-init";
 import { PlasmicClientRootProvider } from "@/plasmic-init-client";
 import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
-import { DataProvider } from "@plasmicapp/host";
-import { buildEpCtx } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import {
+  buildEpCtx,
+  withEpSession,
+} from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
 import { epAuth, epProviderHeaders } from "@/lib/ep-auth";
 import { cookies } from "next/headers";
 
@@ -339,7 +343,7 @@ export default async function PlasmicLoaderPage({ params, searchParams }) {
     headers: await epProviderHeaders(prefetchedData),
   });
 
-  // Compose $ctx.ep — auth + cart context for server-side EP calls.
+  // Compose the EP session — auth + cart context for server-side EP calls.
   const epCtx = buildEpCtx(prefetchedData, {
     session: {
       accessToken: session.session?.accessToken,
@@ -348,14 +352,18 @@ export default async function PlasmicLoaderPage({ params, searchParams }) {
     },
   });
 
-  // Run Studio Server Queries with the auth-enriched ctx.
-  const prefetchedQueryData = await PLASMIC.unstable__getServerQueriesData(prefetchedData, {
-    pageRoute: pageMeta.path,
-    pagePath: plasmicPath,
-    params: pageMeta.params ?? {},
-    query: (await searchParams) ?? {},
-    ep: epCtx,
-  });
+  // Run Studio Server Queries inside an EP session scope. Each `ep.*`
+  // function reads the active session via AsyncLocalStorage — no `auth`
+  // binding required in Studio, no `<DataProvider name="ep">` wrap on
+  // the client side.
+  const prefetchedQueryData = await withEpSession(epCtx, () =>
+    PLASMIC.unstable__getServerQueriesData(prefetchedData, {
+      pageRoute: pageMeta.path,
+      pagePath: plasmicPath,
+      params: pageMeta.params ?? {},
+      query: (await searchParams) ?? {},
+    })
+  );
 
   return (
     <PlasmicClientRootProvider
@@ -363,13 +371,7 @@ export default async function PlasmicLoaderPage({ params, searchParams }) {
       prefetchedQueryData={prefetchedQueryData}
       pageParams={pageMeta.params}
     >
-      {/* Expose $ctx.ep client-side so the SWR cache key matches the
-          server-computed key. Without this wrap the client recomputes a
-          different key, misses the prefetched cache, and refetches
-          unauthenticated. Tracked for follow-up retirement in #272. */}
-      <DataProvider name="ep" data={epCtx}>
-        <PlasmicComponent component={pageMeta.displayName} />
-      </DataProvider>
+      <PlasmicComponent component={pageMeta.displayName} />
     </PlasmicClientRootProvider>
   );
 }
@@ -380,7 +382,7 @@ export default async function PlasmicLoaderPage({ params, searchParams }) {
 For each Server Query in the Plasmic UI, set the function and arguments. For a product detail page (`/product/[slug]`):
 
 - **Function:** `ep.getProduct`
-- **Arguments:** `{ id: $ctx.params.slug, auth: $ctx.ep }`
+- **Arguments:** `{ id: $ctx.params.slug }`
 
 Then bind the `EPProductProvider` component's advanced `product` prop to `$q.product.data`. Server Queries appear under `$q` (not `$queries`) in the binding panel.
 
@@ -392,10 +394,10 @@ Then bind the `EPProductProvider` component's advanced `product` prop to `$q.pro
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `$q.product.data` always `undefined` on the client | `<DataProvider name="ep">` wrap missing | Wrap `<PlasmicComponent>` per step 3 |
+| `$q.product.data` always `null` / queries return `null` despite valid input | `withEpSession` not wrapped around `unstable__getServerQueriesData` | Wrap the query call per step 3; functions fail-soft to `null` outside an EP session scope |
 | `prefetchedQueryData: "$undefined"` in the SSR HTML | `appDir: true` not set in `plasmic-init.ts` | Add `platformOptions: { nextjs: { appDir: true } }` |
 | `EP OAuth failed (401) Invalid credentials` | API route's `epProviderHeaders()` returned empty (project has no homepage at `/`) | Ensure the storefront resolves a real page path via `fetchPages()` (already done if you copied `lib/ep-auth.ts` from the example) |
-| `auth: undefined` reaching `epGetProduct` | Using `auth: $ctx.ep` binding without the `<DataProvider name="ep">` wrap, OR passing `disableCookieCache: true` to `getSession` | See first row; never pass `disableCookieCache` |
+| Studio binding still references `auth: $ctx.ep` | Project predates PRD #272 | Drop `auth` from each Server Query argument — the session now flows via ALS, not execParams |
 
 ## Components
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getCart.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getCart.test.ts
@@ -11,13 +11,22 @@ jest.mock("@epcc-sdk/sdks-shopper", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { epGetCart } = require("../getCart");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withEpSession } = require("../session-context");
+
+const SESSION_BASE = {
+  accessToken: "tok",
+  host: "https://api.ep.com",
+  clientId: "cid",
+  serverCartMode: false,
+};
 
 beforeEach(() => {
   mockGetACart.mockReset();
 });
 
 describe("epGetCart", () => {
-  it("returns a normalized cart for the given cartId", async () => {
+  it("returns a normalized cart for the cartId carried by the ALS session", async () => {
     mockGetACart.mockResolvedValue({
       data: {
         data: {
@@ -43,14 +52,10 @@ describe("epGetCart", () => {
       },
     });
 
-    const result = await epGetCart({
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-        cartId: "cart-id",
-      },
-    });
+    const result = await withEpSession(
+      { ...SESSION_BASE, cartId: "cart-id" },
+      () => epGetCart()
+    );
 
     expect(result).not.toBeNull();
     expect(result?.id).toBe("cart-id");
@@ -61,14 +66,15 @@ describe("epGetCart", () => {
     );
   });
 
-  it("returns null when no cartId is present (anonymous visitor, no cart yet)", async () => {
-    const result = await epGetCart({
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+  it("returns null when no cartId is on the ALS session (anonymous visitor)", async () => {
+    const result = await withEpSession(SESSION_BASE, () => epGetCart());
+
+    expect(result).toBeNull();
+    expect(mockGetACart).not.toHaveBeenCalled();
+  });
+
+  it("returns null when called outside any withEpSession scope", async () => {
+    const result = await epGetCart();
 
     expect(result).toBeNull();
     expect(mockGetACart).not.toHaveBeenCalled();
@@ -77,14 +83,10 @@ describe("epGetCart", () => {
   it("returns null when EP throws (stale cartId, cart deleted, network error)", async () => {
     mockGetACart.mockRejectedValue(new Error("404 cart not found"));
 
-    const result = await epGetCart({
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-        cartId: "stale-cart-id",
-      },
-    });
+    const result = await withEpSession(
+      { ...SESSION_BASE, cartId: "stale-cart-id" },
+      () => epGetCart()
+    );
 
     expect(result).toBeNull();
   });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProduct.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProduct.test.ts
@@ -121,6 +121,67 @@ describe("epGetProduct", () => {
     expect(result).toBeNull();
   });
 
+  // Studio canvas + the data-query "Execute" panel call the function
+  // outside any withEpSession scope. To keep designer-side testability,
+  // the function falls back to `input.auth` when ALS has no session.
+  // SSR consumers never set `auth` in Studio bindings, so this fallback
+  // doesn't affect the SSR cache key.
+  it("falls back to input.auth when no ALS session is active", async () => {
+    mockGetByContextProduct.mockResolvedValue({
+      data: {
+        data: {
+          id: "canvas-product",
+          type: "product",
+          attributes: { name: "Canvas Product", slug: "canvas-product" },
+          meta: {
+            display_price: {
+              without_tax: { amount: 999, currency: "USD" },
+            },
+            product_types: [],
+          },
+        },
+        included: {},
+      },
+    });
+
+    // No withEpSession wrap — passes auth via input instead.
+    const result = await epGetProduct({
+      id: "canvas-product",
+      auth: TEST_SESSION as any,
+    } as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("canvas-product");
+  });
+
+  it("prefers ALS session over input.auth when both are present", async () => {
+    mockGetByContextProduct.mockResolvedValue({
+      data: {
+        data: {
+          id: "test-product-id",
+          type: "product",
+          attributes: { name: "From ALS", slug: "p" },
+          meta: {
+            display_price: { without_tax: { amount: 1, currency: "USD" } },
+            product_types: [],
+          },
+        },
+        included: {},
+      },
+    });
+
+    // Both ALS and input.auth set — ALS wins (so cache-key parity holds in SSR).
+    const result = await withEpSession(TEST_SESSION, () =>
+      epGetProduct({
+        id: "test-product-id",
+        auth: { ...TEST_SESSION, accessToken: "FROM_INPUT" } as any,
+      } as any)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe("From ALS");
+  });
+
   it("fetches parent and attaches __initialVariantId when id points at a child variant", async () => {
     const childResponse = {
       data: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProduct.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProduct.test.ts
@@ -20,6 +20,15 @@ jest.mock("@epcc-sdk/sdks-shopper", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { epGetProduct } = require("../getProduct");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withEpSession } = require("../session-context");
+
+const TEST_SESSION = {
+  accessToken: "token-abc",
+  host: "https://api.test.elasticpath.com",
+  clientId: "client-xyz",
+  serverCartMode: false,
+};
 
 beforeEach(() => {
   mockGetByContextProduct.mockReset();
@@ -54,14 +63,9 @@ describe("epGetProduct", () => {
       },
     });
 
-    const result = await epGetProduct({
-      id: "test-product-id",
-      auth: {
-        accessToken: "token-abc",
-        host: "https://api.test.elasticpath.com",
-        clientId: "client-xyz",
-      },
-    });
+    const result = await withEpSession(TEST_SESSION, () =>
+      epGetProduct({ id: "test-product-id" })
+    );
 
     expect(result).not.toBeNull();
     expect(result?.id).toBe("test-product-id");
@@ -74,44 +78,34 @@ describe("epGetProduct", () => {
     );
   });
 
-  // When the caller's auth is undefined (typical in Studio canvas, where
-  // $ctx.ep isn't populated by buildEpCtx), epGetProduct must fail-soft
-  // and return null — NOT throw. The failure mode before this guard was
-  // buildClient crashing on `auth.host` reading undefined, which blew up
-  // the designer's query preview panel.
-  it("returns null when auth is missing without calling EP", async () => {
-    const result = await epGetProduct({
-      id: "test-product-id",
-      auth: undefined as any,
-    });
+  // When called outside any withEpSession scope (typical in Studio canvas,
+  // where the loader runs in the browser without ALS), epGetProduct must
+  // fail-soft and return null — NOT throw. Designers see an empty preview
+  // instead of a crashed query panel.
+  it("returns null when called outside withEpSession", async () => {
+    const result = await epGetProduct({ id: "test-product-id" });
 
     expect(result).toBeNull();
     expect(mockGetByContextProduct).not.toHaveBeenCalled();
   });
 
-  // Same contract for a half-populated auth object — if either host,
-  // clientId, or accessToken is missing, the SDK call would either
-  // crash or send an unauthenticated request. Return null upstream so
-  // the emptyContent slot renders instead.
-  it("returns null when auth is missing required fields", async () => {
-    const result = await epGetProduct({
-      id: "test-product-id",
-      auth: { host: "", clientId: "x", accessToken: "y" } as any,
-    });
+  // Same contract when the ALS session is half-populated — host,
+  // clientId, or accessToken missing. Return null upstream so the
+  // emptyContent slot renders instead of an unauthenticated SDK call.
+  it("returns null when ALS session is missing required fields", async () => {
+    const result = await withEpSession(
+      { host: "", clientId: "x", accessToken: "y" } as any,
+      () => epGetProduct({ id: "test-product-id" })
+    );
 
     expect(result).toBeNull();
     expect(mockGetByContextProduct).not.toHaveBeenCalled();
   });
 
   it("returns null when id is empty without calling EP", async () => {
-    const result = await epGetProduct({
-      id: "",
-      auth: {
-        accessToken: "token-abc",
-        host: "https://api.test.elasticpath.com",
-        clientId: "client-xyz",
-      },
-    });
+    const result = await withEpSession(TEST_SESSION, () =>
+      epGetProduct({ id: "" })
+    );
 
     expect(result).toBeNull();
     expect(mockGetByContextProduct).not.toHaveBeenCalled();
@@ -120,14 +114,9 @@ describe("epGetProduct", () => {
   it("returns null when EP responds with no product data", async () => {
     mockGetByContextProduct.mockResolvedValue({ data: null });
 
-    const result = await epGetProduct({
-      id: "missing-id",
-      auth: {
-        accessToken: "token-abc",
-        host: "https://api.test.elasticpath.com",
-        clientId: "client-xyz",
-      },
-    });
+    const result = await withEpSession(TEST_SESSION, () =>
+      epGetProduct({ id: "missing-id" })
+    );
 
     expect(result).toBeNull();
   });
@@ -169,14 +158,9 @@ describe("epGetProduct", () => {
       .mockResolvedValueOnce(childResponse)
       .mockResolvedValueOnce(parentResponse);
 
-    const result = await epGetProduct({
-      id: "child-id",
-      auth: {
-        accessToken: "token-abc",
-        host: "https://api.test.elasticpath.com",
-        clientId: "client-xyz",
-      },
-    });
+    const result = await withEpSession(TEST_SESSION, () =>
+      epGetProduct({ id: "child-id" })
+    );
 
     expect(result).not.toBeNull();
     expect(result?.id).toBe("parent-id");

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProductList.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getProductList.test.ts
@@ -12,6 +12,15 @@ jest.mock("@epcc-sdk/sdks-shopper", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { epGetProductList } = require("../getProductList");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withEpSession } = require("../session-context");
+
+const SESSION = {
+  accessToken: "tok",
+  host: "https://api.ep.com",
+  clientId: "cid",
+  serverCartMode: false,
+};
 
 beforeEach(() => {
   mockGetByContextAllProducts.mockReset();
@@ -38,14 +47,9 @@ describe("epGetProductList", () => {
       },
     });
 
-    const result = await epGetProductList({
-      limit: 10,
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const result = await withEpSession(SESSION, () =>
+      epGetProductList({ limit: 10 })
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0].id).toBe("p1");
@@ -62,13 +66,7 @@ describe("epGetProductList", () => {
       data: { data: [], included: {} },
     });
 
-    const result = await epGetProductList({
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const result = await withEpSession(SESSION, () => epGetProductList());
 
     expect(result).toEqual([]);
   });
@@ -76,14 +74,15 @@ describe("epGetProductList", () => {
   it("returns empty array on error (graceful degradation)", async () => {
     mockGetByContextAllProducts.mockRejectedValue(new Error("EP down"));
 
-    const result = await epGetProductList({
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const result = await withEpSession(SESSION, () => epGetProductList());
 
     expect(result).toEqual([]);
+  });
+
+  it("returns empty array when called outside withEpSession", async () => {
+    const result = await epGetProductList();
+
+    expect(result).toEqual([]);
+    expect(mockGetByContextAllProducts).not.toHaveBeenCalled();
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getRelatedProducts.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getRelatedProducts.test.ts
@@ -12,6 +12,15 @@ jest.mock("@epcc-sdk/sdks-shopper", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { epGetRelatedProducts } = require("../getRelatedProducts");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withEpSession } = require("../session-context");
+
+const SESSION = {
+  accessToken: "tok",
+  host: "https://api.ep.com",
+  clientId: "cid",
+  serverCartMode: false,
+};
 
 beforeEach(() => {
   mockGetByContextAllRelatedProducts.mockReset();
@@ -38,16 +47,13 @@ describe("epGetRelatedProducts", () => {
       },
     });
 
-    const result = await epGetRelatedProducts({
-      productId: "base-id",
-      relationshipSlug: "CRP_related_products",
-      limit: 4,
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const result = await withEpSession(SESSION, () =>
+      epGetRelatedProducts({
+        productId: "base-id",
+        relationshipSlug: "CRP_related_products",
+        limit: 4,
+      })
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0].id).toBe("r1");
@@ -62,27 +68,30 @@ describe("epGetRelatedProducts", () => {
   });
 
   it("returns empty array when productId or relationshipSlug is missing", async () => {
-    const noProductId = await epGetRelatedProducts({
-      productId: "",
-      relationshipSlug: "CRP_related_products",
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const noProductId = await withEpSession(SESSION, () =>
+      epGetRelatedProducts({
+        productId: "",
+        relationshipSlug: "CRP_related_products",
+      })
+    );
     expect(noProductId).toEqual([]);
 
-    const noSlug = await epGetRelatedProducts({
-      productId: "base-id",
-      relationshipSlug: "",
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const noSlug = await withEpSession(SESSION, () =>
+      epGetRelatedProducts({
+        productId: "base-id",
+        relationshipSlug: "",
+      })
+    );
     expect(noSlug).toEqual([]);
+    expect(mockGetByContextAllRelatedProducts).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when called outside withEpSession", async () => {
+    const result = await epGetRelatedProducts({
+      productId: "base-id",
+      relationshipSlug: "CRP_related_products",
+    });
+    expect(result).toEqual([]);
     expect(mockGetByContextAllRelatedProducts).not.toHaveBeenCalled();
   });
 
@@ -91,15 +100,12 @@ describe("epGetRelatedProducts", () => {
       new Error("not found")
     );
 
-    const result = await epGetRelatedProducts({
-      productId: "base-id",
-      relationshipSlug: "CRP_related_products",
-      auth: {
-        accessToken: "tok",
-        host: "https://api.ep.com",
-        clientId: "cid",
-      },
-    });
+    const result = await withEpSession(SESSION, () =>
+      epGetRelatedProducts({
+        productId: "base-id",
+        relationshipSlug: "CRP_related_products",
+      })
+    );
     expect(result).toEqual([]);
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/register-custom-functions.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/register-custom-functions.test.ts
@@ -56,4 +56,19 @@ describe("registerEpCustomFunctions", () => {
       "@elasticpath/plasmic-ep-commerce-elastic-path/server"
     );
   });
+
+  // After PRD #272 — auth flows via AsyncLocalStorage (`withEpSession`),
+  // not through Server Query execParams. Param descriptions must NOT
+  // mention `auth` or `$ctx.ep`, otherwise designers will continue to
+  // hand-bind it in Studio and the `<DataProvider name="ep">` wrap will
+  // silently come back as a workaround. Pin this contract.
+  it("does not advertise an `auth` parameter on any registered function", () => {
+    const registerFunction = jest.fn();
+    registerEpCustomFunctions({ registerFunction } as any);
+
+    for (const [, meta] of registerFunction.mock.calls) {
+      const description = meta.params?.[0]?.description ?? "";
+      expect(description).not.toMatch(/\bauth\b/);
+    }
+  });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/session-context.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/session-context.test.ts
@@ -1,0 +1,101 @@
+import {
+  withEpSession,
+  getCurrentEpSession,
+} from "../session-context";
+
+// The module is reachable from the CLIENT bundle through
+// plasmic-register.ts → registerEpCustomFunctions → epGetProduct →
+// session-context. Browsers have no `async_hooks`, so the module must
+// load cleanly when the import throws. Without this guard, Next.js dev
+// mode crashes with "Module not found: Can't resolve 'async_hooks'"
+// before any user code runs.
+describe("browser-bundle safety — module loads without async_hooks", () => {
+  it("does not crash when async_hooks is unresolvable; getCurrentEpSession returns undefined", () => {
+    jest.isolateModules(() => {
+      jest.doMock("async_hooks", () => {
+        throw new Error(
+          "Module not found: Can't resolve 'async_hooks' (simulated)"
+        );
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require("../session-context");
+
+      // Module must load without throwing.
+      expect(typeof mod.withEpSession).toBe("function");
+      expect(typeof mod.getCurrentEpSession).toBe("function");
+
+      // With no ALS available, getCurrentEpSession returns undefined and
+      // withEpSession still invokes the callback (so consumer code keeps
+      // running; ep.* functions just fail-soft because they read undefined).
+      expect(mod.getCurrentEpSession()).toBeUndefined();
+      const result = mod.withEpSession(
+        { accessToken: "tok", host: "h", clientId: "c", serverCartMode: false },
+        () => "ran"
+      );
+      expect(result).toBe("ran");
+    });
+  });
+});
+
+describe("withEpSession / getCurrentEpSession", () => {
+  it("exposes the session to code running inside the callback", async () => {
+    const session = {
+      accessToken: "tok-1",
+      host: "https://api.ep.com",
+      clientId: "cid-1",
+      serverCartMode: false,
+    };
+
+    const observed = await withEpSession(session, async () => {
+      return getCurrentEpSession();
+    });
+
+    expect(observed).toEqual(session);
+  });
+
+  it("returns undefined outside any withEpSession scope", () => {
+    expect(getCurrentEpSession()).toBeUndefined();
+  });
+
+  it("isolates concurrent withEpSession callbacks — no cross-request leakage", async () => {
+    // The critical property of AsyncLocalStorage. If we accidentally fall back
+    // to a module-level variable, two parallel "requests" would observe each
+    // other's session.
+    const sessionA: any = {
+      accessToken: "tok-A",
+      host: "https://api.ep.com",
+      clientId: "cid-A",
+      serverCartMode: false,
+    };
+    const sessionB: any = {
+      accessToken: "tok-B",
+      host: "https://api.ep.com",
+      clientId: "cid-B",
+      serverCartMode: false,
+    };
+
+    // Force interleaving: each callback yields to the event loop multiple
+    // times before reading the session, so the two callbacks ping-pong.
+    const observe = async (label: string) => {
+      const samples: { label: string; observed: string | undefined }[] = [];
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setImmediate(r));
+        samples.push({
+          label,
+          observed: getCurrentEpSession()?.accessToken,
+        });
+      }
+      return samples;
+    };
+
+    const [samplesA, samplesB] = await Promise.all([
+      withEpSession(sessionA, () => observe("A")),
+      withEpSession(sessionB, () => observe("B")),
+    ]);
+
+    // Every sample inside the A callback must see token A; same for B.
+    expect(samplesA.every((s) => s.observed === "tok-A")).toBe(true);
+    expect(samplesB.every((s) => s.observed === "tok-B")).toBe(true);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
@@ -1,17 +1,16 @@
 /**
- * Composes the `$ctx.ep` payload that flows into Plasmic Studio Server
- * Queries (per PRD #262). Takes the Plasmic loader's prefetchedData (source
+ * Composes the EP session payload that drives every `ep.*` server function
+ * (per PRD #262 / #272). Takes the Plasmic loader's prefetchedData (source
  * of connection/config — clientId, host) and the resolved EP session
- * (source of per-shopper auth — accessToken, cartId, accountId), and
- * returns the shape that every `ep.*` server function accepts as its
- * `auth` parameter.
+ * (source of per-shopper auth — accessToken, cartId, accountId).
  *
- * Consumers call this in their RSC catchall page:
- *     const $ctx = {
- *       pageRoute, pagePath, params, query,
- *       ep: buildEpCtx(prefetchedData, { session }),
- *     };
- *     await PLASMIC.unstable__getServerQueriesData(prefetchedData, $ctx);
+ * Consumers call this in their RSC catchall page, then run Server Queries
+ * inside a `withEpSession` scope so each function reads the session via
+ * AsyncLocalStorage instead of a per-call `auth` argument:
+ *     const epCtx = buildEpCtx(prefetchedData, { session });
+ *     const prefetchedQueryData = await withEpSession(epCtx, () =>
+ *       PLASMIC.unstable__getServerQueriesData(prefetchedData, queryCtx)
+ *     );
  */
 
 import { extractEpProviderConfig } from "../auth/extract-ep-provider-config";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/ep-client.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/ep-client.ts
@@ -6,8 +6,8 @@ import type { EpServerAuth } from "./types";
  *
  * Returns a configured EPCC shopper client, or `null` when auth is
  * incomplete. Callers fail-soft (typically `return null`) so Studio
- * canvas — where `$ctx.ep` isn't populated by `buildEpCtx` — sees an
- * empty response instead of blowing up on `undefined.host`.
+ * canvas — where no `withEpSession` scope is active — sees an empty
+ * response instead of blowing up on `undefined.host`.
  */
 export function isUsableAuth(auth: unknown): auth is EpServerAuth {
   if (!auth || typeof auth !== "object") return false;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
@@ -2,8 +2,12 @@ import { getACart } from "@epcc-sdk/sdks-shopper";
 import { normalizeCart } from "../utils/normalize";
 import { buildEpClient, isUsableAuth } from "./ep-client";
 import { getCurrentEpSession } from "./session-context";
+import type { EpServerAuth } from "./types";
 
-export type EpGetCartInput = Record<string, never>;
+export interface EpGetCartInput {
+  /** Studio canvas / Execute-panel fallback only — see EpGetProductInput. */
+  auth?: EpServerAuth;
+}
 
 /**
  * Fetches a cart by ID, server-side. Returns null when:
@@ -14,9 +18,9 @@ export type EpGetCartInput = Record<string, never>;
  *  - the cart is missing or EP returns an error (stale cookie, deleted cart).
  */
 export async function epGetCart(
-  _input?: EpGetCartInput
+  input?: EpGetCartInput
 ): Promise<ReturnType<typeof normalizeCart> | null> {
-  const auth = getCurrentEpSession();
+  const auth = getCurrentEpSession() ?? input?.auth;
   if (!isUsableAuth(auth)) return null;
   if (!auth.cartId) return null;
   const client = buildEpClient(auth);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
@@ -1,23 +1,22 @@
 import { getACart } from "@epcc-sdk/sdks-shopper";
 import { normalizeCart } from "../utils/normalize";
-import type { EpServerAuth } from "./types";
 import { buildEpClient, isUsableAuth } from "./ep-client";
+import { getCurrentEpSession } from "./session-context";
 
-export interface EpGetCartInput {
-  auth: EpServerAuth;
-}
+export type EpGetCartInput = Record<string, never>;
 
 /**
  * Fetches a cart by ID, server-side. Returns null when:
- *  - auth is missing or incomplete (Studio canvas, unauthenticated call);
- *  - no cartId is present on the auth payload (anonymous visitor — server
- *    reads must not create carts; creation is a mutation and belongs on
+ *  - no ALS session is active (Studio canvas, unauthenticated call);
+ *  - the session lacks a cartId (anonymous visitor — server reads must
+ *    not create carts; creation is a mutation and belongs on
  *    `POST /api/ep/cart/items`);
  *  - the cart is missing or EP returns an error (stale cookie, deleted cart).
  */
-export async function epGetCart({
-  auth,
-}: EpGetCartInput): Promise<ReturnType<typeof normalizeCart> | null> {
+export async function epGetCart(
+  _input?: EpGetCartInput
+): Promise<ReturnType<typeof normalizeCart> | null> {
+  const auth = getCurrentEpSession();
   if (!isUsableAuth(auth)) return null;
   if (!auth.cartId) return null;
   const client = buildEpClient(auth);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
@@ -4,12 +4,11 @@ import {
 } from "@epcc-sdk/sdks-shopper";
 import { normalizeProduct } from "../utils/normalize";
 import type { Product } from "../types/product";
-import type { EpServerAuth } from "./types";
 import { buildEpClient, isUsableAuth } from "./ep-client";
+import { getCurrentEpSession } from "./session-context";
 
 export interface EpGetProductInput {
   id: string;
-  auth: EpServerAuth;
 }
 
 interface ProductWithInitialVariant extends Product {
@@ -18,9 +17,9 @@ interface ProductWithInitialVariant extends Product {
 
 export async function epGetProduct({
   id,
-  auth,
 }: EpGetProductInput): Promise<Product | null> {
   if (!id) return null;
+  const auth = getCurrentEpSession();
   if (!isUsableAuth(auth)) return null;
 
   const client = buildEpClient(auth);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
@@ -6,9 +6,18 @@ import { normalizeProduct } from "../utils/normalize";
 import type { Product } from "../types/product";
 import { buildEpClient, isUsableAuth } from "./ep-client";
 import { getCurrentEpSession } from "./session-context";
+import type { EpServerAuth } from "./types";
 
 export interface EpGetProductInput {
   id: string;
+  /**
+   * Optional auth fallback for Studio canvas + the data-query
+   * "Execute" panel, where no `withEpSession` scope is established.
+   * SSR consumers should NOT set this in Studio bindings — `withEpSession`
+   * in the catchall page handles it via AsyncLocalStorage and keeps the
+   * SWR cache key minimal.
+   */
+  auth?: EpServerAuth;
 }
 
 interface ProductWithInitialVariant extends Product {
@@ -17,9 +26,10 @@ interface ProductWithInitialVariant extends Product {
 
 export async function epGetProduct({
   id,
+  auth: inputAuth,
 }: EpGetProductInput): Promise<Product | null> {
   if (!id) return null;
-  const auth = getCurrentEpSession();
+  const auth = getCurrentEpSession() ?? inputAuth;
   if (!isUsableAuth(auth)) return null;
 
   const client = buildEpClient(auth);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProductList.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProductList.ts
@@ -4,6 +4,7 @@ import { getSortVariables } from "../utils";
 import type { Product } from "../types/product";
 import { buildEpClient, isUsableAuth } from "./ep-client";
 import { getCurrentEpSession } from "./session-context";
+import type { EpServerAuth } from "./types";
 
 export interface EpGetProductListInput {
   /** Page size. Defaults to 25 (EP default). */
@@ -14,6 +15,8 @@ export interface EpGetProductListInput {
   categoryId?: string | number;
   /** Sort key understood by the shared `getSortVariables` helper. */
   sort?: string;
+  /** Studio canvas / Execute-panel fallback only — see EpGetProductInput. */
+  auth?: EpServerAuth;
 }
 
 export async function epGetProductList({
@@ -21,8 +24,9 @@ export async function epGetProductList({
   search,
   categoryId,
   sort,
+  auth: inputAuth,
 }: EpGetProductListInput = {}): Promise<Product[]> {
-  const auth = getCurrentEpSession();
+  const auth = getCurrentEpSession() ?? inputAuth;
   if (!isUsableAuth(auth)) return [];
   const client = buildEpClient(auth);
   const query: Record<string, unknown> = {};

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProductList.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProductList.ts
@@ -2,8 +2,8 @@ import { getByContextAllProducts } from "@epcc-sdk/sdks-shopper";
 import { normalizeProductFromList } from "../utils/normalize";
 import { getSortVariables } from "../utils";
 import type { Product } from "../types/product";
-import type { EpServerAuth } from "./types";
 import { buildEpClient, isUsableAuth } from "./ep-client";
+import { getCurrentEpSession } from "./session-context";
 
 export interface EpGetProductListInput {
   /** Page size. Defaults to 25 (EP default). */
@@ -14,7 +14,6 @@ export interface EpGetProductListInput {
   categoryId?: string | number;
   /** Sort key understood by the shared `getSortVariables` helper. */
   sort?: string;
-  auth: EpServerAuth;
 }
 
 export async function epGetProductList({
@@ -22,8 +21,8 @@ export async function epGetProductList({
   search,
   categoryId,
   sort,
-  auth,
-}: EpGetProductListInput): Promise<Product[]> {
+}: EpGetProductListInput = {}): Promise<Product[]> {
+  const auth = getCurrentEpSession();
   if (!isUsableAuth(auth)) return [];
   const client = buildEpClient(auth);
   const query: Record<string, unknown> = {};

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getRelatedProducts.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getRelatedProducts.ts
@@ -3,6 +3,7 @@ import { normalizeProductFromList } from "../utils/normalize";
 import type { Product } from "../types/product";
 import { buildEpClient, isUsableAuth } from "./ep-client";
 import { getCurrentEpSession } from "./session-context";
+import type { EpServerAuth } from "./types";
 
 export interface EpGetRelatedProductsInput {
   productId: string;
@@ -12,15 +13,18 @@ export interface EpGetRelatedProductsInput {
    */
   relationshipSlug: string;
   limit?: number;
+  /** Studio canvas / Execute-panel fallback only — see EpGetProductInput. */
+  auth?: EpServerAuth;
 }
 
 export async function epGetRelatedProducts({
   productId,
   relationshipSlug,
   limit,
+  auth: inputAuth,
 }: EpGetRelatedProductsInput): Promise<Product[]> {
   if (!productId || !relationshipSlug) return [];
-  const auth = getCurrentEpSession();
+  const auth = getCurrentEpSession() ?? inputAuth;
   if (!isUsableAuth(auth)) return [];
   const client = buildEpClient(auth);
   const query: Record<string, unknown> = {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getRelatedProducts.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getRelatedProducts.ts
@@ -1,8 +1,8 @@
 import { getByContextAllRelatedProducts } from "@epcc-sdk/sdks-shopper";
 import { normalizeProductFromList } from "../utils/normalize";
 import type { Product } from "../types/product";
-import type { EpServerAuth } from "./types";
 import { buildEpClient, isUsableAuth } from "./ep-client";
+import { getCurrentEpSession } from "./session-context";
 
 export interface EpGetRelatedProductsInput {
   productId: string;
@@ -12,16 +12,15 @@ export interface EpGetRelatedProductsInput {
    */
   relationshipSlug: string;
   limit?: number;
-  auth: EpServerAuth;
 }
 
 export async function epGetRelatedProducts({
   productId,
   relationshipSlug,
   limit,
-  auth,
 }: EpGetRelatedProductsInput): Promise<Product[]> {
   if (!productId || !relationshipSlug) return [];
+  const auth = getCurrentEpSession();
   if (!isUsableAuth(auth)) return [];
   const client = buildEpClient(auth);
   const query: Record<string, unknown> = {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/index.ts
@@ -12,4 +12,6 @@ export type {
   BuildEpCtxSessionInput,
   EpCtx,
 } from "./build-ep-ctx";
+export { withEpSession, getCurrentEpSession } from "./session-context";
+export type { EpSessionContext } from "./session-context";
 export type { EpServerAuth } from "./types";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
@@ -38,16 +38,14 @@ const EP_FUNCTIONS: EpFunctionSpec[] = [
     name: "getProduct",
     description:
       "Fetch a single EP product by ID, server-side. Returns null when the product is missing.",
-    paramShape:
-      "{ id: string; auth: { accessToken, host, clientId, cartId?, accountId?, locale? } }",
+    paramShape: "{ id: string }",
   },
   {
     fn: epGetCart,
     name: "getCart",
     description:
       "Fetch the current cart, server-side. Returns null when there is no cart or the cart is unreachable.",
-    paramShape:
-      "{ auth: { accessToken, host, clientId, cartId, accountId?, locale? } }",
+    paramShape: "{}",
   },
   {
     fn: epGetProductList,
@@ -55,7 +53,7 @@ const EP_FUNCTIONS: EpFunctionSpec[] = [
     description:
       "Fetch a list of products with optional filter/sort/limit, server-side. Returns an empty array on error.",
     paramShape:
-      "{ limit?: number; search?: string; categoryId?: string; sort?: string; auth: {...} }",
+      "{ limit?: number; search?: string; categoryId?: string; sort?: string }",
   },
   {
     fn: epGetRelatedProducts,
@@ -63,7 +61,7 @@ const EP_FUNCTIONS: EpFunctionSpec[] = [
     description:
       "Fetch products related to the given product by EP custom-relationship slug. Returns an empty array on error.",
     paramShape:
-      "{ productId: string; relationshipSlug: string; limit?: number; auth: {...} }",
+      "{ productId: string; relationshipSlug: string; limit?: number }",
   },
 ];
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/session-context.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/session-context.ts
@@ -1,0 +1,51 @@
+import type { EpCtx } from "./build-ep-ctx";
+
+export type EpSessionContext = EpCtx;
+
+interface SessionStorage {
+  run<T>(session: EpSessionContext, callback: () => T): T;
+  getStore(): EpSessionContext | undefined;
+}
+
+// `async_hooks` is a Node-only built-in. This module is reachable from
+// the CLIENT bundle (plasmic-register.ts → registerEpCustomFunctions →
+// epGetProduct → here), so we must load cleanly when the module is
+// unresolvable. The browser fallback is a no-op storage: callbacks still
+// run, but every read returns `undefined`. That matches the contract
+// every `ep.*` function already enforces — they fail-soft to `null` /
+// `[]` outside an active session.
+function makeStorage(): SessionStorage {
+  if (typeof window === "undefined") {
+    try {
+      // Hide the require from bundlers via eval — webpack would otherwise
+      // try to resolve `async_hooks` for the client bundle and fail.
+      // eslint-disable-next-line no-eval
+      const req = eval("require") as NodeRequire;
+      const { AsyncLocalStorage } = req("async_hooks");
+      return new AsyncLocalStorage<EpSessionContext>();
+    } catch {
+      // fall through to no-op
+    }
+  }
+  return {
+    run<T>(_session: EpSessionContext, callback: () => T): T {
+      return callback();
+    },
+    getStore(): EpSessionContext | undefined {
+      return undefined;
+    },
+  };
+}
+
+const storage = makeStorage();
+
+export function withEpSession<T>(
+  session: EpSessionContext,
+  callback: () => Promise<T> | T
+): Promise<T> | T {
+  return storage.run(session, callback);
+}
+
+export function getCurrentEpSession(): EpSessionContext | undefined {
+  return storage.getStore();
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/types.ts
@@ -1,9 +1,9 @@
 /**
- * Resolved EP connection + auth context passed into every `ep.*` server
- * function. Built by the consumer's RSC catchall page from
- * `extractEpProviderConfig(prefetchedData)` (connection) and
- * `epAuth.api.getSession()` (per-shopper auth), then injected into
- * `$ctx.ep` for Studio Server Queries to reference.
+ * Resolved EP connection + auth context. Built by the consumer's RSC
+ * catchall page from `extractEpProviderConfig(prefetchedData)` (connection)
+ * and `epAuth.api.getSession()` (per-shopper auth), then handed to
+ * `withEpSession()` so every `ep.*` server function can read it via
+ * AsyncLocalStorage (per PRD #272).
  *
  * Token is input-only to server functions — never returned, never
  * serialised into the prefetched query cache (per PRD #262).

--- a/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
@@ -57,7 +57,7 @@ export type {
   EpProviderBundleConfig,
 } from "./auth";
 
-// Server-side custom functions for Studio Server Queries (PRD #262)
+// Server-side custom functions for Studio Server Queries (PRD #262 / #272)
 export {
   epGetProduct,
   epGetCart,
@@ -65,6 +65,8 @@ export {
   epGetRelatedProducts,
   registerEpCustomFunctions,
   buildEpCtx,
+  withEpSession,
+  getCurrentEpSession,
 } from "./ep-server-functions";
 export type {
   EpGetProductInput,
@@ -73,5 +75,6 @@ export type {
   EpGetRelatedProductsInput,
   BuildEpCtxSessionInput,
   EpCtx,
+  EpSessionContext,
   EpServerAuth,
 } from "./ep-server-functions";


### PR DESCRIPTION
Closes #272.

## Summary

Replaces per-call `auth: $ctx.ep` argument threading with `AsyncLocalStorage`. Each `ep.*` server function now reads the session via `getCurrentEpSession()` inside a `withEpSession(epCtx, …)` scope established once per request in the catchall page. Studio bindings collapse from `{ id, auth: $ctx.ep }` to `{ id }`; the `<DataProvider name="ep">` wrap is dropped from the catchall.

Three commits on the branch:

1. **`1ce4ef1d4`** — main implementation: deep `session-context` module with `withEpSession` / `getCurrentEpSession`, ALS migration of all four `ep.*` functions, paramShape updates, example-app catchall wired, README + COMPONENTS docs updated.
2. **`8c1c5015c`** — `withRegistryCapture` drops its loader-forward calls. With `@plasmicapp/host` no longer in `serverExternalPackages` (per #270), the loader's `registerFunction` carries the package's `"use client"` marker; forwarding from a server route trips Next's RSC boundary protection. The forwards were redundant — the host()-population path is what the API route actually needs.
3. **`5e8170466`** — optional `input.auth` fallback on every `ep.*` function for Studio canvas + Execute panel testability. ALS wins when both are present, so SSR cache keys stay clean.

## Why ALS, not execParams

PR description body of #272 covers the full motivation. TL;DR:

- Removes the SWR cache-key dependency on `$ctx.ep`, which previously required a `<DataProvider name="ep">` wrap on the client AND a matching `ep:` field in the server-side queryCtx. Forgetting either side caused silent server↔client cache misses and unauthenticated client refetches.
- The session never reaches the prefetched query cache — it lives in the per-request ALS scope, established once.
- Studio bindings become `{ id }` instead of `{ id, auth: $ctx.ep }`. Cleaner DX, no auth-leak risk.

## Verification

- 34 tests in `ep-server-functions/__tests__/`, including:
  - Tracer for `withEpSession` / `getCurrentEpSession`
  - Concurrent isolation across parallel `withEpSession` callbacks (verified to fail on a non-ALS impl — actual regression net)
  - Browser-bundle-safe `async_hooks` loading (jest.doMock simulates webpack failure)
  - ALS-context-present, ALS-context-absent, half-populated session paths for each `ep.*` function
  - paramShape regression net (no `auth` in any registered description)
  - `input.auth` fallback when ALS empty
  - ALS precedence when both present
- Live URL `localhost:3456/product/<uuid>` renders real product data via SSR (verified via Playwright + curl). Visible HTML contains the product name and price; no `useContext` null errors; no SSR fallback to client rendering.
- Studio canvas Execute panel: with the optional `input.auth` populated, returns real data. Without it (current behaviour), returns null — which is the same null-out behaviour pre-#272 had when `$ctx.ep` was undefined in canvas.

## Follow-ups (filed separately)

- **#274** — Auth-aware `/plasmic-host` to inject server-derived EP session into Studio canvas, so designers can render real data with just a slug param. This composes with #272; not a replacement.

## Test plan

- [ ] CI green
- [ ] Reviewer hits `/product/<uuid>` on the example app and confirms real product renders SSR-side
- [ ] Reviewer confirms `Studio binding for ep.getProduct` is `{ id }` (no `auth`) on the EP test project
- [ ] Reviewer reads the new `withRegistryCapture` rationale and confirms it tracks with #270

