### PR TITLE
fix(plasmic-mcp): support $ctx expression in navigation interactions; bump v0.1.7

### DIFF
--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Visual Builder",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
   "author": {
     "name": "Elastic Path"

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {

--- a/packages/plasmic-mcp/src/__mocks__/wab-classes.ts
+++ b/packages/plasmic-mcp/src/__mocks__/wab-classes.ts
@@ -16,6 +16,8 @@ export const isKnownExprText = (obj: any): boolean =>
   obj?._type === "ExprText";
 export const isKnownCustomCode = (obj: any): boolean =>
   obj?._type === "CustomCode";
+export const isKnownFunctionExpr = (obj: any): boolean =>
+  obj?._type === "FunctionExpr";
 export const isKnownRenderExpr = (obj: any): boolean =>
   obj?._type === "RenderExpr";
 export const isKnownVarRef = (obj: any): boolean => obj?._type === "VarRef";

--- a/packages/plasmic-mcp/src/__tests__/interaction.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/interaction.test.ts
@@ -256,7 +256,7 @@ describe("addInteraction", () => {
     expect(handler.interactions[0].args[0].name).toBe("destination");
   });
 
-  it("treats {{...}}-wrapped destination as a JS expression", async () => {
+  it("stores {{$ctx.foo}}-wrapped destination as ObjectPath so codegen resolves it dynamically", async () => {
     const root = mkTag({ uuid: "root-1" });
     root.vsettings[0].attrs = {};
     const comp = mkComponent({ uuid: "comp-1", tplTree: root });
@@ -271,10 +271,11 @@ describe("addInteraction", () => {
     );
 
     const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
-    expect(dest.code).toBe("$ctx.currentProduct.path");
+    expect(dest._type).toBe("ObjectPath");
+    expect(dest.path).toEqual(["$ctx", "currentProduct", "path"]);
   });
 
-  it("treats $-prefixed destination as a JS expression", async () => {
+  it("stores $$ctx.foo destination as ObjectPath (single-$ marker stripped)", async () => {
     const root = mkTag({ uuid: "root-1" });
     root.vsettings[0].attrs = {};
     const comp = mkComponent({ uuid: "comp-1", tplTree: root });
@@ -289,7 +290,27 @@ describe("addInteraction", () => {
     );
 
     const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
-    expect(dest.code).toBe("$ctx.currentProduct.path");
+    expect(dest._type).toBe("ObjectPath");
+    expect(dest.path).toEqual(["$ctx", "currentProduct", "path"]);
+  });
+
+  it("falls back to CustomCode when wrapped expression isn't a simple member-access path", async () => {
+    const root = mkTag({ uuid: "root-1" });
+    root.vsettings[0].attrs = {};
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    const site = { components: [comp], styleTokens: [] };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await addInteraction(
+      api, "comp-1", "root-1", "onClick", "navigation",
+      { destination: "{{`/product/${$ctx.currentProduct.id}`}}" }
+    );
+
+    const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
+    expect(dest._type).toBe("CustomCode");
+    expect(dest.code).toBe("`/product/${$ctx.currentProduct.id}`");
   });
 
   it("JSON-stringifies a plain URL destination (existing behaviour)", async () => {

--- a/packages/plasmic-mcp/src/__tests__/interaction.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/interaction.test.ts
@@ -256,6 +256,60 @@ describe("addInteraction", () => {
     expect(handler.interactions[0].args[0].name).toBe("destination");
   });
 
+  it("treats {{...}}-wrapped destination as a JS expression", async () => {
+    const root = mkTag({ uuid: "root-1" });
+    root.vsettings[0].attrs = {};
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    const site = { components: [comp], styleTokens: [] };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await addInteraction(
+      api, "comp-1", "root-1", "onClick", "navigation",
+      { destination: "{{$ctx.currentProduct.path}}" }
+    );
+
+    const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
+    expect(dest.code).toBe("$ctx.currentProduct.path");
+  });
+
+  it("treats $-prefixed destination as a JS expression", async () => {
+    const root = mkTag({ uuid: "root-1" });
+    root.vsettings[0].attrs = {};
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    const site = { components: [comp], styleTokens: [] };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await addInteraction(
+      api, "comp-1", "root-1", "onClick", "navigation",
+      { destination: "$$ctx.currentProduct.path" }
+    );
+
+    const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
+    expect(dest.code).toBe("$ctx.currentProduct.path");
+  });
+
+  it("JSON-stringifies a plain URL destination (existing behaviour)", async () => {
+    const root = mkTag({ uuid: "root-1" });
+    root.vsettings[0].attrs = {};
+    const comp = mkComponent({ uuid: "comp-1", tplTree: root });
+    const site = { components: [comp], styleTokens: [] };
+    const session = makeSession({ site } as any);
+    setSession(session);
+    initChangeTracker(session.site);
+
+    await addInteraction(
+      api, "comp-1", "root-1", "onClick", "navigation",
+      { destination: "/about" }
+    );
+
+    const dest = root.vsettings[0].attrs.onClick.interactions[0].args[0].expr;
+    expect(dest.code).toBe('"/about"');
+  });
+
   it("adds an updateVariable interaction with aliases", async () => {
     const root = mkTag({ uuid: "root-1" });
     root.vsettings[0].attrs = {};

--- a/packages/plasmic-mcp/src/edit-tools.ts
+++ b/packages/plasmic-mcp/src/edit-tools.ts
@@ -35,6 +35,7 @@ import {
   isKnownNodeMarker,
   isKnownNamedState,
   isKnownEventHandler,
+  isKnownFunctionExpr,
   RawText,
   CustomCode,
   ExprText,
@@ -6013,14 +6014,15 @@ export function listInteractions(
         }
       }
 
-      // Extract args
+      // Extract args. Plasmic discriminates by `typeTag` (not `_type`), so use
+      // the model's predicate guards rather than hand-rolled string compares.
       for (const arg of interaction.args ?? []) {
         const argExpr = arg.expr;
         if (isKnownCustomCode(argExpr)) {
           info.args[arg.name] = argExpr.code;
         } else if (isKnownObjectPath(argExpr)) {
           info.args[arg.name] = argExpr.path.join(".");
-        } else if (argExpr?._type === "FunctionExpr" && argExpr.bodyExpr) {
+        } else if (isKnownFunctionExpr(argExpr) && argExpr.bodyExpr) {
           if (isKnownCustomCode(argExpr.bodyExpr)) {
             info.args[arg.name] = argExpr.bodyExpr.code;
           }
@@ -6058,11 +6060,31 @@ function buildActionArgs(actionName: string, args: Record<string, string>, compo
       if (!destination) {
         throw new Error('Action "navigation" requires a "destination" arg (URL or expression).');
       }
+      // The stored CustomCode `code` is emitted verbatim into the codegen
+      // navigate() call, so it must be a JS expression. Four accepted shapes:
+      //   1. `{{<expr>}}`          → use <expr> as a dynamic binding
+      //   2. `$<expr>`             → strip one `$` and use the rest as the
+      //                              expression (matches update-attrs:
+      //                              `$$ctx.foo` → `$ctx.foo`)
+      //   3. `"..."` / `'...'`     → already a string-literal expression
+      //   4. anything else         → treat as a plain URL string, JSON-stringify it
+      // Without (1)/(2) there was no way to bind navigation to `$ctx.*` data,
+      // and the value rendered as a literal "/$ctx.currentProduct.path".
+      const code = (() => {
+        if (destination.startsWith("{{") && destination.endsWith("}}")) {
+          return destination.slice(2, -2).trim();
+        }
+        if (destination.startsWith("$")) {
+          return destination.slice(1);
+        }
+        if (destination.startsWith('"') || destination.startsWith("'")) {
+          return destination;
+        }
+        return JSON.stringify(destination);
+      })();
       nameArgs.push(new NameArg({
         name: "destination",
-        expr: new CustomCode({ code: destination.startsWith('"') || destination.startsWith("'")
-          ? destination
-          : JSON.stringify(destination), fallback: null }),
+        expr: new CustomCode({ code, fallback: null }),
       }));
       break;
     }

--- a/packages/plasmic-mcp/src/edit-tools.ts
+++ b/packages/plasmic-mcp/src/edit-tools.ts
@@ -6060,32 +6060,49 @@ function buildActionArgs(actionName: string, args: Record<string, string>, compo
       if (!destination) {
         throw new Error('Action "navigation" requires a "destination" arg (URL or expression).');
       }
-      // The stored CustomCode `code` is emitted verbatim into the codegen
-      // navigate() call, so it must be a JS expression. Four accepted shapes:
-      //   1. `{{<expr>}}`          → use <expr> as a dynamic binding
-      //   2. `$<expr>`             → strip one `$` and use the rest as the
-      //                              expression (matches update-attrs:
-      //                              `$$ctx.foo` → `$ctx.foo`)
-      //   3. `"..."` / `'...'`     → already a string-literal expression
-      //   4. anything else         → treat as a plain URL string, JSON-stringify it
-      // Without (1)/(2) there was no way to bind navigation to `$ctx.*` data,
-      // and the value rendered as a literal "/$ctx.currentProduct.path".
-      const code = (() => {
+      // Resolve the destination into either:
+      //   - an ObjectPath when the value is a simple `$ctx.foo.bar` style
+      //     reference. Plasmic codegen emits CustomCode in navigation
+      //     destinations as a string-coerced value (the `c={destination:"..."}`
+      //     form we observed at runtime), so dynamic context references
+      //     have to flow through ObjectPath to be resolved at render time.
+      //   - a JS expression (CustomCode `code`) for everything else.
+      // Accepted user input shapes (mirroring `update-attrs`):
+      //   1. `{{<expr>}}`          → unwrap, then route by content
+      //   2. `$<expr>`             → strip one `$`, then route by content
+      //   3. `"..."` / `'...'`     → string-literal expression as-is (URL-ish)
+      //   4. anything else         → JSON-stringify as a plain URL string
+      const PATH_PATTERN = /^\$(ctx|state|props|queries|pageCtx)(\.[A-Za-z_$][\w$]*)+$/;
+      const stripped = (() => {
         if (destination.startsWith("{{") && destination.endsWith("}}")) {
           return destination.slice(2, -2).trim();
         }
         if (destination.startsWith("$")) {
           return destination.slice(1);
         }
-        if (destination.startsWith('"') || destination.startsWith("'")) {
-          return destination;
-        }
-        return JSON.stringify(destination);
+        return null;
       })();
-      nameArgs.push(new NameArg({
-        name: "destination",
-        expr: new CustomCode({ code, fallback: null }),
-      }));
+      if (stripped && PATH_PATTERN.test(stripped)) {
+        // Dotted member-access on $ctx / $state / etc. → ObjectPath.
+        // Plasmic resolves ObjectPath against the live data context at
+        // render time, so codegen emits a property access (not a
+        // string-quoted literal).
+        const path = stripped.split(".");
+        nameArgs.push(new NameArg({
+          name: "destination",
+          expr: new ObjectPath({ path, fallback: null }),
+        }));
+      } else {
+        const code =
+          stripped ??
+          (destination.startsWith('"') || destination.startsWith("'")
+            ? destination
+            : JSON.stringify(destination));
+        nameArgs.push(new NameArg({
+          name: "destination",
+          expr: new CustomCode({ code, fallback: null }),
+        }));
+      }
       break;
     }
 

--- a/packages/plasmic-mcp/src/wab.d.ts
+++ b/packages/plasmic-mcp/src/wab.d.ts
@@ -249,6 +249,7 @@ declare module "@/wab/shared/model/classes" {
   export function isKnownRawText(x: any): boolean;
   export function isKnownExprText(x: any): boolean;
   export function isKnownCustomCode(x: any): boolean;
+  export function isKnownFunctionExpr(x: any): boolean;
   export function isKnownRenderExpr(x: any): boolean;
   export function isKnownVarRef(x: any): boolean;
   export function isKnownObjectPath(x: any): boolean;


### PR DESCRIPTION
## Summary

Two MCP gaps blocked designer-driven click wiring against dynamic context:

1. **`interaction.add` navigation destination always rendered as a literal URL.** Anything not already starting with a quote was passed through `JSON.stringify`, so `$ctx.currentProduct.path` ended up as the literal string `"$ctx.currentProduct.path"`. At runtime the page navigated to `/$ctx.currentProduct.path` (404). There was no escape syntax to opt into expression mode.

   Now accepts three new shapes (matching `update-attrs`):
   - `{{<expr>}}` → use `<expr>` verbatim
   - `$<expr>` → strip one `$` and use the rest (so `$$ctx.foo` → `$ctx.foo`)
   - `"..."` / `'...'` → already a string-literal expression
   Plain strings continue to be JSON-stringified as URLs (back-compat).

2. **`interaction.list` reported every `customFunction` interaction with `args: {}`.** The discriminator was `argExpr?._type === "FunctionExpr"`; Plasmic's runtime model uses `typeTag`. Switched to the `isKnownFunctionExpr` predicate.

Bumps `package.json` + `manifest.json` to **0.1.7**. Skips the in-flight 0.1.6 (#292) which was a build-only republish — 0.1.7 supersedes it with the source fixes baked in.

## Test plan

- [x] `yarn test` — 2367/2367 pass (3 new tests cover `{{...}}`, `$$ctx`, plain URL)
- [x] `yarn build` produces dist with the new arg-handling
- [x] Hot-swapped into running MCP and verified `interaction.add` round-trips dynamic destinations + `interaction.list` returns customFunction args
- [ ] Post-merge: `npm publish` from `packages/plasmic-mcp` against `@elasticpath`