### PR TITLE
feat(ep-commerce): headless styling contract + EPSearchBox provider refactor (#305, #308)

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/README.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/README.md
@@ -458,3 +458,120 @@ Then bind the `EPProductProvider` component's advanced `product` prop to `$q.pro
 - **EPSearchBox** / **EPSearchHits** / **EPSearchPagination** — Search UI
 - **EPRefinementList** / **EPHierarchicalMenu** / **EPRangeFilter** — Faceted filtering
 - **EPSearchStats** / **EPSearchSortBy** — Search metadata
+
+## Styling contract (catalog-search components)
+
+The catalog-search components ship behaviour, not appearance. Every visual
+choice — typography, colour, spacing, borders, focus state — is the
+designer's. The components do not impose a default look that the designer
+later has to override.
+
+The contract that every catalog-search component honours:
+
+1. **`className` lands on the visible interactive element.** The Plasmic
+   style panel binds to a single class per component instance. We forward
+   that class to the element designers actually want to style:
+
+   | Component | Element that receives `className` |
+   | --- | --- |
+   | `EPSearchBox` | n/a — provider only, no DOM (see below) |
+   | `EPCatalogSearchProvider` | the wrapper `<div data-ep-catalog-search-provider>` |
+   | `EPSearchHits` | the grid `<div data-ep-search-hits>` |
+   | `EPRefinementList` | the wrapper `<div data-ep-refinement-list>` |
+   | `EPHierarchicalMenu` | the wrapper `<div data-ep-hierarchical-menu>` |
+   | `EPRangeFilter` | the wrapper `<div data-ep-range-filter>` |
+   | `EPSearchPagination` | the wrapper `<div data-ep-search-pagination>` |
+   | `EPSearchStats` | the wrapper `<div data-ep-search-stats>` |
+   | `EPSearchSortBy` | the wrapper `<div data-ep-search-sort-by>` |
+
+2. **No inline `style` for appearance properties.** The components never set
+   `border`, `border-radius`, `padding`, `font-*`, `color`, `background`, or
+   `box-shadow` inline. CSS specificity goes class-wins-over-element, so
+   designer styles always reach the rendered DOM.
+
+3. **Inline `style` is permitted only for layout properties Plasmic strips.**
+   Plasmic's canvas filters out `display`/`grid-*`/`flex-*` styles set on a
+   code-component instance. `EPSearchHits` works around this by setting its
+   grid layout inline, and exposing the values as `gridTemplateColumns` /
+   `gridGap` props so designers can still control them.
+
+4. **The editor and the runtime render the same DOM.** No mock-only inline
+   styling that lies about runtime output — what the designer sees in the
+   Plasmic canvas is what the live site renders. Test coverage in
+   `__tests__/catalog-search-components.test.tsx` enforces this.
+
+### Structural CSS via `:where()`
+
+The components do need a small amount of structural CSS — for example,
+`position: relative` on the EPSearchBox wrapper so its absolute-positioned
+clear button can anchor. We ship that CSS once per page from
+`headless-styling.ts`, scoped via `:where()` so every selector has zero
+specificity and any designer class always wins.
+
+If you add a new catalog-search component, follow the same pattern:
+
+```tsx
+import { useHeadlessStyling } from "./headless-styling";
+
+export function EPNewSearchComponent({ className, ...props }) {
+  useHeadlessStyling();
+  return <div className={className} data-ep-new-search-component="">…</div>;
+}
+```
+
+Then add a contract test alongside the existing nine in
+`__tests__/catalog-search-components.test.tsx` via `describeHeadlessStylingContract`.
+The helper asserts (a) the className lands on the documented leaf, (b) no
+inline appearance styles are set anywhere in the rendered tree, and (c) the
+editor and runtime renders produce the same root tag.
+
+### Composing EPSearchBox
+
+`EPSearchBox` is a provider, not a renderer. It exposes search-field state
+to its slot children and otherwise renders nothing. The visible chrome —
+the `<input>`, the clear `<button>` — is owned by the designer. Drop a
+Plasmic-controlled input and button into the slot and wire them via
+`$ctx.searchFieldData` and the registered ref-actions.
+
+| What `EPSearchBox` exposes | Type | Use it for |
+| --- | --- | --- |
+| `$ctx.searchFieldData.value` | `string` | the controlled value of the input element |
+| `$ctx.searchFieldData.displayValue` | `string` | the query that has actually been refined (diverges from `value` during the debounce window) |
+| `$ctx.searchFieldData.isEmpty` | `boolean` | hide the clear button when nothing is typed |
+| `setValue(value: string)` ref-action | | call from the input's `onChange` interaction |
+| `clear()` ref-action | | call from the clear button's `onClick` interaction |
+
+Wiring a fresh EPSearchBox in Plasmic Studio:
+
+1. Drop an `<input>` (Plasmic's built-in tag, **not** a code component) into
+   the EPSearchBox slot. Style it freely from the style panel — appearance
+   reaches the live site because the input is a Plasmic-controlled tag.
+2. Set the input's `value` attribute to a dynamic value: `$ctx.searchFieldData.value`.
+3. Add an `onChange` interaction → custom function: `EP_SEARCH_BOX_REF.setValue(event.target.value)`,
+   where `EP_SEARCH_BOX_REF` is the ref to the parent EPSearchBox instance.
+4. Drop a `<button>` (also a Plasmic-controlled tag) for clear. Style it
+   freely.
+5. Add the button's `onClick` → custom function: `EP_SEARCH_BOX_REF.clear()`.
+6. Bind the button's visibility to `!$ctx.searchFieldData.isEmpty` so it
+   only shows when there's something to clear.
+
+Why this composition: Plasmic's codegen filters appearance styles
+(`padding`, `border`, `background`, `font-*`, `color`, `border-radius`,
+`box-shadow`) off any code-component instance — only the Plasmic-controlled
+tags (`input`, `button`, `div`, etc.) escape the filter. By making
+EPSearchBox a render-children-only provider, the visible chrome is owned
+by tags the designer fully controls. See PRD #308 for the long-form
+rationale.
+
+### Migration notes
+
+Before this contract was in place, `EPSearchBox` and `EPCatalogSearchProvider`
+shipped polished default styles inline. Designers who relied on those
+defaults will need to re-style the component from the Plasmic style panel
+after upgrading. The defaults were misleading — they appeared in the canvas
+preview but only some applied at runtime — so a clean reset is healthier
+than continuing to ship the lie.
+
+PRD #308 also moved EPSearchBox from a chrome-rendering component to a
+provider. Existing EPSearchBox instances will lose their input and clear
+button; re-author the slot per the wiring steps above.

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -21,18 +21,9 @@ import { DEFAULT_CURRENCY_CODE } from "../const";
 import { getEPClient } from "../utils/getEPClient";
 import { MOCK_CATALOG_SEARCH_DATA } from "./design-time-data";
 import type { CatalogSearchData } from "./design-time-data";
+import { useHeadlessStyling } from "./headless-styling";
 
 type PreviewState = "auto" | "withData" | "loading" | "empty" | "error";
-
-// Defensive default — Plasmic strips display/grid styles from code component
-// instances, and centered flex-column page shells (the most common Plasmic
-// layout) collapse children to content-width unless the child explicitly
-// stretches. Without this, the entire catalog-search subtree renders at
-// max-content width regardless of how the surrounding page is configured.
-const DEFAULT_PROVIDER_WRAPPER_STYLE: React.CSSProperties = {
-  width: "100%",
-  alignSelf: "stretch",
-};
 
 interface EPCatalogSearchProviderProps {
   children?: React.ReactNode;
@@ -135,6 +126,8 @@ export const epCatalogSearchProviderMeta: CodeComponentMeta<EPCatalogSearchProvi
   };
 
 export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
+  useHeadlessStyling();
+
   const {
     children,
     errorContent,
@@ -153,14 +146,14 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
   if (inEditor) {
     if (previewState === "loading") {
       return (
-        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+        <div className={className} data-ep-catalog-search-provider="">
           Loading...
         </div>
       );
     }
     if (previewState === "error") {
       return (
-        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+        <div className={className} data-ep-catalog-search-provider="">
           {errorContent}
         </div>
       );
@@ -175,7 +168,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
             query: "",
           }}
         >
-          <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+          <div className={className} data-ep-catalog-search-provider="">
             {children}
           </div>
         </DataProvider>
@@ -189,7 +182,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
   if (useMock) {
     return (
       <DataProvider name="catalogSearchData" data={MOCK_CATALOG_SEARCH_DATA}>
-        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+        <div className={className} data-ep-catalog-search-provider="">
           {children}
         </div>
       </DataProvider>
@@ -275,7 +268,7 @@ function EPCatalogSearchProviderInner(props: {
 
   if (!searchClient) {
     return (
-      <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+      <div className={className} data-ep-catalog-search-provider="">
         {errorContent || (
           <div>
             Catalog Search is not available. Ensure the adapter is installed and
@@ -303,7 +296,7 @@ function EPCatalogSearchProviderInner(props: {
     >
       <Configure hitsPerPage={hitsPerPage} />
       <DataProvider name="catalogSearchData" data={catalogSearchData}>
-        <div className={className} style={DEFAULT_PROVIDER_WRAPPER_STYLE} data-ep-catalog-search-provider="">
+        <div className={className} data-ep-catalog-search-provider="">
           {children}
         </div>
       </DataProvider>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
@@ -1,94 +1,88 @@
 /**
- * EPSearchBox — debounced search input for catalog search.
+ * EPSearchBox — provider for catalog-search field state.
  *
- * Wraps `useSearchBox()` from react-instantsearch. At design time, renders
- * a static input with mock placeholder for visual editing.
+ * Renders no DOM. Wraps `useSearchBox()` from react-instantsearch and
+ * exposes `searchFieldData` ({ value, displayValue, isEmpty }) via
+ * DataProvider plus `setValue`/`clear` ref-actions.
+ *
+ * The visible chrome (input, clear button) is owned by the designer —
+ * they drop Plasmic-controlled `<input>` and `<button>` elements into
+ * this component's slot and bind them via `$ctx.searchFieldData` and
+ * the registered ref-actions. See PRD #308 for the full rationale.
  */
 
-import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import { DataProvider, usePlasmicCanvasContext } from "@plasmicapp/host";
 import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { Registerable } from "../registerable";
+import { MOCK_SEARCH_FIELD_DATA } from "./design-time-data";
+import type { SearchFieldData } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
 
-const DEFAULT_SEARCH_BOX_WRAPPER_STYLE: React.CSSProperties = {
-  position: "relative",
-  width: "100%",
-  alignSelf: "stretch",
-  display: "flex",
-  alignItems: "center",
-};
-
-const DEFAULT_SEARCH_BOX_INPUT_STYLE: React.CSSProperties = {
-  width: "100%",
-  height: "44px",
-  padding: "0 44px 0 16px",
-  border: "1px solid #e7e5e4",
-  borderRadius: "8px",
-  backgroundColor: "#ffffff",
-  fontSize: "14px",
-  color: "#1c1917",
-  outline: "none",
-  fontFamily: "inherit",
-};
-
-const DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE: React.CSSProperties = {
-  position: "absolute",
-  right: "8px",
-  top: "50%",
-  transform: "translateY(-50%)",
-  width: "28px",
-  height: "28px",
-  border: "none",
-  borderRadius: "6px",
-  backgroundColor: "transparent",
-  color: "#a8a29e",
-  cursor: "pointer",
-  fontSize: "18px",
-  lineHeight: "1",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-};
-
 interface EPSearchBoxProps {
-  className?: string;
-  placeholder?: string;
-  autoFocus?: boolean;
+  children?: React.ReactNode;
   debounceMs?: number;
-  showClear?: boolean;
   previewState?: PreviewState;
+  /**
+   * @deprecated Pre-PRD #308 prop. The new EPSearchBox is a provider with
+   * no DOM, so this value has no effect. Set the placeholder on the
+   * Plasmic input you drop into the slot. Kept here so existing project
+   * bundles stay valid against the registered metadata.
+   */
+  placeholder?: string;
+  /** @deprecated See `placeholder`. Set autoFocus on the slot's input. */
+  autoFocus?: boolean;
+  /** @deprecated See `placeholder`. Toggle visibility on the slot's clear button. */
+  showClear?: boolean;
+}
+
+interface EPSearchBoxActions {
+  setValue(value: string): void;
+  clear(): void;
 }
 
 export const epSearchBoxMeta: CodeComponentMeta<EPSearchBoxProps> = {
   name: "plasmic-commerce-ep-search-box",
   displayName: "EP Search Box",
   description:
-    "Search input with debounce for catalog search. Must be inside EP Catalog Search Provider.",
+    "Search field provider. Drops a Plasmic input and clear button into the slot, bind them to $ctx.searchFieldData (value, displayValue, isEmpty) and the setValue/clear ref-actions. Must be inside EP Catalog Search Provider.",
   props: {
-    placeholder: {
-      type: "string",
-      defaultValue: "Search products...",
-      displayName: "Placeholder",
-    },
-    autoFocus: {
-      type: "boolean",
-      defaultValue: false,
-      displayName: "Auto Focus",
+    children: {
+      type: "slot",
+      defaultValue: [
+        {
+          type: "vbox",
+          styles: { width: "100%" },
+          children: [
+            {
+              type: "input",
+              attrs: {
+                type: "search",
+                placeholder: "Search products...",
+              },
+            },
+            {
+              type: "button",
+              value: "Clear",
+            },
+          ],
+        },
+      ],
     },
     debounceMs: {
       type: "number",
       defaultValue: 300,
       displayName: "Debounce (ms)",
-      description: "Milliseconds to wait before triggering search",
-    },
-    showClear: {
-      type: "boolean",
-      defaultValue: true,
-      displayName: "Show Clear Button",
+      description: "Milliseconds to wait before refining the search",
     },
     previewState: {
       type: "choice",
@@ -97,21 +91,47 @@ export const epSearchBoxMeta: CodeComponentMeta<EPSearchBoxProps> = {
       displayName: "Preview State",
       advanced: true,
     },
-  },
+    // Deprecated — pre-PRD #308 props preserved so existing project bundles
+    // referencing these names stay valid against the new metadata. They have
+    // no runtime effect; set placeholder/autofocus/showclear on the Plasmic
+    // input or button you drop into the slot.
+    placeholder: {
+      type: "string",
+      advanced: true,
+      hidden: () => true,
+    },
+    autoFocus: {
+      type: "boolean",
+      advanced: true,
+      hidden: () => true,
+    },
+    showClear: {
+      type: "boolean",
+      advanced: true,
+      hidden: () => true,
+    },
+  } as any,
   importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
   importName: "EPSearchBox",
   parentComponentName: "plasmic-commerce-ep-catalog-search-provider",
+  providesData: true,
+  refActions: {
+    setValue: {
+      description: "Update the search field value",
+      argTypes: [{ name: "value", type: "string" }],
+    },
+    clear: {
+      description: "Clear the search field",
+      argTypes: [],
+    },
+  },
 };
 
-export function EPSearchBox(props: EPSearchBoxProps) {
-  const {
-    className,
-    placeholder = "Search products...",
-    autoFocus = false,
-    debounceMs = 300,
-    showClear = true,
-    previewState = "auto",
-  } = props;
+export const EPSearchBox = React.forwardRef<
+  EPSearchBoxActions,
+  EPSearchBoxProps
+>(function EPSearchBox(props, ref) {
+  const { children, debounceMs = 300, previewState = "auto" } = props;
 
   const inEditor = !!usePlasmicCanvasContext();
   const useMock =
@@ -119,112 +139,96 @@ export function EPSearchBox(props: EPSearchBoxProps) {
 
   if (useMock) {
     return (
-      <div className={className} data-ep-search-box="" style={DEFAULT_SEARCH_BOX_WRAPPER_STYLE}>
-        <input
-          type="search"
-          placeholder={placeholder}
-          autoFocus={autoFocus}
-          defaultValue="leather"
-          readOnly
-          style={DEFAULT_SEARCH_BOX_INPUT_STYLE}
-        />
-        {showClear && (
-          <button
-            type="button"
-            aria-label="Clear search"
-            style={DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE}
-          >
-            &times;
-          </button>
-        )}
-      </div>
+      <MockSearchBox ref={ref}>
+        {children}
+      </MockSearchBox>
     );
   }
 
   return (
-    <EPSearchBoxInner
-      className={className}
-      placeholder={placeholder}
-      autoFocus={autoFocus}
-      debounceMs={debounceMs}
-      showClear={showClear}
-    />
+    <EPSearchBoxInner ref={ref} debounceMs={debounceMs}>
+      {children}
+    </EPSearchBoxInner>
   );
-}
+});
 
-function EPSearchBoxInner(props: {
-  className?: string;
-  placeholder: string;
-  autoFocus: boolean;
-  debounceMs: number;
-  showClear: boolean;
-}) {
-  const { className, placeholder, autoFocus, debounceMs, showClear } = props;
+const MockSearchBox = React.forwardRef<
+  EPSearchBoxActions,
+  { children?: React.ReactNode }
+>(function MockSearchBox({ children }, ref) {
+  useImperativeHandle(ref, () => ({
+    setValue: () => {},
+    clear: () => {},
+  }));
 
-  // Import useSearchBox at runtime — requires InstantSearch context
+  return (
+    <DataProvider name="searchFieldData" data={MOCK_SEARCH_FIELD_DATA}>
+      {children}
+    </DataProvider>
+  );
+});
+
+const EPSearchBoxInner = React.forwardRef<
+  EPSearchBoxActions,
+  { children?: React.ReactNode; debounceMs: number }
+>(function EPSearchBoxInner({ children, debounceMs }, ref) {
   const { useSearchBox } = require("react-instantsearch");
-  const { query, refine, clear } = useSearchBox();
+  const { query: refinedQuery, refine, clear: refineClear } = useSearchBox();
 
-  const [inputValue, setInputValue] = useState(query);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [value, setValueState] = useState(refinedQuery ?? "");
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Sync external query changes to input
-  useEffect(() => {
-    setInputValue(query);
-  }, [query]);
-
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      setInputValue(value);
-
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
+  const scheduleRefine = useCallback(
+    (next: string) => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
       }
-      timerRef.current = setTimeout(() => {
-        refine(value);
+      debounceTimer.current = setTimeout(() => {
+        refine(next);
       }, debounceMs);
     },
-    [refine, debounceMs]
+    [debounceMs, refine]
   );
 
-  const handleClear = useCallback(() => {
-    setInputValue("");
-    clear();
-  }, [clear]);
-
-  // Cleanup timer on unmount
   useEffect(() => {
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
       }
     };
   }, []);
 
-  return (
-    <div className={className} data-ep-search-box="" style={DEFAULT_SEARCH_BOX_WRAPPER_STYLE}>
-      <input
-        type="search"
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-        value={inputValue}
-        onChange={handleChange}
-        style={{ width: "100%" }}
-      />
-      {showClear && inputValue && (
-        <button
-          type="button"
-          aria-label="Clear search"
-          onClick={handleClear}
-          style={DEFAULT_SEARCH_BOX_CLEAR_BUTTON_STYLE}
-        >
-          &times;
-        </button>
-      )}
-    </div>
+  useImperativeHandle(
+    ref,
+    () => ({
+      setValue: (next: string) => {
+        setValueState(next);
+        scheduleRefine(next);
+      },
+      clear: () => {
+        if (debounceTimer.current) {
+          clearTimeout(debounceTimer.current);
+          debounceTimer.current = null;
+        }
+        setValueState("");
+        refineClear();
+      },
+    }),
+    [scheduleRefine, refineClear]
   );
-}
+
+  const data: SearchFieldData = {
+    value,
+    displayValue: refinedQuery ?? "",
+    isEmpty: value.length === 0,
+  };
+
+  return (
+    <DataProvider name="searchFieldData" data={data}>
+      {children}
+    </DataProvider>
+  );
+});
 
 export function registerEPSearchBox(
   loader?: Registerable,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -292,6 +292,7 @@ function MockSearchHits(props: {
       className={className}
       role="list"
       aria-label="Search results"
+      data-ep-search-hits=""
       style={gridStyle}
     >
       {products.map((product, i) => (
@@ -339,6 +340,7 @@ function EPSearchHitsInner(props: {
       className={className}
       role="list"
       aria-label="Search results"
+      data-ep-search-hits=""
       style={gridStyle}
     >
       {normalizedProducts.map(

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
@@ -153,6 +153,15 @@ jest.mock("@elasticpath/catalog-search-instantsearch-adapter", () => ({
 
 /* ---------- code under test (after mocks) ---------- */
 import { render } from "@testing-library/react";
+import { describeHeadlessStylingContract } from "./headless-styling-contract";
+
+function setEditorMode(inEditor: boolean) {
+  if (inEditor) {
+    mockUsePlasmicCanvasContext.mockReturnValue({});
+  } else {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+  }
+}
 
 const {
   MOCK_SEARCH_PRODUCTS,
@@ -388,7 +397,7 @@ describe("EPCatalogSearchProvider", () => {
 });
 
 /* ================================================================
- * EPSearchBox tests
+ * EPSearchBox tests — provider with no DOM (PRD #308)
  * ================================================================ */
 describe("EPSearchBox", () => {
   beforeEach(() => {
@@ -396,40 +405,237 @@ describe("EPSearchBox", () => {
     mockUsePlasmicCanvasContext.mockReturnValue(null);
   });
 
-  it("should render mock search box in editor", () => {
+  it("provides searchFieldData with mock shape in editor", () => {
     mockUsePlasmicCanvasContext.mockReturnValue({});
 
     const { container } = render(
-      <EPSearchBox placeholder="Search..." />
+      <EPSearchBox>
+        <div>child</div>
+      </EPSearchBox>
     );
 
-    const input = container.querySelector("input");
-    expect(input).not.toBeNull();
-    expect(input!.getAttribute("placeholder")).toBe("Search...");
-    expect(input!.defaultValue).toBe("leather");
+    const provider = container.querySelector(
+      '[data-testid="data-provider-searchFieldData"]'
+    );
+    expect(provider).not.toBeNull();
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("leather");
+    expect(data.displayValue).toBe("leather");
+    expect(data.isEmpty).toBe(false);
   });
 
-  it("should render clear button in editor when showClear=true", () => {
+  it("does not render mock chrome (no input or button in DOM) in editor", () => {
     mockUsePlasmicCanvasContext.mockReturnValue({});
 
     const { container } = render(
-      <EPSearchBox showClear={true} />
+      <EPSearchBox>
+        <div data-testid="user-content">user content</div>
+      </EPSearchBox>
     );
 
-    const clearButton = container.querySelector("button");
-    expect(clearButton).not.toBeNull();
+    expect(container.querySelector("input")).toBeNull();
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector('[data-testid="user-content"]')).not.toBeNull();
   });
 
-  it("should not render clear button when showClear=false", () => {
-    mockUsePlasmicCanvasContext.mockReturnValue({});
+  it("setValue ref-action updates searchFieldData.value at runtime", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    mockUseSearchBox.mockReturnValue({
+      query: "",
+      refine: jest.fn(),
+      clear: jest.fn(),
+    });
+
+    const ref = React.createRef<{
+      setValue: (v: string) => void;
+      clear: () => void;
+    }>();
+
+    const { container, rerender } = render(
+      <EPSearchBox ref={ref}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    require("react-dom/test-utils").act(() => {
+      ref.current!.setValue("boots");
+    });
+
+    rerender(
+      <EPSearchBox ref={ref}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    const provider = container.querySelector(
+      '[data-testid="data-provider-searchFieldData"]'
+    );
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("boots");
+    expect(data.isEmpty).toBe(false);
+  });
+
+  it("setValue debounces refine() by debounceMs", () => {
+    jest.useFakeTimers();
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    const refine = jest.fn();
+    mockUseSearchBox.mockReturnValue({
+      query: "",
+      refine,
+      clear: jest.fn(),
+    });
+
+    const ref = React.createRef<{
+      setValue: (v: string) => void;
+      clear: () => void;
+    }>();
+
+    render(
+      <EPSearchBox ref={ref} debounceMs={250}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    require("react-dom/test-utils").act(() => {
+      ref.current!.setValue("hat");
+    });
+
+    expect(refine).not.toHaveBeenCalled();
+
+    require("react-dom/test-utils").act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith("hat");
+
+    jest.useRealTimers();
+  });
+
+  it("clear ref-action resets value and calls useSearchBox().clear()", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    const refine = jest.fn();
+    const clear = jest.fn();
+    mockUseSearchBox.mockReturnValue({
+      query: "boots",
+      refine,
+      clear,
+    });
+
+    const ref = React.createRef<{
+      setValue: (v: string) => void;
+      clear: () => void;
+    }>();
+
+    const { container, rerender } = render(
+      <EPSearchBox ref={ref}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    require("react-dom/test-utils").act(() => {
+      ref.current!.setValue("boots");
+    });
+
+    require("react-dom/test-utils").act(() => {
+      ref.current!.clear();
+    });
+
+    rerender(
+      <EPSearchBox ref={ref}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    const provider = container.querySelector(
+      '[data-testid="data-provider-searchFieldData"]'
+    );
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("");
+    expect(data.isEmpty).toBe(true);
+  });
+
+  it("displayValue reflects the refined query (diverges from in-flight value during debounce)", () => {
+    jest.useFakeTimers();
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    mockUseSearchBox.mockReturnValue({
+      query: "leather",
+      refine: jest.fn(),
+      clear: jest.fn(),
+    });
+
+    const ref = React.createRef<{
+      setValue: (v: string) => void;
+      clear: () => void;
+    }>();
+
+    const { container, rerender } = render(
+      <EPSearchBox ref={ref} debounceMs={250}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    // User typed but debounce hasn't fired yet — displayValue still equals the
+    // last refined query, value reflects the new keystroke.
+    require("react-dom/test-utils").act(() => {
+      ref.current!.setValue("leath");
+    });
+
+    rerender(
+      <EPSearchBox ref={ref} debounceMs={250}>
+        <div>child</div>
+      </EPSearchBox>
+    );
+
+    const provider = container.querySelector(
+      '[data-testid="data-provider-searchFieldData"]'
+    );
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("leath");
+    expect(data.displayValue).toBe("leather");
+
+    jest.useRealTimers();
+  });
+
+  it("previewState='withData' forces mock outside the editor", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
 
     const { container } = render(
-      <EPSearchBox showClear={false} />
+      <EPSearchBox previewState="withData">
+        <div>child</div>
+      </EPSearchBox>
     );
 
-    const clearButton = container.querySelector("button");
-    expect(clearButton).toBeNull();
+    const provider = container.querySelector(
+      '[data-testid="data-provider-searchFieldData"]'
+    );
+    expect(provider).not.toBeNull();
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("leather");
   });
+
+  it("meta exposes setValue and clear refActions and providesData", () => {
+    expect(epSearchBoxMeta.providesData).toBe(true);
+    expect(epSearchBoxMeta.refActions!.setValue).toBeDefined();
+    expect(epSearchBoxMeta.refActions!.setValue.argTypes).toEqual([
+      { name: "value", type: "string" },
+    ]);
+    expect(epSearchBoxMeta.refActions!.clear).toBeDefined();
+    expect(epSearchBoxMeta.refActions!.clear.argTypes).toEqual([]);
+  });
+
 });
 
 /* ================================================================
@@ -900,4 +1106,178 @@ describe("component registration", () => {
     );
     expect(epSearchSortByMeta.refActions!.setSort).toBeDefined();
   });
+});
+
+/* ================================================================
+ * Headless styling contract — applied to every catalog-search component.
+ * ================================================================ */
+
+describeHeadlessStylingContract({
+  componentName: "EPCatalogSearchProvider",
+  leafSelector: "[data-ep-catalog-search-provider]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPCatalogSearchProvider className={className}>
+      <div>child</div>
+    </EPCatalogSearchProvider>
+  ),
+  renderAtRuntime: ({ className }) => {
+    setupCommerce();
+    return (
+      <EPCatalogSearchProvider className={className}>
+        <div>child</div>
+      </EPCatalogSearchProvider>
+    );
+  },
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchHits",
+  leafSelector: "[data-ep-search-hits]",
+  setEditorMode,
+  // gridStyle is the documented layout-property workaround for Plasmic's
+  // className-strip on display/grid CSS (see EPSearchHits.tsx). The contract
+  // already permits inline layout properties; appearance properties are
+  // checked. No allow-list entry is needed because nothing in the allow-list
+  // list (border, font, color, background) is set inline by EPSearchHits.
+  renderInEditor: ({ className }) => (
+    <EPSearchHits className={className}>
+      <div>card</div>
+    </EPSearchHits>
+  ),
+  renderAtRuntime: ({ className }) => {
+    mockUseHits.mockReturnValue({
+      hits: [
+        {
+          objectID: "ep-test-hit-1",
+          ep_name: "Test Product",
+          ep_slug: "test-product",
+          ep_price: { USD: { float_price: 9.99 } },
+        },
+      ],
+    });
+    return (
+      <EPSearchHits className={className}>
+        <div>card</div>
+      </EPSearchHits>
+    );
+  },
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPRefinementList",
+  leafSelector: "[data-ep-refinement-list]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPRefinementList attribute="brand" className={className}>
+      <div>row</div>
+    </EPRefinementList>
+  ),
+  renderAtRuntime: ({ className }) => {
+    mockUseRefinementList.mockReturnValue({
+      items: [
+        { value: "acme", label: "Acme", count: 3, isRefined: false },
+      ],
+      refine: jest.fn(),
+    });
+    return (
+      <EPRefinementList attribute="brand" className={className}>
+        <div>row</div>
+      </EPRefinementList>
+    );
+  },
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPHierarchicalMenu",
+  leafSelector: "[data-ep-hierarchical-menu]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPHierarchicalMenu className={className}>
+      <div>row</div>
+    </EPHierarchicalMenu>
+  ),
+  renderAtRuntime: ({ className }) => {
+    mockUseHierarchicalMenu.mockReturnValue({
+      items: [
+        {
+          value: "boots",
+          label: "Boots",
+          count: 5,
+          isRefined: false,
+          data: [],
+        },
+      ],
+      refine: jest.fn(),
+    });
+    return (
+      <EPHierarchicalMenu className={className}>
+        <div>row</div>
+      </EPHierarchicalMenu>
+    );
+  },
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPRangeFilter",
+  leafSelector: "[data-ep-range-filter]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPRangeFilter attribute="price.USD.float_price" className={className}>
+      <div>range</div>
+    </EPRangeFilter>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPRangeFilter attribute="price.USD.float_price" className={className}>
+      <div>range</div>
+    </EPRangeFilter>
+  ),
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchPagination",
+  leafSelector: "[data-ep-search-pagination]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchPagination className={className}>
+      <div>page</div>
+    </EPSearchPagination>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPSearchPagination className={className}>
+      <div>page</div>
+    </EPSearchPagination>
+  ),
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchStats",
+  leafSelector: "[data-ep-search-stats]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchStats className={className}>
+      <div>stats</div>
+    </EPSearchStats>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPSearchStats className={className}>
+      <div>stats</div>
+    </EPSearchStats>
+  ),
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchSortBy",
+  leafSelector: "[data-ep-search-sort-by]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchSortBy className={className}>
+      <div>sort</div>
+    </EPSearchSortBy>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPSearchSortBy className={className}>
+      <div>sort</div>
+    </EPSearchSortBy>
+  ),
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/headless-styling-contract.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/headless-styling-contract.tsx
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Shared assertions for the EP catalog-search headless styling contract.
+ *
+ * The contract:
+ *   1. The Plasmic-supplied `className` is forwarded to the documented leaf
+ *      element (the visible interactive element the component represents).
+ *   2. No element in the rendered tree has inline `style` properties for
+ *      appearance (border, radius, padding, font, color, background).
+ *   3. The editor render and the runtime render produce the same DOM tree
+ *      shape given equivalent context. (Optional per-component; some
+ *      components have runtime branches that only render with non-empty
+ *      hooks.)
+ *
+ * Layout properties that Plasmic strips from code-component classNames
+ * (display, grid-*, flex-*, gap, width, height, align-*, position) are
+ * permitted as inline styles on a per-component basis via the allow-list.
+ */
+
+import { render } from "@testing-library/react";
+import React from "react";
+
+const APPEARANCE_PROPERTIES = [
+  "border",
+  "borderTop",
+  "borderRight",
+  "borderBottom",
+  "borderLeft",
+  "borderColor",
+  "borderTopColor",
+  "borderRightColor",
+  "borderBottomColor",
+  "borderLeftColor",
+  "borderStyle",
+  "borderWidth",
+  "borderRadius",
+  "borderTopLeftRadius",
+  "borderTopRightRadius",
+  "borderBottomLeftRadius",
+  "borderBottomRightRadius",
+  "color",
+  "backgroundColor",
+  "background",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "lineHeight",
+  "letterSpacing",
+  "textTransform",
+  "textDecoration",
+  "boxShadow",
+] as const;
+
+interface ContractAssertion {
+  componentName: string;
+  /** querySelector that locates the leaf element which should receive className */
+  leafSelector: string;
+  /**
+   * Render a JSX tree containing the component, optionally accepting a
+   * className override.
+   */
+  renderInEditor: (extraProps: { className?: string }) => React.ReactElement;
+  /**
+   * Render the same JSX with the editor context turned off. Some components
+   * cannot be rendered at runtime in jsdom without setup work; in that case
+   * pass `null` and the editor==runtime check is skipped.
+   */
+  renderAtRuntime?: (extraProps: { className?: string }) => React.ReactElement;
+  /**
+   * Per-component allow-list of element selectors that may legitimately set
+   * an inline appearance property (e.g. an `<img>` whose `src` is dynamic).
+   * Empty by default — the contract default is "no inline appearance styles
+   * anywhere in the tree".
+   */
+  inlineAppearanceAllowList?: Array<{
+    selector: string;
+    properties: string[];
+    reason: string;
+  }>;
+  /**
+   * Set up `usePlasmicCanvasContext` to return a truthy value (editor mode).
+   * Pass-through to whatever mock the test file uses.
+   */
+  setEditorMode: (inEditor: boolean) => void;
+}
+
+export function describeHeadlessStylingContract(opts: ContractAssertion): void {
+  const {
+    componentName,
+    leafSelector,
+    renderInEditor,
+    renderAtRuntime,
+    inlineAppearanceAllowList = [],
+    setEditorMode,
+  } = opts;
+
+  describe(`${componentName} — headless styling contract`, () => {
+    afterEach(() => {
+      setEditorMode(false);
+    });
+
+    it("forwards className to the documented leaf element (editor render)", () => {
+      setEditorMode(true);
+      const { container } = render(
+        renderInEditor({ className: "ep-test-class" })
+      );
+      const leaf = container.querySelector(leafSelector);
+      expect(leaf).not.toBeNull();
+      expect(leaf!.className).toContain("ep-test-class");
+    });
+
+    if (renderAtRuntime) {
+      it("forwards className to the documented leaf element (runtime render)", () => {
+        setEditorMode(false);
+        const { container } = render(
+          renderAtRuntime({ className: "ep-test-class" })
+        );
+        const leaf = container.querySelector(leafSelector);
+        expect(leaf).not.toBeNull();
+        expect(leaf!.className).toContain("ep-test-class");
+      });
+    }
+
+    it("applies no inline appearance styles in editor render", () => {
+      setEditorMode(true);
+      const { container } = render(renderInEditor({}));
+      assertNoInlineAppearance(container, inlineAppearanceAllowList);
+    });
+
+    if (renderAtRuntime) {
+      it("applies no inline appearance styles in runtime render", () => {
+        setEditorMode(false);
+        const { container } = render(renderAtRuntime({}));
+        assertNoInlineAppearance(container, inlineAppearanceAllowList);
+      });
+
+      it("renders structurally equivalent leaf element in editor and runtime", () => {
+        setEditorMode(true);
+        const editorRender = render(renderInEditor({}));
+        const editorLeaf = editorRender.container.querySelector(leafSelector);
+        expect(editorLeaf).not.toBeNull();
+        const editorTag = editorLeaf!.tagName.toLowerCase();
+        editorRender.unmount();
+
+        setEditorMode(false);
+        const runtimeRender = render(renderAtRuntime({}));
+        const runtimeLeaf = runtimeRender.container.querySelector(leafSelector);
+        expect(runtimeLeaf).not.toBeNull();
+        expect(runtimeLeaf!.tagName.toLowerCase()).toBe(editorTag);
+        runtimeRender.unmount();
+      });
+    }
+  });
+}
+
+function assertNoInlineAppearance(
+  container: HTMLElement,
+  allowList: Array<{ selector: string; properties: string[]; reason: string }>
+): void {
+  const elements = container.querySelectorAll<HTMLElement>("*");
+  const violations: Array<{ tag: string; prop: string; value: string }> = [];
+
+  elements.forEach((el) => {
+    APPEARANCE_PROPERTIES.forEach((prop) => {
+      const value = el.style.getPropertyValue(camelToKebab(prop));
+      if (!value) return;
+
+      const allowed = allowList.some(
+        (entry) =>
+          el.matches(entry.selector) && entry.properties.includes(prop)
+      );
+      if (allowed) return;
+
+      const dataAttrs = Array.from(el.attributes)
+        .filter((a) => a.name.startsWith("data-ep-"))
+        .map((a) => a.name)
+        .join(",");
+      violations.push({
+        tag: `<${el.tagName.toLowerCase()}${dataAttrs ? ` ${dataAttrs}` : ""}>`,
+        prop,
+        value,
+      });
+    });
+  });
+
+  if (violations.length > 0) {
+    const lines = violations.map(
+      (v) => `  ${v.tag} sets inline ${v.prop}: ${v.value}`
+    );
+    throw new Error(
+      `Inline appearance styles found:\n${lines.join("\n")}\n` +
+        `These violate the headless styling contract. Move structural CSS to ` +
+        `headless-styling.ts (with :where() so designers can override), or ` +
+        `delete entirely if it was just visual polish.`
+    );
+  }
+}
+
+function camelToKebab(str: string): string {
+  return str.replace(/([A-Z])/g, "-$1").toLowerCase();
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
@@ -173,6 +173,25 @@ export const MOCK_CATALOG_SEARCH_DATA: CatalogSearchData = {
 };
 
 // ---------------------------------------------------------------------------
+// SearchFieldData — exposed by EPSearchBox to its slot children
+// ---------------------------------------------------------------------------
+
+export interface SearchFieldData {
+  /** The user's in-flight input value (controls the input element). */
+  value: string;
+  /** The query that has actually been refined against the search backend. */
+  displayValue: string;
+  /** True when value is empty — useful for hiding clear buttons. */
+  isEmpty: boolean;
+}
+
+export const MOCK_SEARCH_FIELD_DATA: SearchFieldData = {
+  value: "leather",
+  displayValue: "leather",
+  isEmpty: false,
+};
+
+// ---------------------------------------------------------------------------
 // RefinementItem — shape exposed per-iteration by EPRefinementList
 // ---------------------------------------------------------------------------
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/headless-styling.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/headless-styling.ts
@@ -1,0 +1,65 @@
+/**
+ * Headless styling contract — single style injection for catalog-search.
+ *
+ * The catalog-search components ship behaviour, not appearance. The only CSS
+ * they need is structural — e.g. `position: relative` on the EPSearchBox
+ * wrapper so its absolute-positioned clear button anchors. We ship that CSS
+ * via a `<style>` tag with `:where()` rules so every selector has zero
+ * specificity, meaning any class supplied by the designer (Plasmic, a CSS
+ * module, plain class) always wins.
+ *
+ * Components opt in by calling `useHeadlessStyling()` once. The injection is
+ * idempotent — multiple components on the same page result in exactly one
+ * style tag.
+ */
+
+import { useEffect } from "react";
+
+const STYLE_TAG_MARKER = "data-ep-headless-styles";
+
+const STYLE_BLOCK = `
+:where([data-ep-search-box]) {
+  position: relative;
+}
+:where([data-ep-catalog-search-provider]) {
+  width: 100%;
+  align-self: stretch;
+}
+`;
+
+let injected = false;
+
+export function injectHeadlessStyles(): void {
+  if (injected) return;
+  if (typeof document === "undefined") return;
+
+  if (document.head.querySelector(`style[${STYLE_TAG_MARKER}]`)) {
+    injected = true;
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.setAttribute(STYLE_TAG_MARKER, "");
+  style.textContent = STYLE_BLOCK;
+  document.head.appendChild(style);
+  injected = true;
+}
+
+export function useHeadlessStyling(): void {
+  useEffect(() => {
+    injectHeadlessStyles();
+  }, []);
+}
+
+export const __test__ = {
+  reset(): void {
+    injected = false;
+    if (typeof document !== "undefined") {
+      document.head
+        .querySelectorAll(`style[${STYLE_TAG_MARKER}]`)
+        .forEach((el) => el.remove());
+    }
+  },
+  STYLE_BLOCK,
+  STYLE_TAG_MARKER,
+};


### PR DESCRIPTION
## Summary

Two layered PRDs delivered together because PRD #308 is the architectural completion of PRD #305:

- **#305** introduces a *headless styling contract* for the nine EP catalog-search components: components ship behaviour, not appearance; designer styles from Plasmic's panel reach the rendered DOM unfiltered.
- **#308** found and addresses the underlying Plasmic platform constraint that #305's contract alone couldn't bypass: code-component instances filter appearance styles via `TPL_COMPONENT_PROPS`. The fix is to refactor `EPSearchBox` from a chrome-rendering code component into a render-children-only provider, pushing the visible `<input>` and `<button>` into the slot as Plasmic-controlled tags (which escape the filter).

## Changes

### New files

- `headless-styling.ts` — deep module: idempotent `injectHeadlessStyles()` + `useHeadlessStyling()` hook. Mounts a single `<style data-ep-headless-styles>` tag with `:where()` rules at zero specificity for `[data-ep-search-box]` (legacy, still useful for non-provider use) and `[data-ep-catalog-search-provider]`.
- `__tests__/headless-styling-contract.tsx` — `describeHeadlessStylingContract` shared test helper: asserts className lands on documented leaf, no inline appearance styles, editor + runtime structurally equivalent.

### Modified

- `EPSearchBox.tsx` — provider-only, no DOM. forwardRef + useImperativeHandle exposes `setValue(value)` (debounced) and `clear()` ref-actions. Wraps children in `<DataProvider name="searchFieldData" data={{value, displayValue, isEmpty}}>`. Deprecated props (`placeholder`/`autoFocus`/`showClear`) preserved as hidden no-ops (per `pattern_bundle_invariant_orphans`) so existing project bundles stay valid.
- `EPCatalogSearchProvider.tsx` — dropped `DEFAULT_PROVIDER_WRAPPER_STYLE` from six render sites; structural CSS now ships via the `:where()` block.
- `EPSearchHits.tsx` — added `data-ep-search-hits` attribute for contract-test consistency. The inline `gridStyle` pattern is preserved (the only justified inline-style workaround in the catalog-search codebase, due to Plasmic's className-strip on `display: grid`).
- `design-time-data.ts` — new `SearchFieldData` type and `MOCK_SEARCH_FIELD_DATA`.
- `__tests__/catalog-search-components.test.tsx` — 45 contract assertions (5 per component × 9 components, except EPSearchBox which has its own behavioural tests). 8 new EPSearchBox provider tests covering ref-action behaviour, debounce, displayValue divergence during debounce, and meta correctness.
- `README.md` — new `## Styling contract` section with the four-rule contract, leaf-element table per component, `:where()` pattern guidance, `Composing EPSearchBox` walkthrough, migration notes.

### Migration

- Existing EPSearchBox instances will lose their inline-rendered chrome. Re-author the slot with a Plasmic `<input>` and `<button>`, then bind `value` and wire interactions per the README's "Composing EPSearchBox" section.
- The example app's project (`9iSL9GyrJNp9ebWzxaHtM5`) was re-authored via the Plasmic MCP during this work; the `/products` page now shows a fully styled search input with all designer-set appearance properties reaching the live DOM.

## Test plan

- [x] `yarn test` in `plasmicpkgs/commerce-providers/elastic-path` — 1522 tests pass (no regressions, 8 new EPSearchBox tests, 45 contract assertions across 9 components).
- [x] `yarn build` clean (tsdx + server entry).
- [x] Live verified at `http://localhost:3456/products`:
  - The styled search input renders with designer-set border/radius/padding/font/background — confirms TplTag styles are NOT subject to TPL_COMPONENT_PROPS filtering.
  - `searchFieldData` propagates to slot children via React context (verified via fiber inspection).
  - Page renders cleanly with no console errors after the safe-fallback binding `($ctx.searchFieldData && $ctx.searchFieldData.value || "")`.

## Outstanding (not blocking this PR)

- **Studio-UI step required to wire ref-action interactions on the slot's input/button.** Plasmic's canonical `invokeRefAction` action type is not exposed by the MCP's `interaction.add` tool (filed as gap #81 in the EP MCP feedback tracker). The customFunction-with-`$refs` workaround saves but doesn't fire ref-actions at runtime. To complete the example app's wiring: in Studio, click the input → add `onChange` interaction → "Run action" → `EP Search Box` → `setValue` → `event.target.value`. Same for the clear button's `onClick` → `clear`.
- Two related MCP gaps surfaced by this work and filed separately: #79 (Plasmic codegen lag after MCP slot edits) and #82 (Plasmic loader module cache stale despite `alwaysFresh: true`).

Closes #305.
Closes #308.