### PR TITLE
chore(plasmic-mcp): bump to v0.1.6

### DIFF
--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Visual Builder",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
   "author": {
     "name": "Elastic Path"

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Rebuild MCP bundle to pick up the `isMutation` field on `CustomFunction` (added upstream in `cbacec89c` — "Filter on isQuery and add isMutation"). The 0.1.5 bundle was built before that commit and rejects projects whose CustomFunctions carry `isMutation` with `Unexpected fields on [CustomFunction]: + isMutation`.

No source changes — pure version bump so we can republish the dist that already incorporates the new schema field.

## Test plan

- [x] `yarn test` in `packages/plasmic-mcp` — 2364/2364 pass
- [x] `yarn build` produces dist that contains `isMutation` field on the CustomFunction class metadata
- [ ] Post-merge: `npm publish` from `packages/plasmic-mcp` against the `@elasticpath` scope