### PR TITLE
fix(ep-commerce): catalog-search renders real EP catalog data end-to-end

### DIFF
--- a/examples/ep-commerce-app-router/plasmic-init.ts
+++ b/examples/ep-commerce-app-router/plasmic-init.ts
@@ -10,6 +10,10 @@ export const PLASMIC = initPlasmicLoader({
   ],
   host: "http://localhost:3003",
   preview: true,
+  // Dev-only: bypass loader's in-process cache so MCP / Studio edits take
+  // effect on the next request without a Next dev restart. Trade: an extra
+  // wab fetch per request. Drop this for prod builds.
+  alwaysFresh: process.env.NODE_ENV !== "production",
   // Required to receive server-queries exec modules
   // (serverQueriesExecFuncFileName per page) in the bundle.
   platformOptions: { nextjs: { appDir: true } },

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -24,6 +24,16 @@ import type { CatalogSearchData } from "./design-time-data";
 
 type PreviewState = "auto" | "withData" | "loading" | "empty" | "error";
 
+// Defensive default — Plasmic strips display/grid styles from code component
+// instances, and centered flex-column page shells (the most common Plasmic
+// layout) collapse children to content-width unless the child explicitly
+// stretches. Without this, the entire catalog-search subtree renders at
+// max-content width regardless of how the surrounding page is configured.
+const DEFAULT_PROVIDER_WRAPPER_STYLE: React.CSSProperties = {
+  width: "100%",
+  alignSelf: "stretch",
+};
+
 interface EPCatalogSearchProviderProps {
   children?: React.ReactNode;
   errorContent?: React.ReactNode;
@@ -143,14 +153,14 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
   if (inEditor) {
     if (previewState === "loading") {
       return (
-        <div className={className} data-ep-catalog-search-provider="">
+        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
           Loading...
         </div>
       );
     }
     if (previewState === "error") {
       return (
-        <div className={className} data-ep-catalog-search-provider="">
+        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
           {errorContent}
         </div>
       );
@@ -165,7 +175,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
             query: "",
           }}
         >
-          <div className={className} data-ep-catalog-search-provider="">
+          <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
             {children}
           </div>
         </DataProvider>
@@ -179,7 +189,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
   if (useMock) {
     return (
       <DataProvider name="catalogSearchData" data={MOCK_CATALOG_SEARCH_DATA}>
-        <div className={className} data-ep-catalog-search-provider="">
+        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
           {children}
         </div>
       </DataProvider>
@@ -258,7 +268,7 @@ function EPCatalogSearchProviderInner(props: {
 
   if (!searchClient) {
     return (
-      <div className={className} data-ep-catalog-search-provider="">
+      <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
         {errorContent || (
           <div>
             Catalog Search is not available. Ensure the adapter is installed and
@@ -286,7 +296,7 @@ function EPCatalogSearchProviderInner(props: {
     >
       <Configure hitsPerPage={hitsPerPage} />
       <DataProvider name="catalogSearchData" data={catalogSearchData}>
-        <div className={className} data-ep-catalog-search-provider="">
+        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
           {children}
         </div>
       </DataProvider>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -231,9 +231,15 @@ function EPCatalogSearchProviderInner(props: {
   const searchClient = useMemo(() => {
     if (!client) return null;
     try {
-      // Dynamic require — the adapter is a default export
+      // Dynamic require — the adapter is a default export.
+      // The published 0.0.5 build ships an esbuild __toESM(..., 1)
+      // double-wrap, so `mod.default` is `{ default: <class>, __esModule: true }`
+      // instead of the class itself. Unwrap defensively to handle both shapes.
+      const mod = require("@elasticpath/catalog-search-instantsearch-adapter");
       const CatalogSearchInstantSearchAdapter =
-        require("@elasticpath/catalog-search-instantsearch-adapter").default;
+        typeof mod.default === "function"
+          ? mod.default
+          : mod.default?.default ?? mod;
       const adapter = new CatalogSearchInstantSearchAdapter({
         client,
         additionalSearchParameters: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
@@ -180,17 +180,24 @@ const EPHierarchicalMenuInner = React.forwardRef<
     refineCategory: (value: string) => refine(value),
   }));
 
-  const flatItems = useMemo(
-    () => flattenHierarchicalItems(items || []),
-    [items]
-  );
+  // Expose `refine` on each category so designers can wire a click in
+  // Studio (interaction → customFunction `$ctx.currentCategory.refine()`)
+  // without the component pre-rendering a button. See EPRefinementList for
+  // the same pattern.
+  const flatItems = useMemo(() => {
+    const flat = flattenHierarchicalItems(items || []);
+    return flat.map((item) => ({
+      ...item,
+      refine: () => refine(item.value),
+    }));
+  }, [items, refine]);
 
   if (flatItems.length === 0) return null;
 
   return (
     <div className={className} data-ep-hierarchical-menu="">
       <div role="list">
-        {flatItems.map((item, i) => (
+        {flatItems.map((item: any, i: number) => (
           <div key={item.value} role="listitem">
             <DataProvider name="currentCategory" data={item}>
               {repeatedElement(i, children)}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
@@ -20,20 +20,6 @@ import type { CategoryItem } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
 
-// Defensive style — make every category item act as a clickable button
-// without forcing designers to wire onClick handlers themselves.
-const CATEGORY_ROW_STYLE: React.CSSProperties = {
-  display: "block",
-  width: "100%",
-  textAlign: "inherit",
-  background: "none",
-  border: "none",
-  padding: 0,
-  font: "inherit",
-  color: "inherit",
-  cursor: "pointer",
-};
-
 interface EPHierarchicalMenuProps {
   children?: React.ReactNode;
   attributes?: string;
@@ -156,17 +142,11 @@ const MockHierarchicalMenu = React.forwardRef<
     <div className={className} data-ep-hierarchical-menu="">
       <div role="list">
         {MOCK_CATEGORY_ITEMS.map((item, i) => (
-          <button
-            key={item.value}
-            type="button"
-            role="listitem"
-            aria-pressed={item.isRefined}
-            style={CATEGORY_ROW_STYLE}
-          >
+          <div key={item.value} role="listitem">
             <DataProvider name="currentCategory" data={item}>
               {repeatedElement(i, children)}
             </DataProvider>
-          </button>
+          </div>
         ))}
       </div>
     </div>
@@ -211,18 +191,11 @@ const EPHierarchicalMenuInner = React.forwardRef<
     <div className={className} data-ep-hierarchical-menu="">
       <div role="list">
         {flatItems.map((item, i) => (
-          <button
-            key={item.value}
-            type="button"
-            role="listitem"
-            aria-pressed={item.isRefined}
-            onClick={() => refine(item.value)}
-            style={CATEGORY_ROW_STYLE}
-          >
+          <div key={item.value} role="listitem">
             <DataProvider name="currentCategory" data={item}>
               {repeatedElement(i, children)}
             </DataProvider>
-          </button>
+          </div>
         ))}
       </div>
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
@@ -20,6 +20,20 @@ import type { CategoryItem } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
 
+// Defensive style — make every category item act as a clickable button
+// without forcing designers to wire onClick handlers themselves.
+const CATEGORY_ROW_STYLE: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  textAlign: "inherit",
+  background: "none",
+  border: "none",
+  padding: 0,
+  font: "inherit",
+  color: "inherit",
+  cursor: "pointer",
+};
+
 interface EPHierarchicalMenuProps {
   children?: React.ReactNode;
   attributes?: string;
@@ -142,11 +156,17 @@ const MockHierarchicalMenu = React.forwardRef<
     <div className={className} data-ep-hierarchical-menu="">
       <div role="list">
         {MOCK_CATEGORY_ITEMS.map((item, i) => (
-          <div key={item.value} role="listitem">
+          <button
+            key={item.value}
+            type="button"
+            role="listitem"
+            aria-pressed={item.isRefined}
+            style={CATEGORY_ROW_STYLE}
+          >
             <DataProvider name="currentCategory" data={item}>
               {repeatedElement(i, children)}
             </DataProvider>
-          </div>
+          </button>
         ))}
       </div>
     </div>
@@ -191,11 +211,18 @@ const EPHierarchicalMenuInner = React.forwardRef<
     <div className={className} data-ep-hierarchical-menu="">
       <div role="list">
         {flatItems.map((item, i) => (
-          <div key={item.value} role="listitem">
+          <button
+            key={item.value}
+            type="button"
+            role="listitem"
+            aria-pressed={item.isRefined}
+            onClick={() => refine(item.value)}
+            style={CATEGORY_ROW_STYLE}
+          >
             <DataProvider name="currentCategory" data={item}>
               {repeatedElement(i, children)}
             </DataProvider>
-          </div>
+          </button>
         ))}
       </div>
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
@@ -21,20 +21,6 @@ import type { RefinementItem } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
 
-// Defensive style — make every refinement item act as a clickable button
-// without forcing designers to wire onClick handlers themselves.
-const REFINEMENT_ROW_STYLE: React.CSSProperties = {
-  display: "block",
-  width: "100%",
-  textAlign: "inherit",
-  background: "none",
-  border: "none",
-  padding: 0,
-  font: "inherit",
-  color: "inherit",
-  cursor: "pointer",
-};
-
 interface EPRefinementListProps {
   children?: React.ReactNode;
   attribute?: string;
@@ -171,19 +157,13 @@ const MockRefinementList = React.forwardRef<
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
         {MOCK_REFINEMENT_ITEMS.map((item, i) => (
-          <button
-            key={item.value}
-            type="button"
-            role="listitem"
-            aria-pressed={item.isRefined}
-            style={REFINEMENT_ROW_STYLE}
-          >
+          <div key={item.value} role="listitem">
             <DataProvider name="currentRefinement" data={item}>
               <DataProvider name="currentRefinementIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </button>
+          </div>
         ))}
       </div>
     </div>
@@ -234,20 +214,13 @@ const EPRefinementListInner = React.forwardRef<
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
         {normalizedItems.map((item, i) => (
-          <button
-            key={item.value}
-            type="button"
-            role="listitem"
-            aria-pressed={item.isRefined}
-            onClick={() => refine(item.value)}
-            style={REFINEMENT_ROW_STYLE}
-          >
+          <div key={item.value} role="listitem">
             <DataProvider name="currentRefinement" data={item}>
               <DataProvider name="currentRefinementIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </button>
+          </div>
         ))}
       </div>
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
@@ -197,15 +197,21 @@ const EPRefinementListInner = React.forwardRef<
     toggleRefinement: (value: string) => refine(value),
   }));
 
-  const normalizedItems: RefinementItem[] = useMemo(
+  // Expose `toggle` as part of the per-item context so designers can wire
+  // a click in Studio (interaction → customFunction `$ctx.currentRefinement.toggle()`)
+  // without the component pre-rendering a button or <a>. Functions in
+  // DataProvider data are passed through React context untouched, so this
+  // costs nothing for designers who don't use it.
+  const normalizedItems = useMemo(
     () =>
       (items || []).map((item: any) => ({
         value: item.value,
         label: item.label,
         count: item.count,
         isRefined: item.isRefined,
+        toggle: () => refine(item.value),
       })),
-    [items]
+    [items, refine]
   );
 
   if (normalizedItems.length === 0) return null;
@@ -213,7 +219,7 @@ const EPRefinementListInner = React.forwardRef<
   return (
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
-        {normalizedItems.map((item, i) => (
+        {normalizedItems.map((item: any, i: number) => (
           <div key={item.value} role="listitem">
             <DataProvider name="currentRefinement" data={item}>
               <DataProvider name="currentRefinementIndex" data={i}>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
@@ -21,6 +21,20 @@ import type { RefinementItem } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
 
+// Defensive style — make every refinement item act as a clickable button
+// without forcing designers to wire onClick handlers themselves.
+const REFINEMENT_ROW_STYLE: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  textAlign: "inherit",
+  background: "none",
+  border: "none",
+  padding: 0,
+  font: "inherit",
+  color: "inherit",
+  cursor: "pointer",
+};
+
 interface EPRefinementListProps {
   children?: React.ReactNode;
   attribute?: string;
@@ -157,13 +171,19 @@ const MockRefinementList = React.forwardRef<
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
         {MOCK_REFINEMENT_ITEMS.map((item, i) => (
-          <div key={item.value} role="listitem">
+          <button
+            key={item.value}
+            type="button"
+            role="listitem"
+            aria-pressed={item.isRefined}
+            style={REFINEMENT_ROW_STYLE}
+          >
             <DataProvider name="currentRefinement" data={item}>
               <DataProvider name="currentRefinementIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </div>
+          </button>
         ))}
       </div>
     </div>
@@ -214,13 +234,20 @@ const EPRefinementListInner = React.forwardRef<
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
         {normalizedItems.map((item, i) => (
-          <div key={item.value} role="listitem">
+          <button
+            key={item.value}
+            type="button"
+            role="listitem"
+            aria-pressed={item.isRefined}
+            onClick={() => refine(item.value)}
+            style={REFINEMENT_ROW_STYLE}
+          >
             <DataProvider name="currentRefinement" data={item}>
               <DataProvider name="currentRefinementIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </div>
+          </button>
         ))}
       </div>
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
@@ -17,6 +17,7 @@ type PreviewState = "auto" | "withData";
 const DEFAULT_SEARCH_BOX_WRAPPER_STYLE: React.CSSProperties = {
   position: "relative",
   width: "100%",
+  alignSelf: "stretch",
   display: "flex",
   alignItems: "center",
 };

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
@@ -14,6 +14,45 @@ import { Registerable } from "../registerable";
 
 type PreviewState = "auto" | "withData";
 
+const DEFAULT_SEARCH_BOX_WRAPPER_STYLE: React.CSSProperties = {
+  position: "relative",
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+};
+
+const DEFAULT_SEARCH_BOX_INPUT_STYLE: React.CSSProperties = {
+  width: "100%",
+  height: "44px",
+  padding: "0 44px 0 16px",
+  border: "1px solid #e7e5e4",
+  borderRadius: "8px",
+  backgroundColor: "#ffffff",
+  fontSize: "14px",
+  color: "#1c1917",
+  outline: "none",
+  fontFamily: "inherit",
+};
+
+const DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE: React.CSSProperties = {
+  position: "absolute",
+  right: "8px",
+  top: "50%",
+  transform: "translateY(-50%)",
+  width: "28px",
+  height: "28px",
+  border: "none",
+  borderRadius: "6px",
+  backgroundColor: "transparent",
+  color: "#a8a29e",
+  cursor: "pointer",
+  fontSize: "18px",
+  lineHeight: "1",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
 interface EPSearchBoxProps {
   className?: string;
   placeholder?: string;
@@ -79,17 +118,21 @@ export function EPSearchBox(props: EPSearchBoxProps) {
 
   if (useMock) {
     return (
-      <div className={className} data-ep-search-box="">
+      <div className={className} data-ep-search-box="" style={DEFAULT_SEARCH_BOX_WRAPPER_STYLE}>
         <input
           type="search"
           placeholder={placeholder}
           autoFocus={autoFocus}
           defaultValue="leather"
           readOnly
-          style={{ width: "100%" }}
+          style={DEFAULT_SEARCH_BOX_INPUT_STYLE}
         />
         {showClear && (
-          <button type="button" aria-label="Clear search">
+          <button
+            type="button"
+            aria-label="Clear search"
+            style={DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE}
+          >
             &times;
           </button>
         )}
@@ -159,7 +202,7 @@ function EPSearchBoxInner(props: {
   }, []);
 
   return (
-    <div className={className} data-ep-search-box="">
+    <div className={className} data-ep-search-box="" style={DEFAULT_SEARCH_BOX_WRAPPER_STYLE}>
       <input
         type="search"
         placeholder={placeholder}
@@ -169,7 +212,12 @@ function EPSearchBoxInner(props: {
         style={{ width: "100%" }}
       />
       {showClear && inputValue && (
-        <button type="button" aria-label="Clear search" onClick={handleClear}>
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={handleClear}
+          style={DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE}
+        >
           &times;
         </button>
       )}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -56,24 +56,7 @@ interface EPSearchHitsProps {
   className?: string;
   gridTemplateColumns?: string;
   gridGap?: string;
-  /**
-   * URL pattern for product cards. Each `{id}` / `{slug}` / `{sku}` token
-   * is replaced from the current hit. Set to "" to disable the link wrap
-   * (designers who want to handle navigation themselves inside the slot).
-   */
-  linkPattern?: string;
   previewState?: PreviewState;
-}
-
-function resolveHitLink(
-  pattern: string | undefined,
-  product: { id?: string; slug?: string; sku?: string }
-): string | undefined {
-  if (!pattern) return undefined;
-  return pattern
-    .replace("{id}", product.id ?? "")
-    .replace("{slug}", product.slug ?? "")
-    .replace("{sku}", product.sku ?? "");
 }
 
 /**
@@ -243,13 +226,6 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
       description: "CSS gap between hit cards.",
       defaultValue: DEFAULT_GRID_GAP,
     },
-    linkPattern: {
-      type: "string",
-      displayName: "Card Link Pattern",
-      description:
-        "URL pattern for each hit card. Tokens `{id}`, `{slug}`, `{sku}` are substituted from the current hit. Leave blank to disable the link wrap.",
-      defaultValue: "/product/{id}",
-    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -270,7 +246,6 @@ export function EPSearchHits(props: EPSearchHitsProps) {
     className,
     gridTemplateColumns = DEFAULT_GRID_TEMPLATE_COLUMNS,
     gridGap = DEFAULT_GRID_GAP,
-    linkPattern = "/product/{id}",
     previewState = "auto",
   } = props;
 
@@ -282,55 +257,25 @@ export function EPSearchHits(props: EPSearchHitsProps) {
 
   if (useMock) {
     return (
-      <MockSearchHits
-        className={className}
-        gridStyle={gridStyle}
-        linkPattern={linkPattern}
-      >
+      <MockSearchHits className={className} gridStyle={gridStyle}>
         {children}
       </MockSearchHits>
     );
   }
 
   return (
-    <EPSearchHitsInner
-      className={className}
-      gridStyle={gridStyle}
-      linkPattern={linkPattern}
-    >
+    <EPSearchHitsInner className={className} gridStyle={gridStyle}>
       {children}
     </EPSearchHitsInner>
   );
-}
-
-function HitCard(props: {
-  product: { id?: string; slug?: string; sku?: string };
-  href?: string;
-  children?: React.ReactNode;
-}) {
-  const { href, children } = props;
-  const baseStyle: React.CSSProperties = {
-    display: "block",
-    color: "inherit",
-    textDecoration: "none",
-  };
-  if (href) {
-    return (
-      <a href={href} role="listitem" style={baseStyle}>
-        {children}
-      </a>
-    );
-  }
-  return <div role="listitem">{children}</div>;
 }
 
 function MockSearchHits(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
-  linkPattern?: string;
 }) {
-  const { children, className, gridStyle, linkPattern } = props;
+  const { children, className, gridStyle } = props;
 
   const products = useMemo(
     () => MOCK_SEARCH_PRODUCTS.map(buildMockCurrentProduct),
@@ -347,17 +292,13 @@ function MockSearchHits(props: {
       style={gridStyle}
     >
       {products.map((product, i) => (
-        <HitCard
-          key={product.id}
-          product={product}
-          href={resolveHitLink(linkPattern, product)}
-        >
+        <div key={product.id} role="listitem">
           <DataProvider name="currentProduct" data={product}>
             <DataProvider name="currentProductIndex" data={i}>
               {repeatedElement(i, children)}
             </DataProvider>
           </DataProvider>
-        </HitCard>
+        </div>
       ))}
     </div>
   );
@@ -367,9 +308,8 @@ function EPSearchHitsInner(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
-  linkPattern?: string;
 }) {
-  const { children, className, gridStyle, linkPattern } = props;
+  const { children, className, gridStyle } = props;
 
   const { useHits, useInstantSearch } = require("react-instantsearch");
   const { hits } = useHits();
@@ -400,17 +340,13 @@ function EPSearchHitsInner(props: {
     >
       {normalizedProducts.map(
         (product: ReturnType<typeof normalizeHitToCurrentProduct>, i: number) => (
-          <HitCard
-            key={product.id || i}
-            product={product}
-            href={resolveHitLink(linkPattern, product)}
-          >
+          <div key={product.id || i} role="listitem">
             <DataProvider name="currentProduct" data={product}>
               <DataProvider name="currentProductIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </HitCard>
+          </div>
         )
       )}
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -29,16 +29,33 @@ type PreviewState = "auto" | "withData";
 // Default grid layout — applied as inline style so it survives Plasmic's
 // className filter (which strips display/grid props from code component
 // instances).
-const DEFAULT_HITS_GRID_STYLE: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
-  gap: "24px",
-  width: "100%",
-};
+//
+// `align-self: stretch` keeps the grid full-width when its parent is a flex
+// container with `align-items: center` (a common Plasmic page layout).
+// Without it the grid collapses to its `min-content` (one column) because
+// flex defaults each child to `align-self: auto`.
+function buildHitsGridStyle(
+  gridTemplateColumns: string,
+  gap: string
+): React.CSSProperties {
+  return {
+    display: "grid",
+    gridTemplateColumns,
+    gap,
+    width: "100%",
+    alignSelf: "stretch",
+  };
+}
+
+const DEFAULT_GRID_TEMPLATE_COLUMNS =
+  "repeat(auto-fill, minmax(220px, 1fr))";
+const DEFAULT_GRID_GAP = "24px";
 
 interface EPSearchHitsProps {
   children?: React.ReactNode;
   className?: string;
+  gridTemplateColumns?: string;
+  gridGap?: string;
   previewState?: PreviewState;
 }
 
@@ -196,6 +213,19 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
         },
       ],
     },
+    gridTemplateColumns: {
+      type: "string",
+      displayName: "Grid Template Columns",
+      description:
+        "CSS grid-template-columns value applied to the hits container. Defaults to a responsive auto-fill. Plasmic strips display/grid styles set in the canvas Style panel from code components, so this prop is the supported way to override the layout.",
+      defaultValue: DEFAULT_GRID_TEMPLATE_COLUMNS,
+    },
+    gridGap: {
+      type: "string",
+      displayName: "Grid Gap",
+      description: "CSS gap between hit cards.",
+      defaultValue: DEFAULT_GRID_GAP,
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -211,28 +241,41 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
 };
 
 export function EPSearchHits(props: EPSearchHitsProps) {
-  const { children, className, previewState = "auto" } = props;
+  const {
+    children,
+    className,
+    gridTemplateColumns = DEFAULT_GRID_TEMPLATE_COLUMNS,
+    gridGap = DEFAULT_GRID_GAP,
+    previewState = "auto",
+  } = props;
 
   const inEditor = !!usePlasmicCanvasContext();
   const useMock =
     previewState === "withData" || (previewState === "auto" && inEditor);
 
+  const gridStyle = buildHitsGridStyle(gridTemplateColumns, gridGap);
+
   if (useMock) {
     return (
-      <MockSearchHits className={className}>{children}</MockSearchHits>
+      <MockSearchHits className={className} gridStyle={gridStyle}>
+        {children}
+      </MockSearchHits>
     );
   }
 
   return (
-    <EPSearchHitsInner className={className}>{children}</EPSearchHitsInner>
+    <EPSearchHitsInner className={className} gridStyle={gridStyle}>
+      {children}
+    </EPSearchHitsInner>
   );
 }
 
 function MockSearchHits(props: {
   children?: React.ReactNode;
   className?: string;
+  gridStyle: React.CSSProperties;
 }) {
-  const { children, className } = props;
+  const { children, className, gridStyle } = props;
 
   const products = useMemo(
     () => MOCK_SEARCH_PRODUCTS.map(buildMockCurrentProduct),
@@ -246,7 +289,7 @@ function MockSearchHits(props: {
       className={className}
       role="list"
       aria-label="Search results"
-      style={DEFAULT_HITS_GRID_STYLE}
+      style={gridStyle}
     >
       {products.map((product, i) => (
         <div key={product.id} role="listitem">
@@ -264,8 +307,9 @@ function MockSearchHits(props: {
 function EPSearchHitsInner(props: {
   children?: React.ReactNode;
   className?: string;
+  gridStyle: React.CSSProperties;
 }) {
-  const { children, className } = props;
+  const { children, className, gridStyle } = props;
 
   const { useHits, useInstantSearch } = require("react-instantsearch");
   const { hits } = useHits();
@@ -292,7 +336,7 @@ function EPSearchHitsInner(props: {
       className={className}
       role="list"
       aria-label="Search results"
-      style={DEFAULT_HITS_GRID_STYLE}
+      style={gridStyle}
     >
       {normalizedProducts.map(
         (product: ReturnType<typeof normalizeHitToCurrentProduct>, i: number) => (

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -56,7 +56,24 @@ interface EPSearchHitsProps {
   className?: string;
   gridTemplateColumns?: string;
   gridGap?: string;
+  /**
+   * URL pattern for product cards. Each `{id}` / `{slug}` / `{sku}` token
+   * is replaced from the current hit. Set to "" to disable the link wrap
+   * (designers who want to handle navigation themselves inside the slot).
+   */
+  linkPattern?: string;
   previewState?: PreviewState;
+}
+
+function resolveHitLink(
+  pattern: string | undefined,
+  product: { id?: string; slug?: string; sku?: string }
+): string | undefined {
+  if (!pattern) return undefined;
+  return pattern
+    .replace("{id}", product.id ?? "")
+    .replace("{slug}", product.slug ?? "")
+    .replace("{sku}", product.sku ?? "");
 }
 
 /**
@@ -226,6 +243,13 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
       description: "CSS gap between hit cards.",
       defaultValue: DEFAULT_GRID_GAP,
     },
+    linkPattern: {
+      type: "string",
+      displayName: "Card Link Pattern",
+      description:
+        "URL pattern for each hit card. Tokens `{id}`, `{slug}`, `{sku}` are substituted from the current hit. Leave blank to disable the link wrap.",
+      defaultValue: "/product/{id}",
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -246,6 +270,7 @@ export function EPSearchHits(props: EPSearchHitsProps) {
     className,
     gridTemplateColumns = DEFAULT_GRID_TEMPLATE_COLUMNS,
     gridGap = DEFAULT_GRID_GAP,
+    linkPattern = "/product/{id}",
     previewState = "auto",
   } = props;
 
@@ -257,25 +282,55 @@ export function EPSearchHits(props: EPSearchHitsProps) {
 
   if (useMock) {
     return (
-      <MockSearchHits className={className} gridStyle={gridStyle}>
+      <MockSearchHits
+        className={className}
+        gridStyle={gridStyle}
+        linkPattern={linkPattern}
+      >
         {children}
       </MockSearchHits>
     );
   }
 
   return (
-    <EPSearchHitsInner className={className} gridStyle={gridStyle}>
+    <EPSearchHitsInner
+      className={className}
+      gridStyle={gridStyle}
+      linkPattern={linkPattern}
+    >
       {children}
     </EPSearchHitsInner>
   );
+}
+
+function HitCard(props: {
+  product: { id?: string; slug?: string; sku?: string };
+  href?: string;
+  children?: React.ReactNode;
+}) {
+  const { href, children } = props;
+  const baseStyle: React.CSSProperties = {
+    display: "block",
+    color: "inherit",
+    textDecoration: "none",
+  };
+  if (href) {
+    return (
+      <a href={href} role="listitem" style={baseStyle}>
+        {children}
+      </a>
+    );
+  }
+  return <div role="listitem">{children}</div>;
 }
 
 function MockSearchHits(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
+  linkPattern?: string;
 }) {
-  const { children, className, gridStyle } = props;
+  const { children, className, gridStyle, linkPattern } = props;
 
   const products = useMemo(
     () => MOCK_SEARCH_PRODUCTS.map(buildMockCurrentProduct),
@@ -292,13 +347,17 @@ function MockSearchHits(props: {
       style={gridStyle}
     >
       {products.map((product, i) => (
-        <div key={product.id} role="listitem">
+        <HitCard
+          key={product.id}
+          product={product}
+          href={resolveHitLink(linkPattern, product)}
+        >
           <DataProvider name="currentProduct" data={product}>
             <DataProvider name="currentProductIndex" data={i}>
               {repeatedElement(i, children)}
             </DataProvider>
           </DataProvider>
-        </div>
+        </HitCard>
       ))}
     </div>
   );
@@ -308,8 +367,9 @@ function EPSearchHitsInner(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
+  linkPattern?: string;
 }) {
-  const { children, className, gridStyle } = props;
+  const { children, className, gridStyle, linkPattern } = props;
 
   const { useHits, useInstantSearch } = require("react-instantsearch");
   const { hits } = useHits();
@@ -340,13 +400,17 @@ function EPSearchHitsInner(props: {
     >
       {normalizedProducts.map(
         (product: ReturnType<typeof normalizeHitToCurrentProduct>, i: number) => (
-          <div key={product.id || i} role="listitem">
+          <HitCard
+            key={product.id || i}
+            product={product}
+            href={resolveHitLink(linkPattern, product)}
+          >
             <DataProvider name="currentProduct" data={product}>
               <DataProvider name="currentProductIndex" data={i}>
                 {repeatedElement(i, children)}
               </DataProvider>
             </DataProvider>
-          </div>
+          </HitCard>
         )
       )}
     </div>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -135,7 +135,9 @@ function normalizeHitToCurrentProduct(
     slug,
     sku,
     description,
-    path: `/${slug}`,
+    // Match the EP ProductDetail page route (`/product/[slug]`).
+    // Falls back to id-based URL when the hit lacks a slug.
+    path: slug ? `/product/${slug}` : `/product/${hit.objectID || hit.id || ""}`,
     images: [
       {
         url: imageUrl || TRANSPARENT_PIXEL,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -61,13 +61,22 @@ function normalizeHitToCurrentProduct(
     hit.attributes?.description ||
     "";
 
-  // Image: try multiple patterns
+  // Image: try multiple patterns. EP catalog-search hits don't denormalize
+  // file URLs by default (`relationships.main_image.data.id` is just a UUID),
+  // so for unconfigured catalogs imageUrl will be empty.
   const imageUrl =
     hit.ep_main_image_url ||
     hit.main_image_url ||
     hit.main_image?.link?.href ||
     (hit.ep_main_image && hit.ep_main_image.link?.href) ||
     "";
+
+  // 1x1 transparent gif — keeps the <img src> attribute non-empty so the
+  // browser doesn't issue a self-referential request (and React's
+  // empty-string warning stays silent) while letting the surrounding
+  // styles render the visual placeholder.
+  const TRANSPARENT_PIXEL =
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
   // Price resolution — EP catalog search exposes prices in two shapes
   // depending on catalog config:
@@ -110,9 +119,12 @@ function normalizeHitToCurrentProduct(
     sku,
     description,
     path: `/${slug}`,
-    images: imageUrl
-      ? [{ url: imageUrl, alt: name }]
-      : [],
+    images: [
+      {
+        url: imageUrl || TRANSPARENT_PIXEL,
+        alt: name,
+      },
+    ],
     price: {
       value: priceValue,
       currencyCode: priceCurrency,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -26,6 +26,16 @@ import type { Product } from "../types/product";
 
 type PreviewState = "auto" | "withData";
 
+// Default grid layout — applied as inline style so it survives Plasmic's
+// className filter (which strips display/grid props from code component
+// instances).
+const DEFAULT_HITS_GRID_STYLE: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+  gap: "24px",
+  width: "100%",
+};
+
 interface EPSearchHitsProps {
   children?: React.ReactNode;
   className?: string;
@@ -59,17 +69,36 @@ function normalizeHitToCurrentProduct(
     (hit.ep_main_image && hit.ep_main_image.link?.href) ||
     "";
 
-  // Price: try EP catalog search price structure
-  const priceObj =
+  // Price resolution — EP catalog search exposes prices in two shapes
+  // depending on catalog config:
+  //   1. `meta.display_price.without_tax`  → preferred; pre-formatted, currency-aware
+  //   2. `attributes.price[CURRENCY].amount` (in cents) → raw fallback
+  // We also keep the older `ep_price` / `price` paths for back-compat with
+  // search backends that flatten the price object onto the hit root.
+  const displayPrice =
+    hit.meta?.display_price?.without_tax ||
+    hit.meta?.display_price?.with_tax ||
+    null;
+  const attrPriceObj =
+    hit.attributes?.price?.[currencyCode] ||
+    hit.attributes?.price?.USD ||
+    null;
+  const flatPriceObj =
     hit.ep_price?.[currencyCode] ||
     hit.price?.[currencyCode] ||
     hit.ep_price?.USD ||
     hit.price?.USD ||
     null;
   const priceValue =
-    priceObj?.float_price ?? priceObj?.amount ?? hit.price?.value ?? 0;
-  const priceCurrency = currencyCode || "USD";
-  const formatted = formatCurrency(priceValue, priceCurrency);
+    displayPrice?.float_price ??
+    flatPriceObj?.float_price ??
+    flatPriceObj?.amount ??
+    (attrPriceObj?.amount != null ? attrPriceObj.amount / 100 : undefined) ??
+    hit.price?.value ??
+    0;
+  const priceCurrency = displayPrice?.currency || currencyCode || "USD";
+  const formatted =
+    displayPrice?.formatted || formatCurrency(priceValue, priceCurrency);
 
   // Highlight results from InstantSearch
   const highlighted = hit._highlightResult || hit._highlight || {};
@@ -201,7 +230,12 @@ function MockSearchHits(props: {
   if (products.length === 0) return null;
 
   return (
-    <div className={className} role="list" aria-label="Search results">
+    <div
+      className={className}
+      role="list"
+      aria-label="Search results"
+      style={DEFAULT_HITS_GRID_STYLE}
+    >
       {products.map((product, i) => (
         <div key={product.id} role="listitem">
           <DataProvider name="currentProduct" data={product}>
@@ -242,7 +276,12 @@ function EPSearchHitsInner(props: {
   if (normalizedProducts.length === 0) return null;
 
   return (
-    <div className={className} role="list" aria-label="Search results">
+    <div
+      className={className}
+      role="list"
+      aria-label="Search results"
+      style={DEFAULT_HITS_GRID_STYLE}
+    >
       {normalizedProducts.map(
         (product: ReturnType<typeof normalizeHitToCurrentProduct>, i: number) => (
           <div key={product.id || i} role="listitem">


### PR DESCRIPTION
## Summary

Brings the EP catalog-search wrappers (`EPCatalogSearchProvider`, `EPSearchHits`, `EPSearchBox`, `EPHierarchicalMenu`, `EPRefinementList`) from "renders the page tree but no real data" to a fully functional ProductList. Verified end-to-end against a real EP catalog: 33 products render with real prices, multi-column responsive grid, navigable cards, and toggleable filter facets.

Component contract stays **headless** — clicks/links are designer-wired in Studio via Plasmic interactions, not baked into the component output.

## What this fixes

| Issue | Fix |
|----|----|
| Every product card priced `$0.00` | Hit-shape normaliser now reads `hit.meta.display_price.without_tax.{float_price, formatted}` (the actual EP catalog response shape), with fallback to `hit.attributes.price[CCY].amount/100`. Legacy paths kept for back-compat. |
| Empty `<img src="">` triggered React warning + duplicate page-fetch | Hit normaliser produces a 1×1 transparent gif data URL when no image URL is denormalised into the index. |
| Search subtree collapsed to ~580px content-width on a 1280px viewport (single-column grid regardless of viewport) | Plasmic's className filter strips `display`/`grid-*` from code component instances, so user's `grid-template-columns: 1fr 1fr 1fr` set in Studio canvas was lost. Inline default now adds `align-self: stretch` so it doesn't collapse under a centring flex parent, and applies the same defensive style to every `EPCatalogSearchProvider` wrapper variant. New `gridTemplateColumns` / `gridGap` props on `EPSearchHits` give designers the supported override path from Studio. |
| `@elasticpath/catalog-search-instantsearch-adapter` published as `__toESM(..., 1)` double-wrapped default — `new CatalogSearchInstantSearchAdapter(...)` failed | Defensive unwrap in `EPCatalogSearchProvider`: handle `mod.default` being either the class or `{default: <class>}`. |
| MCP/Studio edits to a project required Next dev restart to land in dev | `examples/ep-commerce-app-router/plasmic-init.ts` sets `alwaysFresh: process.env.NODE_ENV !== "production"` so dev iterations bypass the loader's in-process cache. No-op in prod. |
| Designers had no way to wire item interactions in Studio without re-deriving the underlying `refine()` call | `EPRefinementList` and `EPHierarchicalMenu` now expose `toggle()` / `refine()` callables on the per-item `$ctx` (`$ctx.currentRefinement.toggle()`, `$ctx.currentCategory.refine()`). Designers add an On-Click interaction in Studio with a `customFunction` step; no `<button>` baked in by the component. |
| Hit `path` was `/${slug}` — didn't match the EP `ProductDetail` page route `/product/[slug]` | Normaliser produces `/product/${slug}` (with id-based fallback when the hit lacks a slug). |

## Component contract (unchanged on purpose)

Components remain headless. They expose data via `$ctx` and behaviour via `refActions` — no `<a>` / `<button>` wrappers around hit cards or filter rows. Designers wire interactions in Studio.

The earlier auto-wrap commit (`ea3602e45`) is reverted in `8f0c5e57c` — present in history for traceability but has no net effect.

## Companion MCP changes

The Plasmic project this targets needs the navigation-expression handling shipped in [PR #296 (`@elasticpath/plasmic-mcp@0.1.7`)](https://github.com/elasticpath/plasmic/pull/296). Without #296, MCP can write the on-click interaction but `interaction.list` shows `args:{}` for `customFunction` and `navigation` destinations can't bind to `$ctx.*` references.

## Out of scope

- **Backend**: this catalog only has `tags`, `meta.search.categories.lvl0`, and `meta.search.categories.lvl1` configured as facetable. The demo page's `EPRangeFilter` (numeric price) and original `brand`-bound `EPRefinementList` need additional facetable fields enabled in EP Commerce Manager. Today they're gated via `data-cond=false` on the page; flip back to `null` once the catalog config catches up.
- **Runtime error surfacing**: `EPCatalogSearchProvider.errorContent` only fires on adapter construction failure, not on `useInstantSearch().status === "error"`. Attempted this session and hit a children-unmount/remount loop (filters deregister → state resets → re-render → search refires). Correct design is an overlay sibling, not a gated branch — separate piece of work.
- **Workspace symlink**: `examples/ep-commerce-app-router/node_modules/@elasticpath/plasmic-ep-commerce-elastic-path` is a real copied directory, not a workspace symlink. Cost ~30 min this session figuring out why iterations seemed to do nothing. `installConfig.hoistingLimits` would fix it for future setups.

## Test plan

- [x] Full Jest suite for `plasmicpkgs/commerce-providers/elastic-path/src/catalog-search` (44 tests) passes locally.
- [x] `tsdx watch` produces dist with all changes inlined.
- [x] Verified end-to-end on Plasmic project `9iSL9GyrJNp9ebWzxaHtM5` (`/products`):
  - 33 products render with real EP prices.
  - Card click navigates to `/product/<slug>` (PDP).
  - Tag refinement click toggles facet, hits filter (33 → 1 for `test-tag`), URL syncs via InstantSearch routing.
  - Multi-column grid at desktop widths.
- [ ] Visual regression / Storybook checks for the search components — not added in this PR.