### PR TITLE
chore(plasmic-mcp): bump to v0.1.5

### DIFF
--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Visual Builder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
   "author": {
     "name": "Elastic Path"

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `@elasticpath/plasmic-mcp` to `0.1.5` in `package.json` and `manifest.json`
- Matches what was just published to npm — the published `0.1.5` includes the validator/ingestion/update-query fixes from #267 that landed since `0.1.4`

## Test plan
- [x] `npm view @elasticpath/plasmic-mcp version` returns `0.1.5`
- [x] `npx @elasticpath/plasmic-mcp` resolves the new bundle