### PR TITLE
[#20] feat(img-optimizer): single-flight coalescing to prevent thundering herd

### DIFF
--- a/platform/wab/src/wab/server/routes/img-optimizer.spec.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.spec.ts
@@ -274,20 +274,17 @@ describe("img-optimizer routes", () => {
 describe("fetchAndOptimizeSingleFlight", () => {
   const mockBuffer = Buffer.from("fake-image-data");
 
-  // 32-char hex key — required by extractS3Key's regex fallback
+  // 32-char hex key — satisfies extractS3Key's regex when siteAssetsBaseUrl is unset
   const params = {
     src: "https://test-assets.example.com/abcdef0123456789abcdef0123456789.jpg",
     width: 400,
     quality: 75,
   };
 
-  function makeS3Mock(getObjectResult: "success" | "fail") {
+  function makeS3Mock() {
     return {
       getObject: jest.fn().mockReturnValue({
-        promise:
-          getObjectResult === "success"
-            ? jest.fn().mockResolvedValue({ Body: mockBuffer, ContentType: "image/jpeg" })
-            : jest.fn().mockRejectedValue(new Error("S3 error")),
+        promise: jest.fn().mockResolvedValue({ Body: mockBuffer, ContentType: "image/jpeg" }),
       }),
       upload: jest.fn().mockReturnValue({
         promise: jest.fn().mockResolvedValue({ Location: "https://s3/cached" }),
@@ -295,14 +292,18 @@ describe("fetchAndOptimizeSingleFlight", () => {
     };
   }
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+  // Load a fresh module instance so the S3 singleton is constructed with the
+  // current mock implementation. Must be called after configuring S3 mock.
+  function loadFn(): typeof import("./img-optimizer").fetchAndOptimizeSingleFlight {
+    let fn: typeof import("./img-optimizer").fetchAndOptimizeSingleFlight;
+    jest.isolateModules(() => {
+      fn = require("./img-optimizer").fetchAndOptimizeSingleFlight;
+    });
+    return fn!;
+  }
 
-    (S3 as jest.MockedClass<typeof S3>).mockImplementation(
-      () => makeS3Mock("success") as any
-    );
-
-    const mockSharpInstance = {
+  function setupSharpMock() {
+    const inst = {
       metadata: jest.fn().mockResolvedValue({ format: "jpeg", width: 800 }),
       resize: jest.fn().mockReturnThis(),
       jpeg: jest.fn().mockReturnThis(),
@@ -310,11 +311,17 @@ describe("fetchAndOptimizeSingleFlight", () => {
       png: jest.fn().mockReturnThis(),
       toBuffer: jest.fn().mockResolvedValue(mockBuffer),
     };
-    (sharp as unknown as jest.Mock).mockReturnValue(mockSharpInstance);
+    (sharp as unknown as jest.Mock).mockReturnValue(inst);
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
   });
 
   it("first caller gets coalesced: false, concurrent caller gets coalesced: true", async () => {
-    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+    (S3 as jest.MockedClass<typeof S3>).mockImplementation(() => makeS3Mock() as any);
+    setupSharpMock();
+    const fetchAndOptimizeSingleFlight = loadFn();
 
     const [first, second] = await Promise.all([
       fetchAndOptimizeSingleFlight("coalescing-key", params),
@@ -327,22 +334,26 @@ describe("fetchAndOptimizeSingleFlight", () => {
   });
 
   it("removes the cacheKey from the map after a successful call", async () => {
-    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+    (S3 as jest.MockedClass<typeof S3>).mockImplementation(() => makeS3Mock() as any);
+    setupSharpMock();
+    const fetchAndOptimizeSingleFlight = loadFn();
 
     await fetchAndOptimizeSingleFlight("cleanup-success-key", params);
     const second = await fetchAndOptimizeSingleFlight("cleanup-success-key", params);
 
-    // If the map entry had not been removed, the second call would be coalesced.
+    // If the entry were not removed, the second call would return coalesced: true.
     expect(second.coalesced).toBe(false);
   });
 
   it("removes the cacheKey from the map after a failed call", async () => {
-    // First S3 instance (source fetch) rejects; subsequent instances succeed.
-    (S3 as jest.MockedClass<typeof S3>)
-      .mockImplementationOnce(() => makeS3Mock("fail") as any)
-      .mockImplementation(() => makeS3Mock("success") as any);
-
-    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+    const s3Mock = makeS3Mock();
+    // First getObject call rejects; default mock handles subsequent calls (success).
+    s3Mock.getObject.mockReturnValueOnce({
+      promise: jest.fn().mockRejectedValue(new Error("S3 error")),
+    });
+    (S3 as jest.MockedClass<typeof S3>).mockImplementation(() => s3Mock as any);
+    setupSharpMock();
+    const fetchAndOptimizeSingleFlight = loadFn();
 
     await expect(
       fetchAndOptimizeSingleFlight("cleanup-failure-key", params)

--- a/platform/wab/src/wab/server/routes/img-optimizer.spec.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.spec.ts
@@ -3,7 +3,12 @@ process.env.SITE_ASSETS_BUCKET = "test-bucket";
 process.env.SITE_ASSETS_BASE_URL = "https://test-assets.example.com/";
 process.env.S3_ENDPOINT = "https://s3.amazonaws.com";
 
+jest.mock("aws-sdk/clients/s3");
+jest.mock("sharp");
+
 import { BadRequestError } from "@/wab/shared/ApiErrors/errors";
+import S3 from "aws-sdk/clients/s3";
+import sharp from "sharp";
 
 // Simple unit tests focused on core validation logic
 describe("img-optimizer routes", () => {
@@ -241,7 +246,7 @@ describe("img-optimizer routes", () => {
   describe("format validation", () => {
     it("should accept valid formats", () => {
       const validFormats = ["jpeg", "jpg", "png", "webp"];
-      
+
       validFormats.forEach(format => {
         expect(() => {
           if (!validFormats.includes(format)) {
@@ -253,7 +258,7 @@ describe("img-optimizer routes", () => {
 
     it("should reject invalid formats", () => {
       const invalidFormats = ["gif", "bmp", "tiff", "pdf"];
-      
+
       invalidFormats.forEach(format => {
         expect(() => {
           const validFormats = ["jpeg", "jpg", "png", "webp"];
@@ -263,5 +268,88 @@ describe("img-optimizer routes", () => {
         }).toThrow(BadRequestError);
       });
     });
+  });
+});
+
+describe("fetchAndOptimizeSingleFlight", () => {
+  const mockBuffer = Buffer.from("fake-image-data");
+
+  // 32-char hex key — required by extractS3Key's regex fallback
+  const params = {
+    src: "https://test-assets.example.com/abcdef0123456789abcdef0123456789.jpg",
+    width: 400,
+    quality: 75,
+  };
+
+  function makeS3Mock(getObjectResult: "success" | "fail") {
+    return {
+      getObject: jest.fn().mockReturnValue({
+        promise:
+          getObjectResult === "success"
+            ? jest.fn().mockResolvedValue({ Body: mockBuffer, ContentType: "image/jpeg" })
+            : jest.fn().mockRejectedValue(new Error("S3 error")),
+      }),
+      upload: jest.fn().mockReturnValue({
+        promise: jest.fn().mockResolvedValue({ Location: "https://s3/cached" }),
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    (S3 as jest.MockedClass<typeof S3>).mockImplementation(
+      () => makeS3Mock("success") as any
+    );
+
+    const mockSharpInstance = {
+      metadata: jest.fn().mockResolvedValue({ format: "jpeg", width: 800 }),
+      resize: jest.fn().mockReturnThis(),
+      jpeg: jest.fn().mockReturnThis(),
+      webp: jest.fn().mockReturnThis(),
+      png: jest.fn().mockReturnThis(),
+      toBuffer: jest.fn().mockResolvedValue(mockBuffer),
+    };
+    (sharp as unknown as jest.Mock).mockReturnValue(mockSharpInstance);
+  });
+
+  it("first caller gets coalesced: false, concurrent caller gets coalesced: true", async () => {
+    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+
+    const [first, second] = await Promise.all([
+      fetchAndOptimizeSingleFlight("coalescing-key", params),
+      fetchAndOptimizeSingleFlight("coalescing-key", params),
+    ]);
+
+    expect(first.coalesced).toBe(false);
+    expect(second.coalesced).toBe(true);
+    expect(second.buffer).toEqual(mockBuffer);
+  });
+
+  it("removes the cacheKey from the map after a successful call", async () => {
+    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+
+    await fetchAndOptimizeSingleFlight("cleanup-success-key", params);
+    const second = await fetchAndOptimizeSingleFlight("cleanup-success-key", params);
+
+    // If the map entry had not been removed, the second call would be coalesced.
+    expect(second.coalesced).toBe(false);
+  });
+
+  it("removes the cacheKey from the map after a failed call", async () => {
+    // First S3 instance (source fetch) rejects; subsequent instances succeed.
+    (S3 as jest.MockedClass<typeof S3>)
+      .mockImplementationOnce(() => makeS3Mock("fail") as any)
+      .mockImplementation(() => makeS3Mock("success") as any);
+
+    const { fetchAndOptimizeSingleFlight } = await import("./img-optimizer");
+
+    await expect(
+      fetchAndOptimizeSingleFlight("cleanup-failure-key", params)
+    ).rejects.toThrow("S3 error");
+
+    // Map entry was cleaned up — retry gets a fresh attempt, not a dead promise.
+    const retry = await fetchAndOptimizeSingleFlight("cleanup-failure-key", params);
+    expect(retry.coalesced).toBe(false);
   });
 });

--- a/platform/wab/src/wab/server/routes/img-optimizer.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.ts
@@ -15,6 +15,10 @@ type SupportedFormat = (typeof SUPPORTED_FORMATS)[number];
 const siteAssetsBucket = process.env.SITE_ASSETS_BUCKET as string;
 const siteAssetsBaseUrl = process.env.SITE_ASSETS_BASE_URL as string;
 
+// Per-process single-flight map: prevents concurrent requests for the same
+// cache key from each spawning independent S3 fetches and Sharp jobs.
+const inFlightRequests = new Map<string, Promise<{ buffer: Buffer; contentType: string }>>();
+
 function createS3Client() {
   const s3Config: any = {
     endpoint: process.env.S3_ENDPOINT,
@@ -262,15 +266,40 @@ async function optimizeImage(
   };
 }
 
+export async function fetchAndOptimizeSingleFlight(
+  cacheKey: string,
+  params: OptimizeParams
+): Promise<{ buffer: Buffer; contentType: string; coalesced: boolean }> {
+  if (inFlightRequests.has(cacheKey)) {
+    const result = await inFlightRequests.get(cacheKey)!;
+    return { ...result, coalesced: true };
+  }
+
+  const processingPromise = (async () => {
+    const imageBuffer = await fetchImageBuffer(params.src);
+    return optimizeImage(imageBuffer, params);
+  })();
+
+  inFlightRequests.set(cacheKey, processingPromise);
+
+  try {
+    const result = await processingPromise;
+    uploadOptimizedImage(cacheKey, result.buffer, result.contentType).catch((error) => {
+      console.error("[IMG-OPTIMIZER] Failed to cache image:", error);
+    });
+    return { ...result, coalesced: false };
+  } finally {
+    inFlightRequests.delete(cacheKey);
+  }
+}
+
 export async function optimizeImageHandler(req: Request, res: Response) {
   try {
     const params = validateParams(req.query);
     const cacheKey = generateCacheKey(params);
 
-    // Check if we already have this optimized image cached in S3
     const cachedImage = await getCachedImage(cacheKey);
     if (cachedImage) {
-      // Serve the cached image directly
       res.set({
         "Content-Type": cachedImage.contentType,
         "Cache-Control": "public, max-age=31536000", // 1 year
@@ -280,22 +309,11 @@ export async function optimizeImageHandler(req: Request, res: Response) {
       return;
     }
 
-    // Fetch the original image
-    const imageBuffer = await fetchImageBuffer(params.src);
-
-    // Optimize the image
-    const { buffer, contentType } = await optimizeImage(imageBuffer, params);
-
-    // Upload optimized image to S3 for caching (don't wait for it)
-    uploadOptimizedImage(cacheKey, buffer, contentType).catch((error) => {
-      console.error("[IMG-OPTIMIZER] Failed to cache image:", error);
-    });
-
-    // Serve the optimized image directly
+    const { buffer, contentType, coalesced } = await fetchAndOptimizeSingleFlight(cacheKey, params);
     res.set({
       "Content-Type": contentType,
       "Cache-Control": "public, max-age=31536000", // 1 year
-      "X-Cache": "MISS",
+      "X-Cache": coalesced ? "COALESCED" : "MISS",
     });
     res.send(buffer);
   } catch (error) {

--- a/platform/wab/src/wab/server/routes/img-optimizer.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.ts
@@ -19,18 +19,12 @@ const siteAssetsBaseUrl = process.env.SITE_ASSETS_BASE_URL as string;
 // cache key from each spawning independent S3 fetches and Sharp jobs.
 const inFlightRequests = new Map<string, Promise<{ buffer: Buffer; contentType: string }>>();
 
-function createS3Client() {
-  const s3Config: any = {
-    endpoint: process.env.S3_ENDPOINT,
-  };
-
-  // Use path-style URLs only for LocalStack (when endpoint contains localhost)
-  if (process.env.S3_ENDPOINT && process.env.S3_ENDPOINT.includes('localhost')) {
-    s3Config.s3ForcePathStyle = true;
-  }
-
-  return new S3(s3Config);
+const s3Config: any = { endpoint: process.env.S3_ENDPOINT };
+// Use path-style URLs only for LocalStack (when endpoint contains localhost)
+if (process.env.S3_ENDPOINT?.includes("localhost")) {
+  s3Config.s3ForcePathStyle = true;
 }
+const s3 = new S3(s3Config);
 
 function generateCacheKey(params: OptimizeParams): string {
   // Create a deterministic cache key from optimization parameters
@@ -47,9 +41,6 @@ function generateCacheKey(params: OptimizeParams): string {
 
 async function getCachedImage(cacheKey: string): Promise<{ buffer: Buffer; contentType: string } | null> {
   try {
-    const s3 = createS3Client();
-
-    // Try to get the cached optimized image
     const response = await s3
       .getObject({
         Bucket: siteAssetsBucket,
@@ -75,8 +66,6 @@ async function uploadOptimizedImage(
   buffer: Buffer,
   contentType: string
 ): Promise<string> {
-  const s3 = createS3Client();
-
   const { Location } = await s3
     .upload({
       Bucket: siteAssetsBucket,
@@ -176,8 +165,6 @@ async function fetchImageBuffer(url: string): Promise<Buffer> {
   }
 
   try {
-    const s3 = createS3Client();
-
     const result = await s3
       .getObject({
         Bucket: siteAssetsBucket,

--- a/platform/wab/src/wab/server/routes/img-optimizer.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.ts
@@ -9,8 +9,6 @@ import { URL } from "url";
 const MAX_WIDTH = 4096;
 const MAX_HEIGHT = 4096;
 const DEFAULT_QUALITY = 75;
-const SUPPORTED_FORMATS = ["jpeg", "jpg", "png", "webp"] as const;
-type SupportedFormat = (typeof SUPPORTED_FORMATS)[number];
 
 const siteAssetsBucket = process.env.SITE_ASSETS_BUCKET as string;
 const siteAssetsBaseUrl = process.env.SITE_ASSETS_BASE_URL as string;
@@ -19,11 +17,11 @@ const siteAssetsBaseUrl = process.env.SITE_ASSETS_BASE_URL as string;
 // cache key from each spawning independent S3 fetches and Sharp jobs.
 const inFlightRequests = new Map<string, Promise<{ buffer: Buffer; contentType: string }>>();
 
-const s3Config: any = { endpoint: process.env.S3_ENDPOINT };
-// Use path-style URLs only for LocalStack (when endpoint contains localhost)
-if (process.env.S3_ENDPOINT?.includes("localhost")) {
-  s3Config.s3ForcePathStyle = true;
-}
+const s3Config: S3.Types.ClientConfiguration = {
+  endpoint: process.env.S3_ENDPOINT,
+  // Use path-style URLs only for LocalStack (when endpoint contains localhost)
+  ...(process.env.S3_ENDPOINT?.includes("localhost") && { s3ForcePathStyle: true }),
+};
 const s3 = new S3(s3Config);
 
 function generateCacheKey(params: OptimizeParams): string {
@@ -56,7 +54,9 @@ async function getCachedImage(cacheKey: string): Promise<{ buffer: Buffer; conte
     }
     return null;
   } catch (error) {
-    // Object doesn't exist or other error - we'll need to create it
+    if (error.code !== "NoSuchKey" && error.code !== "NotFound") {
+      console.error("[IMG-OPTIMIZER] S3 cache lookup failed:", error);
+    }
     return null;
   }
 }
@@ -225,15 +225,12 @@ async function optimizeImage(
   }
 
   // Apply format transformation
-  let outputFormat: SupportedFormat = "jpeg";
   let contentType = "image/jpeg";
 
   if (format === "webp") {
-    outputFormat = "webp";
     contentType = "image/webp";
     sharpInstance = sharpInstance.webp({ quality });
   } else if (metadata.format === "png") {
-    outputFormat = "png";
     contentType = "image/png";
     sharpInstance = sharpInstance.png({ quality, progressive: true });
   } else {
@@ -313,7 +310,10 @@ export async function optimizeImageHandler(req: Request, res: Response) {
     if (src) {
       try {
         const originalBuffer = await fetchImageBuffer(src as string);
-        const contentType = src.toString().toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg';
+        const srcPath = new URL(src as string).pathname.toLowerCase();
+        const contentType = srcPath.endsWith(".png") ? "image/png"
+          : srcPath.endsWith(".webp") ? "image/webp"
+          : "image/jpeg";
 
         res.set({
           "Content-Type": contentType,


### PR DESCRIPTION
## What does this MR do?

Under thundering herd conditions, N concurrent cold requests for the same image variant each independently fetched the source from S3 and spawned their own Sharp job. This adds per-process single-flight coalescing so only one Sharp job runs per unique `src+w+q+f` combination at a time — subsequent concurrent requests share its result.

## Changes

- Extract `fetchAndOptimizeSingleFlight()` from `optimizeImageHandler` — encapsulates the in-flight Map check, promise registration, fire-and-forget S3 upload, and `finally` cleanup
- Module-level `Map<cacheKey, Promise>` coalesces concurrent work within a single ECS task
- `X-Cache: COALESCED` response header on coalesced responses (observable in perf test output alongside `HIT` / `MISS`)
- Replace per-call `createS3Client()` factory with a module-level S3 singleton — config is static (env vars), no reason to allocate up to 3 clients per cold-miss request
- Type `s3Config` as `S3.Types.ClientConfiguration` instead of `any`
- Log unexpected (non-404) S3 errors in `getCachedImage` instead of silently swallowing them
- Remove dead `outputFormat` variable and now-unused `SupportedFormat` type
- Fix fragile content-type detection in error fallback — use `URL.pathname` to strip query strings and handle `.webp` in addition to `.png`/`.jpeg`
- Unit tests covering: coalesced caller receives correct result, map cleanup on success, map cleanup on failure (dead promise not left in map). Tests use `jest.isolateModules()` so each test loads a fresh module instance with its own S3 singleton constructed against the right mock

## Design decisions

Coalescing is per-process (per ECS task), not distributed. A thundering herd hits one task simultaneously, so per-task coalescing eliminates the duplicate Sharp work without requiring Redis or a distributed lock. Cross-task deduplication is deferred — the S3 cache layer handles the steady-state case once the first task has written the processed variant.

The `finally` block ensures the map key is always removed — including on rejection — so a failing promise never permanently poisons subsequent requests for that variant.

## Testing

\`\`\`bash
npx jest --testPathPattern="img-optimizer.spec" --no-coverage
\`\`\`

Three unit tests for coalescing behaviour:
- Concurrent calls to the same key: first gets `coalesced: false`, second gets `coalesced: true`
- Sequential calls after success: second call is not coalesced (map was cleaned up)
- Sequential calls after failure: retry is not coalesced (dead promise was removed from map)

## Reviewer notes

The check-then-set between `inFlightRequests.has()` and `inFlightRequests.set()` is atomic — Node.js is single-threaded and there is no `await` between those two statements, so no race condition is possible.

Known follow-ups (not in scope here):
- SVGs bypass Sharp but still get uploaded to `img-opt/` cache — wasteful, tracked separately
- `fetchAndOptimizeSingleFlight` is exported for testability — would prefer `@internal` annotation or test via handler