### PR TITLE
feat(rate-limit): add workspace-keyed preview limiter (10 RPS per workspace)

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -36,7 +36,7 @@ import {
   trackPostgresPool,
 } from "@/wab/server/promstats";
 import { createRateLimiter } from "@/wab/server/rate-limit";
-import { createCmsScopeRateLimiter, createGeneralApiRateLimiter, createPreviewRateLimiter, createProjectScopeRateLimiter, createWriteRateLimiter } from "@/wab/server/ep-rate-limit";
+import { createCmsScopeRateLimiter, createGeneralApiRateLimiter, createPreviewRateLimiter, createProjectScopePreviewRateLimiter, createProjectScopeRateLimiter, createWriteRateLimiter } from "@/wab/server/ep-rate-limit";
 import { cmCors, cmCorsPreflight, isCmOriginAllowed } from "@/wab/server/cm-cors";
 import * as adminRoutes from "@/wab/server/routes/admin";
 import * as projectProvisioningRoutes from "@/wab/server/routes/project-provisioning";
@@ -1087,9 +1087,9 @@ export function addCodegenOnlyRoutes(app: express.Application) {
 // Loader routes: Production SDK traffic (high volume)
 export function addLoaderRoutes(app: express.Application) {
   // Scope limiter covers all loader routes (published, versioned, preview).
-  // Preview routes additionally stack createPreviewRateLimiter() for a tighter
-  // per-identity budget — session-authenticated preview requests only hit that
-  // limiter; project-token-authenticated requests hit both.
+  // Preview routes additionally stack createProjectScopePreviewRateLimiter()
+  // (tighter workspace-keyed budget for project-token requests) and
+  // createPreviewRateLimiter() (per-identity budget for session/team-token).
   app.use("/api/v1/loader", createProjectScopeRateLimiter());
 
   app.get(
@@ -1127,6 +1127,7 @@ export function addLoaderRoutes(app: express.Application) {
     "/api/v1/loader/code/preview",
     cors(),
     apiAuth,
+    createProjectScopePreviewRateLimiter(),
     createPreviewRateLimiter(),
     withNext(buildLatestLoaderAssets)
   );
@@ -1147,6 +1148,7 @@ export function addLoaderRoutes(app: express.Application) {
     "/api/v1/loader/repr-v2/preview/:projectId",
     cors(),
     apiAuth,
+    createProjectScopePreviewRateLimiter(),
     createPreviewRateLimiter(),
     buildLatestLoaderReprV2
   );
@@ -1166,6 +1168,7 @@ export function addLoaderRoutes(app: express.Application) {
     "/api/v1/loader/repr-v3/preview/:projectId",
     cors(),
     apiAuth,
+    createProjectScopePreviewRateLimiter(),
     createPreviewRateLimiter(),
     withNext(buildLatestLoaderReprV3)
   );
@@ -1191,6 +1194,7 @@ export function addLoaderHtmlRoutes(app: express.Application) {
     "/api/v1/loader/html/preview/:projectId/:component",
     cors(),
     apiAuth,
+    createProjectScopePreviewRateLimiter(),
     createPreviewRateLimiter(),
     buildLatestLoaderHtml
   );

--- a/platform/wab/src/wab/server/ep-rate-limit.ts
+++ b/platform/wab/src/wab/server/ep-rate-limit.ts
@@ -222,13 +222,16 @@ function createIdentityRateLimiter(
   };
 }
 
-// Rate limiter for loader endpoints, keyed by workspace.id or team.id resolved
-// from x-plasmic-api-project-tokens. All workspaces/teams in a multi-project
-// request are incremented independently. Fails open if Redis is unavailable.
-export function createProjectScopeRateLimiter(deps?: RateLimiterDeps): RequestHandler {
+// Shared factory for project-token-keyed limiters (workspace/team scope).
+// Reads the limit from the given env var, falling back to defaultLimit.
+function makeProjectScopeLimiter(
+  envVar: string,
+  defaultLimit: number,
+  deps?: RateLimiterDeps
+): RequestHandler {
   const redis = deps?.redis !== undefined ? deps.redis : getRedisClient();
   const windowSec = deps?.windowSec ?? parseEnvInt(process.env.RATE_LIMIT_WINDOW_SEC, 60);
-  const limit = deps?.limit ?? parseEnvInt(process.env.RATE_LIMIT_PER_SCOPE, 6000);
+  const limit = deps?.limit ?? parseEnvInt(process.env[envVar], defaultLimit);
 
   return async (req: Request, res: Response, next: NextFunction) => {
     if (!redis) {
@@ -254,6 +257,19 @@ export function createProjectScopeRateLimiter(deps?: RateLimiterDeps): RequestHa
     }
     next();
   };
+}
+
+// Rate limiter for loader endpoints, keyed by workspace.id or team.id resolved
+// from x-plasmic-api-project-tokens. All workspaces/teams in a multi-project
+// request are incremented independently. Fails open if Redis is unavailable.
+export function createProjectScopeRateLimiter(deps?: RateLimiterDeps): RequestHandler {
+  return makeProjectScopeLimiter("RATE_LIMIT_PER_SCOPE", 6000, deps);
+}
+
+// Tighter workspace-keyed limiter for preview routes (project token auth).
+// Preview hits DB + codegen on every call — 10 RPS per workspace default.
+export function createProjectScopePreviewRateLimiter(deps?: RateLimiterDeps): RequestHandler {
+  return makeProjectScopeLimiter("RATE_LIMIT_PREVIEW_PER_SCOPE", 600, deps);
 }
 
 // Rate limiter for public CMS endpoints, keyed by workspace.id or team.id


### PR DESCRIPTION
## Summary

- Refactors `createProjectScopeRateLimiter` body into a shared `makeProjectScopeLimiter(envVar, defaultLimit, deps?)` factory
- Adds `createProjectScopePreviewRateLimiter` keyed by workspace/team via `x-plasmic-api-project-tokens`, controlled by `RATE_LIMIT_PREVIEW_PER_SCOPE` (default 600 req/60s = 10 RPS per workspace)
- Stacks the new limiter on all 4 preview routes before the existing `createPreviewRateLimiter`

## Motivation

Preview routes (`/api/v1/loader/*/preview/*`) hit the DB and run codegen on every call — no CDN cache, no queue. The existing workspace limiter (`RATE_LIMIT_PER_SCOPE`, 100 RPS) is too permissive for such an expensive endpoint. `createPreviewRateLimiter` only fires for session/team-token auth, so project-token requests were only protected by the 100 RPS workspace bucket.

## Rate limit table (updated)

| Scope | Env var | Default |
|---|---|---|
| All loader routes per workspace | `RATE_LIMIT_PER_SCOPE` | 6000/60s = 100 RPS |
| Preview per workspace (project token) | `RATE_LIMIT_PREVIEW_PER_SCOPE` | 600/60s = 10 RPS |
| Preview per user (session/team token) | `RATE_LIMIT_PREVIEW_PER_USER` | 300/60s = 5 RPS |
| Write/publish per user | `RATE_LIMIT_WRITE_PER_USER` | 60/60s = 1 RPS |
| General API per user | `RATE_LIMIT_GENERAL_API_PER_USER` | 300/60s = 5 RPS |

## Test plan

- [ ] Set `RATE_LIMIT_PREVIEW_PER_SCOPE=10` and `RATE_LIMIT_WINDOW_SEC=1` on integration WAB
- [ ] Run `performance/rate_limiting` ramp profile — expect 429s as concurrency exceeds 10 RPS
- [ ] Confirm `RateLimit-Limit: 10` and `RateLimit-Remaining` headers appear in responses
- [ ] Confirm baseline profile (5 VUs) passes cleanly with no 429s