### PR TITLE
refactor(rate-limit): unified key resolver — all auth methods share same limit per endpoint

### DIFF
--- a/platform/wab/src/wab/server/ep-rate-limit.spec.ts
+++ b/platform/wab/src/wab/server/ep-rate-limit.spec.ts
@@ -3,6 +3,7 @@ import type { EntityManager } from "typeorm";
 import type Redis from "ioredis";
 import {
   createCmsScopeRateLimiter,
+  createGeneralApiRateLimiter,
   createPreviewRateLimiter,
   createProjectScopeRateLimiter,
   createWriteRateLimiter,
@@ -70,9 +71,13 @@ function createMockRedis(
 }
 
 function createMockEm(
-  rows: { id: string; workspaceId: string | null; teamId: string | null }[] = []
+  rows: { id: string; workspaceId: string | null; teamId: string | null }[] = [],
+  findOneResult: { teamId: string } | null = null
 ): EntityManager {
-  return { query: jest.fn().mockResolvedValue(rows) } as unknown as EntityManager;
+  return {
+    query: jest.fn().mockResolvedValue(rows),
+    findOne: jest.fn().mockResolvedValue(findOneResult),
+  } as unknown as EntityManager;
 }
 
 function makeProjectReq(
@@ -85,12 +90,33 @@ function makeProjectReq(
   } as unknown as Request;
 }
 
+function makeProjectBodyReq(
+  projectIdsAndTokens: { projectId: string; projectApiToken: string }[],
+  em: EntityManager = createMockEm()
+): Request {
+  return {
+    headers: {},
+    body: { projectIdsAndTokens },
+    noTxMgr: em,
+  } as unknown as Request;
+}
+
 function makeCmsReq(
   tokens: string | undefined,
   em: EntityManager = createMockEm()
 ): Request {
   return {
     headers: { "x-plasmic-api-cms-tokens": tokens },
+    noTxMgr: em,
+  } as unknown as Request;
+}
+
+function makeSessionTokenReq(
+  sessionToken: string,
+  em: EntityManager = createMockEm()
+): Request {
+  return {
+    headers: { "x-plasmic-api-session-token": sessionToken },
     noTxMgr: em,
   } as unknown as Request;
 }
@@ -419,12 +445,28 @@ describe("createCmsScopeRateLimiter", () => {
 // Identity request helpers
 // ---------------------------------------------------------------------------
 
-function makeUserReq(userId: string): Request {
-  return { user: { id: userId }, ip: "1.2.3.4" } as unknown as Request;
+function makeUserReq(
+  userId: string,
+  em: EntityManager = createMockEm()
+): Request {
+  return {
+    headers: {},
+    noTxMgr: em,
+    user: { id: userId },
+    ip: "1.2.3.4",
+  } as unknown as Request;
 }
 
-function makeTeamReq(teamId: string): Request {
-  return { apiTeam: { id: teamId }, ip: "1.2.3.4" } as unknown as Request;
+function makeTeamReq(
+  teamId: string,
+  em: EntityManager = createMockEm()
+): Request {
+  return {
+    headers: {},
+    noTxMgr: em,
+    apiTeam: { id: teamId },
+    ip: "1.2.3.4",
+  } as unknown as Request;
 }
 
 // ---------------------------------------------------------------------------
@@ -524,12 +566,12 @@ describe("createPreviewRateLimiter", () => {
     );
   });
 
-  it("falls back to default limit (300) when env var is not a valid number", async () => {
-    const original = process.env.RATE_LIMIT_PREVIEW_PER_USER;
-    process.env.RATE_LIMIT_PREVIEW_PER_USER = "notanumber";
+  it("falls back to default limit (600) when env var is not a valid number", async () => {
+    const original = process.env.RATE_LIMIT_PREVIEW_PER_SCOPE;
+    process.env.RATE_LIMIT_PREVIEW_PER_SCOPE = "notanumber";
     try {
-      // Seed counter at 300 so the next INCR returns 301 — above the default limit.
-      const { redis } = createMockRedis({}, { "rl:user:user1": 300 });
+      // Seed counter at 600 so the next INCR returns 601 — above the default limit.
+      const { redis } = createMockRedis({}, { "rl:user:user1": 600 });
       // Pass redis via deps but not limit — forces env var code path.
       const middleware = createPreviewRateLimiter({ redis });
       const next = jest.fn() as unknown as NextFunction;
@@ -538,11 +580,11 @@ describe("createPreviewRateLimiter", () => {
       await middleware(makeUserReq("user1"), res, next);
 
       // If NaN were used as the limit, count > NaN would be false and we'd pass through.
-      // Getting a 429 proves the default (300) was used instead.
+      // Getting a 429 proves the default (600) was used instead.
       expect(status).toHaveBeenCalledWith(429);
       expect(next).not.toHaveBeenCalled();
     } finally {
-      process.env.RATE_LIMIT_PREVIEW_PER_USER = original;
+      process.env.RATE_LIMIT_PREVIEW_PER_SCOPE = original;
     }
   });
 });
@@ -615,5 +657,190 @@ describe("createWriteRateLimiter", () => {
       "Rate limiter failed open",
       expect.objectContaining({ err: expect.any(Error) })
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-auth tests — every limiter must fire for every auth method
+// ---------------------------------------------------------------------------
+
+describe("unified key resolver — all auth methods", () => {
+  it("createPreviewRateLimiter fires for project token auth (workspace key)", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([{ id: "proj1", workspaceId: "ws1", teamId: null }]);
+    const middleware = createPreviewRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeProjectReq("proj1:token", em), res, next);
+
+    expect(counters["rl:workspace:ws1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("createPreviewRateLimiter fires for CMS token auth (workspace key)", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([{ id: "db1", workspaceId: "ws1", teamId: null }]);
+    const middleware = createPreviewRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeCmsReq("db1:token", em), res, next);
+
+    expect(counters["rl:workspace:ws1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("createProjectScopeRateLimiter fires for team token auth (team key)", async () => {
+    const { redis, counters } = createMockRedis();
+    const middleware = createProjectScopeRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeTeamReq("team1"), res, next);
+
+    expect(counters["rl:team:team1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("createProjectScopeRateLimiter fires for user session auth (user key)", async () => {
+    const { redis, counters } = createMockRedis();
+    const middleware = createProjectScopeRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeUserReq("user1"), res, next);
+
+    expect(counters["rl:user:user1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("createCmsScopeRateLimiter fires for project token auth", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([{ id: "proj1", workspaceId: "ws2", teamId: null }]);
+    const middleware = createCmsScopeRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeProjectReq("proj1:token", em), res, next);
+
+    expect(counters["rl:workspace:ws2"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("createCmsScopeRateLimiter fires for identity auth", async () => {
+    const { redis, counters } = createMockRedis();
+    const middleware = createCmsScopeRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeTeamReq("team1"), res, next);
+
+    expect(counters["rl:team:team1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("project token takes priority over req.user when both present", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([{ id: "proj1", workspaceId: "ws1", teamId: null }]);
+    const middleware = createPreviewRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    const req = {
+      headers: { "x-plasmic-api-project-tokens": "proj1:token" },
+      noTxMgr: em,
+      user: { id: "user1" },
+    } as unknown as Request;
+    await middleware(req, res, next);
+
+    expect(counters["rl:workspace:ws1"]).toBe(1);
+    expect(counters["rl:user:user1"]).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("body projectIdsAndTokens resolves to workspace key (CLI auth path)", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([{ id: "proj1", workspaceId: "ws1", teamId: null }]);
+    const middleware = createGeneralApiRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(
+      makeProjectBodyReq([{ projectId: "proj1", projectApiToken: "tok" }], em),
+      res,
+      next
+    );
+
+    expect(counters["rl:workspace:ws1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("body and header project tokens are merged and deduplicated", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([
+      { id: "proj1", workspaceId: "ws1", teamId: null },
+      { id: "proj2", workspaceId: "ws2", teamId: null },
+    ]);
+    const middleware = createProjectScopeRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    // proj1 in header, proj2 in body
+    const req = {
+      headers: { "x-plasmic-api-project-tokens": "proj1:tok1" },
+      body: { projectIdsAndTokens: [{ projectId: "proj2", projectApiToken: "tok2" }] },
+      noTxMgr: em,
+    } as unknown as Request;
+    await middleware(req, res, next);
+
+    expect(counters["rl:workspace:ws1"]).toBe(1);
+    expect(counters["rl:workspace:ws2"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("session token resolves to rl:team:{id}", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([], { teamId: "team1" });
+    const middleware = createPreviewRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeSessionTokenReq("sess-tok-abc", em), res, next);
+
+    expect(em.findOne).toHaveBeenCalledTimes(1);
+    expect(counters["rl:team:team1"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("session token: calls next() when token not found in DB", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([], null); // findOne returns null
+    const middleware = createPreviewRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    await middleware(makeSessionTokenReq("unknown-tok", em), res, next);
+
+    expect(Object.keys(counters)).toHaveLength(0);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("body sessionToken resolves to rl:team:{id}", async () => {
+    const { redis, counters } = createMockRedis();
+    const em = createMockEm([], { teamId: "team2" });
+    const middleware = createWriteRateLimiter({ redis, limit: 100 });
+    const next = jest.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+
+    const req = {
+      headers: {},
+      body: { sessionToken: "sess-body-tok" },
+      noTxMgr: em,
+    } as unknown as Request;
+    await middleware(req, res, next);
+
+    expect(counters["rl:team:team2"]).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/platform/wab/src/wab/server/ep-rate-limit.ts
+++ b/platform/wab/src/wab/server/ep-rate-limit.ts
@@ -1,7 +1,8 @@
 import type { NextFunction, Request, RequestHandler, Response } from "express";
-import type { EntityManager } from "typeorm";
+import { IsNull, type EntityManager } from "typeorm";
 import Redis from "ioredis";
 import { logger } from "@/wab/server/observability";
+import { TemporaryTeamApiToken } from "@/wab/server/entities/Entities";
 
 function parseEnvInt(value: string | undefined, defaultValue: number): number {
   const parsed = parseInt(value ?? String(defaultValue), 10);
@@ -152,6 +153,68 @@ function resolveCmsScopeKeys(
   return resolveScopeKeys(redis, em, databaseIds, "cache:cms", CMS_SCOPE_QUERY);
 }
 
+// Resolves a team key from a temporary team API token (x-plasmic-api-session-token).
+// No caching — session tokens are low-frequency and have no stable entity ID to
+// use as a cache key without exposing the token value itself.
+async function resolveSessionTokenKey(
+  em: EntityManager,
+  sessionToken: string
+): Promise<string | null> {
+  const tempToken = await em.findOne(TemporaryTeamApiToken, {
+    where: { token: sessionToken, deletedAt: IsNull() },
+  });
+  return tempToken ? `rl:team:${tempToken.teamId}` : null;
+}
+
+// Resolves the rate limit bucket key(s) for a request regardless of auth method.
+// Tries all auth methods in priority order and returns on the first match:
+//   1. x-plasmic-api-project-tokens header + req.body.projectIdsAndTokens
+//      → workspace/team key (DB + Redis cache)
+//   2. x-plasmic-api-cms-tokens → workspace/team key (DB + Redis cache)
+//   3. x-plasmic-api-session-token / req.body.sessionToken
+//      → rl:team:{id} (DB lookup, no cache)
+//   4. req.apiTeam (team API token) → rl:team:{id}
+//   5. req.user (session / PAT)     → rl:user:{id}
+// Returns an empty set when no auth is present — the request is skipped.
+async function resolveRateLimitKeys(redis: Redis, req: Request): Promise<Set<string>> {
+  // Merge header tokens with body tokens (CLI sends projectIdsAndTokens in body)
+  const headerIds = parseTokenIds(
+    req.headers["x-plasmic-api-project-tokens"] as string | undefined
+  );
+  const bodyIds: string[] = (
+    req.body?.projectIdsAndTokens as
+      | { projectId: string }[]
+      | undefined
+  )?.map((t) => t.projectId) ?? [];
+  const projectIds = [...new Set([...headerIds, ...bodyIds])];
+
+  if (projectIds.length > 0) {
+    const keys = await resolveProjectScopeKeys(redis, req.noTxMgr, projectIds);
+    if (keys.size > 0) return keys;
+  }
+
+  const cmsIds = parseTokenIds(
+    req.headers["x-plasmic-api-cms-tokens"] as string | undefined
+  );
+  if (cmsIds.length > 0) {
+    const keys = await resolveCmsScopeKeys(redis, req.noTxMgr, cmsIds);
+    if (keys.size > 0) return keys;
+  }
+
+  const sessionToken =
+    (req.body?.sessionToken as string | undefined) ??
+    (req.headers["x-plasmic-api-session-token"] as string | undefined);
+  if (sessionToken) {
+    const key = await resolveSessionTokenKey(req.noTxMgr, sessionToken);
+    if (key) return new Set([key]);
+  }
+
+  const identityKey = resolveIdentityKey(req);
+  if (identityKey) return new Set([identityKey]);
+
+  return new Set();
+}
+
 // Increments all rate limit keys within their window and enforces the limit.
 // Each key is incremented via a Lua script that also sets the TTL on first use,
 // so INCR and EXPIRE are never split by a connection failure.
@@ -191,9 +254,10 @@ async function enforceRateLimit(
   return false;
 }
 
-// Shared factory for identity-keyed limiters (preview and write tiers).
-// Reads the limit from the given env var, falling back to defaultLimit.
-function createIdentityRateLimiter(
+// Shared factory for all rate limiters. Resolves the bucket key from whatever
+// auth method the request used — project tokens, CMS tokens, team token, or
+// session/PAT — so the same limit applies regardless of how you authenticate.
+function makeRateLimiter(
   envVar: string,
   defaultLimit: number
 ): (deps?: RateLimiterDeps) => RequestHandler {
@@ -207,12 +271,10 @@ function createIdentityRateLimiter(
       if (!redis) {
         return next();
       }
-      const key = resolveIdentityKey(req);
-      if (!key) {
-        return next();
-      }
       try {
-        const blocked = await enforceRateLimit(redis, res, new Set([key]), windowSec, limit);
+        const keys = await resolveRateLimitKeys(redis, req);
+        if (keys.size === 0) return next();
+        const blocked = await enforceRateLimit(redis, res, keys, windowSec, limit);
         if (blocked) return;
       } catch (err) {
         logger().error("Rate limiter failed open", { err });
@@ -222,111 +284,34 @@ function createIdentityRateLimiter(
   };
 }
 
-// Shared factory for project-token-keyed limiters (workspace/team scope).
-// Reads the limit from the given env var, falling back to defaultLimit.
-function makeProjectScopeLimiter(
-  envVar: string,
-  defaultLimit: number,
-  deps?: RateLimiterDeps
-): RequestHandler {
-  const redis = deps?.redis !== undefined ? deps.redis : getRedisClient();
-  const windowSec = deps?.windowSec ?? parseEnvInt(process.env.RATE_LIMIT_WINDOW_SEC, 60);
-  const limit = deps?.limit ?? parseEnvInt(process.env[envVar], defaultLimit);
-
-  return async (req: Request, res: Response, next: NextFunction) => {
-    if (!redis) {
-      return next();
-    }
-
-    const projectIds = parseTokenIds(
-      req.headers["x-plasmic-api-project-tokens"] as string | undefined
-    );
-    if (projectIds.length === 0) {
-      return next();
-    }
-
-    try {
-      const keys = await resolveProjectScopeKeys(redis, req.noTxMgr, projectIds);
-      if (keys.size === 0) {
-        return next();
-      }
-      const blocked = await enforceRateLimit(redis, res, keys, windowSec, limit);
-      if (blocked) return;
-    } catch (err) {
-      logger().error("Rate limiter failed open", { err });
-    }
-    next();
-  };
-}
-
-// Rate limiter for loader endpoints, keyed by workspace.id or team.id resolved
-// from x-plasmic-api-project-tokens. All workspaces/teams in a multi-project
-// request are incremented independently. Fails open if Redis is unavailable.
-export function createProjectScopeRateLimiter(deps?: RateLimiterDeps): RequestHandler {
-  return makeProjectScopeLimiter("RATE_LIMIT_PER_SCOPE", 6000, deps);
-}
-
-// Tighter workspace-keyed limiter for preview routes (project token auth).
-// Preview hits DB + codegen on every call — 10 RPS per workspace default.
-export function createProjectScopePreviewRateLimiter(deps?: RateLimiterDeps): RequestHandler {
-  return makeProjectScopeLimiter("RATE_LIMIT_PREVIEW_PER_SCOPE", 600, deps);
-}
-
-// Rate limiter for public CMS endpoints, keyed by workspace.id or team.id
-// resolved from x-plasmic-api-cms-tokens. Fails open if Redis is unavailable.
-export function createCmsScopeRateLimiter(deps?: RateLimiterDeps): RequestHandler {
-  const redis = deps?.redis !== undefined ? deps.redis : getRedisClient();
-  const windowSec = deps?.windowSec ?? parseEnvInt(process.env.RATE_LIMIT_WINDOW_SEC, 60);
-  const limit = deps?.limit ?? parseEnvInt(process.env.RATE_LIMIT_PER_SCOPE, 6000);
-
-  return async (req: Request, res: Response, next: NextFunction) => {
-    if (!redis) {
-      return next();
-    }
-
-    const databaseIds = parseTokenIds(
-      req.headers["x-plasmic-api-cms-tokens"] as string | undefined
-    );
-    if (databaseIds.length === 0) {
-      return next();
-    }
-
-    try {
-      const keys = await resolveCmsScopeKeys(redis, req.noTxMgr, databaseIds);
-      if (keys.size === 0) {
-        return next();
-      }
-      const blocked = await enforceRateLimit(redis, res, keys, windowSec, limit);
-      if (blocked) return;
-    } catch (err) {
-      logger().error("Rate limiter failed open", { err });
-    }
-    next();
-  };
-}
-
-// Preview routes bypass S3 cache and trigger codegen on every call — tighter per-identity budget.
-// Keyed by team API token → rl:team:{id}, session/PAT → rl:user:{id};
-// no resolved identity → skip (WAF handles unauthenticated traffic).
+// Rate limiter for loader and CMS endpoints, keyed by workspace.id or team.id.
+// All workspaces/teams in a multi-project request are incremented independently.
 // Fails open if Redis is unavailable.
-export const createPreviewRateLimiter = createIdentityRateLimiter(
-  "RATE_LIMIT_PREVIEW_PER_USER",
-  300
+export const createProjectScopeRateLimiter = makeRateLimiter(
+  "RATE_LIMIT_PER_SCOPE",
+  6000
+);
+
+export const createCmsScopeRateLimiter = makeRateLimiter(
+  "RATE_LIMIT_PER_SCOPE",
+  6000
+);
+
+// Preview routes bypass S3 cache and trigger codegen on every call — tighter budget.
+// Applies to all auth methods: project tokens, CMS tokens, team token, session/PAT.
+export const createPreviewRateLimiter = makeRateLimiter(
+  "RATE_LIMIT_PREVIEW_PER_SCOPE",
+  600
 );
 
 // General authenticated API endpoints — studio CRUD, teams, workspaces, data sources, etc.
-// Keyed by team API token → rl:team:{id}, session/PAT → rl:user:{id}.
-// Generous budget to cover normal studio usage; blocks scripted abuse.
-export const createGeneralApiRateLimiter = createIdentityRateLimiter(
+export const createGeneralApiRateLimiter = makeRateLimiter(
   "RATE_LIMIT_GENERAL_API_PER_USER",
   300
 );
 
-// Write/publish routes are expensive and low-frequency by design — much tighter per-identity budget.
-// Keyed by team API token → rl:team:{id}, session/PAT → rl:user:{id};
-// no resolved identity → skip (WAF handles unauthenticated traffic).
-// Fails open if Redis is unavailable.
-export const createWriteRateLimiter = createIdentityRateLimiter(
+// Write/publish routes are expensive and low-frequency by design — much tighter budget.
+export const createWriteRateLimiter = makeRateLimiter(
   "RATE_LIMIT_WRITE_PER_USER",
   60
 );


### PR DESCRIPTION
## Summary

Replaces the siloed per-auth-type rate limiters with a single unified resolver so every endpoint limiter fires regardless of how the caller authenticates.

**Before:** `createProjectScopeRateLimiter` only fired for `x-plasmic-api-project-tokens`; identity-keyed limiters only fired for `req.apiTeam`/`req.user`; `createCmsScopeRateLimiter` only fired for `x-plasmic-api-cms-tokens`. The effective rate limit depended on how you authenticated, not how expensive the endpoint was.

**After:** A single `resolveRateLimitKeys` helper tries all auth methods in priority order. Every limiter factory uses it, so the limit is determined by endpoint tier alone.

## Key changes

- Adds `resolveRateLimitKeys(redis, req)` — tries all auth methods in order, returns the correct bucket key(s)
- Replaces `createIdentityRateLimiter` + inline project/CMS scope factories with one `makeRateLimiter` factory
- Removes `createProjectScopePreviewRateLimiter` — merged into `createPreviewRateLimiter`
- Adds debug logging when limiter skips silently (no Redis configured, no identity resolved)

## Key resolver priority

1. `x-plasmic-api-project-tokens` header **+ `req.body.projectIdsAndTokens`** (CLI) → `rl:workspace:{id}` / `rl:team:{id}` (DB + Redis cache)
2. `x-plasmic-api-cms-tokens` → `rl:workspace:{id}` / `rl:team:{id}` (DB + Redis cache)
3. `x-plasmic-api-session-token` / `req.body.sessionToken` (temporary team token) → `rl:team:{id}` (DB lookup, no cache)
4. `req.apiTeam` (team API token) → `rl:team:{id}`
5. `req.user` (session / PAT) → `rl:user:{id}`

First match wins. Project/CMS tokens can return multiple keys (multi-workspace request); all are incremented and the strictest bucket triggers the 429.

## Rate limit table

| Endpoint tier | Env var | Default |
|---|---|---|
| All loader routes | `RATE_LIMIT_PER_SCOPE` | 6000/60s = 100 RPS |
| Preview routes | `RATE_LIMIT_PREVIEW_PER_SCOPE` | 600/60s = 10 RPS |
| Write/publish routes | `RATE_LIMIT_WRITE_PER_USER` | 60/60s = 1 RPS |
| General API routes | `RATE_LIMIT_GENERAL_API_PER_USER` | 300/60s = 5 RPS |
| CMS public routes | `RATE_LIMIT_PER_SCOPE` | 6000/60s = 100 RPS |

## Breaking change

`createPreviewRateLimiter` moves from env var `RATE_LIMIT_PREVIEW_PER_USER` (default 300) to `RATE_LIMIT_PREVIEW_PER_SCOPE` (default 600 = 10 RPS). Rename the infra env var if it is set.

## Test plan

- [x] 52 unit tests pass (`ep-rate-limit.spec.ts`) — includes cross-auth tests for every limiter × every auth method, body token merging, and session token resolution
- [ ] Confirm `RateLimit-Limit: 600` on preview endpoint via project token and via team token
- [ ] Confirm `RateLimit-Limit: 6000` on published loader endpoint via team token