### PR TITLE
feat(ep-commerce): wire `include: ["main_image"]` on catalog-search adapter

### DIFF
--- a/examples/ep-commerce-app-router/package.json
+++ b/examples/ep-commerce-app-router/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@elasticpath/plasmic-ep-commerce-elastic-path": "*",
     "@elasticpath/plasmic-mcp-registry": "*",
-    "@epcc-sdk/sdks-shopper": "^0.0.42",
+    "@epcc-sdk/sdks-shopper": "^0.0.43",
     "@plasmicapp/loader-nextjs": "*",
     "@plasmicapp/nextjs-app-router": "*",
     "@plasmicapp/host": "*",

--- a/plasmicpkgs/commerce-providers/elastic-path/package.json
+++ b/plasmicpkgs/commerce-providers/elastic-path/package.json
@@ -51,8 +51,8 @@
     "swr": ">=1.0.0"
   },
   "dependencies": {
-    "@elasticpath/catalog-search-instantsearch-adapter": "0.0.5",
-    "@epcc-sdk/sdks-shopper": "^0.0.42",
+    "@elasticpath/catalog-search-instantsearch-adapter": "0.1.0",
+    "@epcc-sdk/sdks-shopper": "^0.0.43",
     "@hookform/resolvers": "^3.3.2",
     "@plasmicpkgs/commerce": "0.0.232",
     "@stripe/react-stripe-js": "^2.4.0",

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -255,6 +255,13 @@ function EPCatalogSearchProviderInner(props: {
         additionalSearchParameters: {
           query_by: queryBy,
         },
+        // Inline the product image record onto each hit. Adapter v0.1.0+
+        // forwards this as `?include=main_image` on the catalog-search call
+        // and resolves `relationships.main_image` against the returned
+        // `included` block, so `hit.main_image.link.href` is populated and
+        // EPSearchHits can render real product images without a follow-up
+        // round-trip per hit.
+        include: ["main_image"],
       });
       return adapter.searchClient || adapter;
     } catch (e) {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -78,14 +78,15 @@ function normalizeHitToCurrentProduct(
     hit.attributes?.description ||
     "";
 
-  // Image: try multiple patterns. EP catalog-search hits don't denormalize
-  // file URLs by default (`relationships.main_image.data.id` is just a UUID),
-  // so for unconfigured catalogs imageUrl will be empty.
+  // Image: prefer the inlined `main_image` record that EPCatalogSearchProvider
+  // requests via `include: ["main_image"]` (adapter v0.1.0+ resolves the
+  // included block against each hit's relationship reference). Fallbacks
+  // cover catalogs that already denormalize a URL onto the hit root.
   const imageUrl =
+    hit.main_image?.link?.href ||
+    hit.ep_main_image?.link?.href ||
     hit.ep_main_image_url ||
     hit.main_image_url ||
-    hit.main_image?.link?.href ||
-    (hit.ep_main_image && hit.ep_main_image.link?.href) ||
     "";
 
   // 1x1 transparent gif — keeps the <img src> attribute non-empty so the

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,57 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@better-auth/core@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/core/-/core-1.6.9.tgz#87fcdf90a3969777e05352bc2ad01dc23218b74c"
+  integrity sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.39.0"
+    "@standard-schema/spec" "^1.1.0"
+    zod "^4.3.6"
+
+"@better-auth/drizzle-adapter@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.9.tgz#d3bd50405fdb92209096d4e77ae7b5273380effc"
+  integrity sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==
+
+"@better-auth/kysely-adapter@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/kysely-adapter/-/kysely-adapter-1.6.9.tgz#2770e95d327d66c72e57820143319a7cb023cff2"
+  integrity sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==
+
+"@better-auth/memory-adapter@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/memory-adapter/-/memory-adapter-1.6.9.tgz#6c79585562cc0b980b144cb35702fb7db90341cd"
+  integrity sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==
+
+"@better-auth/mongo-adapter@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/mongo-adapter/-/mongo-adapter-1.6.9.tgz#f83523cd7a25e46ba77554c1378bc7b8e8249381"
+  integrity sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==
+
+"@better-auth/prisma-adapter@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/prisma-adapter/-/prisma-adapter-1.6.9.tgz#17ab5b8f48576328dd7ed71294d750af341f8ba2"
+  integrity sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==
+
+"@better-auth/telemetry@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@better-auth/telemetry/-/telemetry-1.6.9.tgz#7a0df15b44c507597726efb24d71bb2b4e0c38c7"
+  integrity sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==
+
+"@better-auth/utils@0.4.0", "@better-auth/utils@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@better-auth/utils/-/utils-0.4.0.tgz#2616ed771cab97d9047b946c4df47da1d6e05a95"
+  integrity sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==
+  dependencies:
+    "@noble/hashes" "^2.0.1"
+
+"@better-fetch/fetch@1.1.21", "@better-fetch/fetch@^1.1.21":
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/@better-fetch/fetch/-/fetch-1.1.21.tgz#2b4990e73c46b0ae5e66b247083610ff8c37bddc"
+  integrity sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==
+
 "@builder.io/partytown@^0.7.5":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.7.6.tgz#697acea6b552167a4dd43ddd4827018aa42e0364"
@@ -3243,10 +3294,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@elasticpath/catalog-search-instantsearch-adapter@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@elasticpath/catalog-search-instantsearch-adapter/-/catalog-search-instantsearch-adapter-0.0.5.tgz#f6484040a3555f406bf65b3ddc2d1c907b5134c4"
-  integrity sha512-OtObToXekaG2S+jiYO78st8oxpgPMkkPWnXzUPqDXUNgdjcLIQO2KtmOULCn4/xYl9ZMiIZOIUhCG7L8q7rEvg==
+"@elasticpath/catalog-search-instantsearch-adapter@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@elasticpath/catalog-search-instantsearch-adapter/-/catalog-search-instantsearch-adapter-0.1.0.tgz#185b740c2feef75caf34d4813d7bc9b2dbbb8875"
+  integrity sha512-ZXqahz0Mb8J+zE8uj2KrrpNuUAhFW+qfJ1jcrWnmwx6r2CyqWfShjR5MusUolqjI7LVgOWvIeqYTSX+LDTBCkQ==
   dependencies:
     vitest "^3.2.4"
 
@@ -3400,10 +3451,10 @@
   dependencies:
     tslib "^2.5.0"
 
-"@epcc-sdk/sdks-shopper@^0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@epcc-sdk/sdks-shopper/-/sdks-shopper-0.0.42.tgz#f5c9b5a7e0b9230a11e600d115bbe8ed1de2405d"
-  integrity sha512-Z6c7kZkDYSutL0jj3nI5HJlUDOZUhNBzn5zXFA+QYvjzOxYr5p01yBpyvN+GOkdotLJiDdCQHqk87qu3jhgxDg==
+"@epcc-sdk/sdks-shopper@^0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@epcc-sdk/sdks-shopper/-/sdks-shopper-0.0.43.tgz#31341d08d64803df03aaf87a9c67428da8d26e16"
+  integrity sha512-+H9Km6Ec9nrwLxaqEKvwn2ZOQXqnl/9209ybKTsQO28zJFTWXQWYLetNEzd7OlqNU2CfQRi3mFDJJV0QRl8MZQ==
   dependencies:
     "@hey-api/client-fetch" "0.6.0"
 
@@ -6462,6 +6513,16 @@
   dependencies:
     eslint-scope "5.1.1"
 
+"@noble/ciphers@^2.1.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-2.2.0.tgz#84fb45ac9332925d643b80f89ceb0ea2f21dba95"
+  integrity sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==
+
+"@noble/hashes@^2.0.1":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.2.0.tgz#22da1d16a469954fce877055d559900a6c73b63b"
+  integrity sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -6879,6 +6940,11 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
   integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
+"@opentelemetry/semantic-conventions@^1.39.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
+  integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
 "@oxc-resolver/binding-android-arm-eabi@11.9.0":
   version "11.9.0"
@@ -9942,6 +10008,11 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@storybook/addon-actions@8.5.5":
   version "8.5.5"
@@ -13752,6 +13823,39 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
+better-auth@^1.6.9:
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/better-auth/-/better-auth-1.6.9.tgz#fb74209e5ac62bda962edec7d7538b6ae28ab064"
+  integrity sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==
+  dependencies:
+    "@better-auth/core" "1.6.9"
+    "@better-auth/drizzle-adapter" "1.6.9"
+    "@better-auth/kysely-adapter" "1.6.9"
+    "@better-auth/memory-adapter" "1.6.9"
+    "@better-auth/mongo-adapter" "1.6.9"
+    "@better-auth/prisma-adapter" "1.6.9"
+    "@better-auth/telemetry" "1.6.9"
+    "@better-auth/utils" "0.4.0"
+    "@better-fetch/fetch" "1.1.21"
+    "@noble/ciphers" "^2.1.1"
+    "@noble/hashes" "^2.0.1"
+    better-call "1.3.5"
+    defu "^6.1.4"
+    jose "^6.1.3"
+    kysely "^0.28.14"
+    nanostores "^1.1.1"
+    zod "^4.3.6"
+
+better-call@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/better-call/-/better-call-1.3.5.tgz#71ea6a0d939ea030c665ea1b0ddcee06b8e423ac"
+  integrity sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==
+  dependencies:
+    "@better-auth/utils" "^0.4.0"
+    "@better-fetch/fetch" "^1.1.21"
+    rou3 "^0.7.12"
+    set-cookie-parser "^3.0.1"
+
 better-opn@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/better-opn/-/better-opn-2.1.1.tgz#94a55b4695dc79288f31d7d0e5f658320759f7c6"
@@ -16111,6 +16215,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+defu@^6.1.4:
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.7.tgz#72543567c8e9f97ff13ce402b6dbe09ac5ae4d23"
+  integrity sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -22452,6 +22561,11 @@ kuler@^2.0.0:
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
+kysely@^0.28.14:
+  version "0.28.16"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.28.16.tgz#b1c17d8820559f363c1950209851326df4d0befc"
+  integrity sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==
+
 language-subtag-registry@^0.3.20:
   version "0.3.23"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz#23529e04d9e3b74679d70142df3fd2eb6ec572e7"
@@ -23985,6 +24099,11 @@ nanospinner@^1.2.2:
   integrity sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==
   dependencies:
     picocolors "^1.1.1"
+
+nanostores@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/nanostores/-/nanostores-1.3.0.tgz#ceb0a3d8cf9f41207139fa2b9c8f61f65c6a7e2d"
+  integrity sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==
 
 napi-build-utils@^2.0.0:
   version "2.0.0"
@@ -28755,6 +28874,11 @@ rope-sequence@^1.3.0:
   resolved "https://registry.yarnpkg.com/rope-sequence/-/rope-sequence-1.3.4.tgz#df85711aaecd32f1e756f76e43a415171235d425"
   integrity sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==
 
+rou3@^0.7.12:
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/rou3/-/rou3-0.7.12.tgz#cac17425c04abddba854a42385cabfe0b971a179"
+  integrity sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==
+
 router@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
@@ -29161,6 +29285,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
+
+set-cookie-parser@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz#e0b1d94c8660c68e6a24dc4e2b5c9e955ccf7e28"
+  integrity sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -33121,7 +33250,7 @@ zod@^3.22.4, zod@^3.25.0:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4":
+"zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4", zod@^4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## Summary

Closes #301.

Bumps `@elasticpath/catalog-search-instantsearch-adapter` from `0.0.5` → `0.1.0`, which adds end-to-end `?include=` support: hits arrive with the resolved `main_image` record inlined onto each hit (`hit.main_image.link.href`) instead of just a relationship-id reference. `EPCatalogSearchProvider` now opts into that on construction.

This is the consumer half of elasticpath/composable-frontend#517 (adapter PR elasticpath/composable-frontend#518, shipped as `@elasticpath/catalog-search-instantsearch-adapter@0.1.0` on npm).

## Changes

- `plasmicpkgs/commerce-providers/elastic-path/package.json` — bump adapter `0.0.5` → `0.1.0`, bump `@epcc-sdk/sdks-shopper` `^0.0.42` → `^0.0.43` to match the adapter's peer-dep (one SDK version in node_modules → shared `Client` class identity).
- `examples/ep-commerce-app-router/package.json` — same SDK bump for alignment.
- `EPCatalogSearchProvider.tsx` — `include: ["main_image"]` added to the adapter constructor.
- `EPSearchHits.tsx` — fallback chain reordered so the inlined `hit.main_image?.link?.href` is read first, and the now-stale comment ("EP catalog-search hits don't denormalize file URLs") refreshed.
- `yarn.lock` regenerated.

The adapter logs a single `console.warn` per instance if EP returns no `included` block while `include` is configured — quiet signal for misconfigured catalog-search servers without becoming console noise on every search.

## Test plan

- [x] All 1477 jest tests in `plasmicpkgs/commerce-providers/elastic-path/` pass with the bumped deps.
- [x] `yarn build` of the EP commerce package succeeds (clean exit).
- [x] **End-to-end browser verification (the only test that actually proves this works):**
  - Restarted Next dev for `examples/ep-commerce-app-router/` so it picks up the new dist + adapter.
  - Loaded `http://localhost:3456/products` (the Plasmic `ProductList` page).
  - 24 hits visible, **15 rendered real CloudFront URLs** (e.g. `https://d1s4tacif4dym4.cloudfront.net/.../21fd36df-7fd4-4617-89ff-36792d1c91a3.jpg`, `naturalWidth: 4460`); the remaining 9 fell back to the transparent-pixel placeholder, which is correct for products that have no `main_image` attached in the catalog.
  - Zero `console.warn`s — confirms EP is honouring the `?include=main_image` query param.
  - Screenshot of a tag-filtered result showing a real product image: see `search-page-real-images.png` (attached locally; not committed).