### PR TITLE
feat(ep-commerce): enrich EPSearchPagination default slot with Prev/Next chrome

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/README.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/README.md
@@ -563,6 +563,36 @@ EPSearchBox a render-children-only provider, the visible chrome is owned
 by tags the designer fully controls. See PRD #308 for the long-form
 rationale.
 
+### Composing EPSearchPagination
+
+`EPSearchPagination` follows the same provider pattern. The default slot
+ships an `hbox` with `Prev` button, page-indicator text, and `Next` button
+so a fresh drop renders working chrome shape — the designer wires the
+behaviour.
+
+| What `EPSearchPagination` exposes | Type | Use it for |
+| --- | --- | --- |
+| `$ctx.searchPaginationData.currentPage` | `number` | zero-indexed current page |
+| `$ctx.searchPaginationData.totalPages` | `number` | total page count |
+| `$ctx.searchPaginationData.hasPrev` | `boolean` | hide Prev button when false |
+| `$ctx.searchPaginationData.hasNext` | `boolean` | hide Next button when false |
+| `$ctx.searchPaginationData.pages` | `number[]` | page-number buttons array |
+| `goToPage(page: number)` ref-action | | call from a page-number button's `onClick` |
+| `prevPage()` ref-action | | call from the Prev button's `onClick` |
+| `nextPage()` ref-action | | call from the Next button's `onClick` |
+
+Wiring a fresh EPSearchPagination in Plasmic Studio:
+
+1. The default slot already contains a Prev button, a page text, and a
+   Next button — restyle them freely from the style panel.
+2. Replace the page-text content with a dynamic expression, e.g.
+   `` `Page ${$ctx.searchPaginationData.currentPage + 1} of ${$ctx.searchPaginationData.totalPages}` ``.
+3. Wire the Prev button's `onClick` → invoke ref-action `prevPage` on the
+   EPSearchPagination instance. Bind its visibility to
+   `$ctx.searchPaginationData.hasPrev`.
+4. Wire the Next button's `onClick` → invoke ref-action `nextPage`. Bind
+   its visibility to `$ctx.searchPaginationData.hasNext`.
+
 ### Migration notes
 
 Before this contract was in place, `EPSearchBox` and `EPCatalogSearchProvider`

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
@@ -32,14 +32,34 @@ export const epSearchPaginationMeta: CodeComponentMeta<EPSearchPaginationProps> 
   name: "plasmic-commerce-ep-search-pagination",
   displayName: "EP Search Pagination",
   description:
-    "Pagination controls for catalog search. Must be inside EP Catalog Search Provider.",
+    "Pagination provider. Drops a Prev button, page-indicator text, and Next button into the slot. Bind text to $ctx.searchPaginationData (currentPage, totalPages, hasNext, hasPrev) and wire button onClick to the prevPage/nextPage ref-actions; hide buttons when !hasPrev / !hasNext. Must be inside EP Catalog Search Provider.",
   props: {
     children: {
       type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Page 1 of 4",
-      },
+      defaultValue: [
+        {
+          type: "hbox",
+          styles: {
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "12px",
+          },
+          children: [
+            {
+              type: "button",
+              value: "Prev",
+            },
+            {
+              type: "text",
+              value: "Page 1 of 4",
+            },
+            {
+              type: "button",
+              value: "Next",
+            },
+          ],
+        },
+      ],
     },
     previewState: {
       type: "choice",

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
@@ -1095,6 +1095,20 @@ describe("component registration", () => {
     expect(epSearchPaginationMeta.refActions!.prevPage).toBeDefined();
   });
 
+  it("EPSearchPagination default slot ships hbox of [button, text, button]", () => {
+    const slot = (epSearchPaginationMeta.props as any).children;
+    expect(slot.type).toBe("slot");
+    const defaultValue = Array.isArray(slot.defaultValue)
+      ? slot.defaultValue[0]
+      : slot.defaultValue;
+    expect(defaultValue.type).toBe("hbox");
+    const kids = defaultValue.children as any[];
+    expect(kids).toHaveLength(3);
+    expect(kids[0].type).toBe("button");
+    expect(kids[1].type).toBe("text");
+    expect(kids[2].type).toBe("button");
+  });
+
   it("EPSearchStats meta should have correct name", () => {
     expect(epSearchStatsMeta.name).toBe("plasmic-commerce-ep-search-stats");
     expect(epSearchStatsMeta.providesData).toBe(true);


### PR DESCRIPTION
Closes #311.

## Summary

- Replaces `EPSearchPagination`'s placeholder slot (`text("Page 1 of 4")`) with a structural starting point — `hbox` containing `Prev` button, page-text, `Next` button — so a fresh drop renders working pagination shape.
- Mirrors the slot-composition pattern `EPSearchBox` ships post-#308: structural skeleton only, wiring (`onClick` → `prevPage`/`nextPage` ref-actions, visibility → `hasPrev`/`hasNext`) is designer-side because Plasmic registration metadata cannot bake bindings into `defaultValue`.
- Updates the component description in registered metadata to spell out the wiring contract.
- README gains a `Composing EPSearchPagination` subsection paralleling the existing `Composing EPSearchBox` walkthrough.
- New test asserts the default slot shape so a future refactor cannot silently regress to the empty-chrome state.

## Test plan

- [x] `yarn jest plasmicpkgs/commerce-providers/elastic-path` — 1523 tests pass (1 added)
- [x] Authored the slot end-to-end via MCP on project `9iSL9GyrJNp9ebWzxaHtM5` (ProductList page) — Prev / page-text / Next render in Studio canvas. Visibility + ref-action wiring still requires Studio UI per gap #81 / PRD #310, same as for `EPSearchBox`.
- [ ] Existing pagination instances in any project that already authored their own slot content keep their authored content (additive change — `defaultValue` only applies to fresh drops).

## Out of scope

- Closing the gap that requires Studio UI for ref-action wiring — tracked separately at #310.
- Adding any new ref-actions or data fields to `EPSearchPagination`.