### PR TITLE
[#20] feat(img-optimizer): add immutable to Cache-Control on processed image responses

### DIFF
--- a/platform/wab/src/wab/server/routes/img-optimizer.ts
+++ b/platform/wab/src/wab/server/routes/img-optimizer.ts
@@ -286,7 +286,7 @@ export async function optimizeImageHandler(req: Request, res: Response) {
     if (cachedImage) {
       res.set({
         "Content-Type": cachedImage.contentType,
-        "Cache-Control": "public, max-age=31536000", // 1 year
+        "Cache-Control": "public, max-age=31536000, immutable",
         "X-Cache": "HIT",
       });
       res.send(cachedImage.buffer);
@@ -296,7 +296,7 @@ export async function optimizeImageHandler(req: Request, res: Response) {
     const { buffer, contentType, coalesced } = await fetchAndOptimizeSingleFlight(cacheKey, params);
     res.set({
       "Content-Type": contentType,
-      "Cache-Control": "public, max-age=31536000", // 1 year
+      "Cache-Control": "public, max-age=31536000, immutable",
       "X-Cache": coalesced ? "COALESCED" : "MISS",
     });
     res.send(buffer);


### PR DESCRIPTION
## What does this MR do?

Adds `immutable` to the `Cache-Control` header on all successful processed image responses.

Closes #20 (item 3 — CloudFront TTL on processed variants)

## Changes

```
// before
Cache-Control: public, max-age=31536000

// after
Cache-Control: public, max-age=31536000, immutable
```

Applied to HIT, MISS, and COALESCED response paths. The error fallback path remains at `max-age=300` with no `immutable` (correct — error responses are not content-addressed).

## Why immutable is correct here

Processed variants are deterministic: the same `src+w+q+f` combination always produces the same bytes. `immutable` tells browsers not to issue conditional revalidation requests (`If-None-Match`, `If-Modified-Since`) during the max-age window. Without it, browsers will check for updates on every navigation even though the content can never change. With it, those round-trips are eliminated entirely for the 1-year cache window.

## CloudFront context

The CloudFront distribution already has `max_ttl = 31536000` and a cache policy that keys on all query strings — so CloudFront-level caching is already correct. This change is purely about browser-level caching behaviour.

## Reviewer notes

No test changes needed — this is a header value change with no logic impact.