### PR TITLE
feat(rate-limit): include bucket state in HTTP response log

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -466,6 +466,7 @@ export function addLoggingMiddleware(app: express.Application) {
           userAgent: req.get("user-agent"),
           contentLength: res.get("content-length"),
           duration: duration,
+          ...(res.locals.rateLimit ? { rateLimit: res.locals.rateLimit } : {}),
         }
       );
     });

--- a/platform/wab/src/wab/server/ep-rate-limit.ts
+++ b/platform/wab/src/wab/server/ep-rate-limit.ts
@@ -250,15 +250,13 @@ async function enforceRateLimit(
   res.setHeader("RateLimit-Limit", String(limit));
   res.setHeader("RateLimit-Remaining", String(Math.max(0, limit - maxCount)));
 
-  for (const [i, key] of keyList.entries()) {
-    logger().info("Rate limit bucket", {
-      key,
-      count: counts[i],
-      limit,
-      remaining: Math.max(0, limit - counts[i]),
-      windowSec,
-    });
-  }
+  res.locals.rateLimit = keyList.map((key, i) => ({
+    key,
+    count: counts[i],
+    limit,
+    remaining: Math.max(0, limit - counts[i]),
+    windowSec,
+  }));
 
   if (counts.some((count) => count > limit)) {
     res.status(429).json({ error: "Too many requests, please try again later." });


### PR DESCRIPTION
## Summary

Moves the rate limit bucket state out of a standalone log line and into the main HTTP response log, so every request's rate limit info is visible alongside method, path, status, and duration in a single log entry.

## What changes

- `ep-rate-limit.ts`: writes bucket state to `res.locals.rateLimit` in `enforceRateLimit` instead of emitting a separate `logger().info("Rate limit bucket", ...)` call
- `AppServer.ts`: spreads `res.locals.rateLimit` into the `addLoggingMiddleware` finish-handler payload

## Resulting log shape

```json
{
  "msg": "GET /api/v1/loader/repr-v3/preview/abc123 200 (312ms)",
  "requestStatusCode": 200,
  "duration": 312,
  "rateLimit": [
    { "key": "rl:workspace:xyz", "count": 42, "limit": 600, "remaining": 558, "windowSec": 60 }
  ]
}
```

The `rateLimit` field is absent on routes with no rate limiter — no noise for unaffected endpoints. Multi-workspace requests produce multiple entries in the array.

## Test plan

- [x] Existing unit tests pass (`ep-rate-limit.spec.ts`)
- [ ] Hit a rate-limited endpoint in integration and confirm `rateLimit` array appears in CloudWatch log entry
- [ ] Hit a non-rate-limited endpoint and confirm `rateLimit` is absent