### PR TITLE
feat(ep-commerce): add EPSearchAutocomplete compound (#327)

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/package.json
+++ b/plasmicpkgs/commerce-providers/elastic-path/package.json
@@ -44,13 +44,20 @@
     "tsdx": "^0.14.1"
   },
   "peerDependencies": {
+    "@algolia/autocomplete-plugin-recent-searches": ">=1.17.0",
     "@plasmicapp/host": ">=1.0.0",
     "@plasmicapp/query": ">=0.1.0",
     "react": ">=16.8.0",
     "react-hook-form": ">=7.28.0",
     "swr": ">=1.0.0"
   },
+  "peerDependenciesMeta": {
+    "@algolia/autocomplete-plugin-recent-searches": {
+      "optional": true
+    }
+  },
   "dependencies": {
+    "@algolia/autocomplete-core": "^1.17.7",
     "@elasticpath/catalog-search-instantsearch-adapter": "0.1.0",
     "@epcc-sdk/sdks-shopper": "^0.0.43",
     "@hookform/resolvers": "^3.3.2",

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPAutocompleteContext.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPAutocompleteContext.ts
@@ -1,0 +1,41 @@
+/**
+ * Internal React context shared between the EPSearchAutocomplete provider
+ * and its three bridge components (Input, Panel, List).
+ *
+ * The provider populates this with the autocomplete-core prop-getters and
+ * imperative handlers it gets out of `useEPAutocompleteState`. Children
+ * read it to spread the right prop-getter onto their slot element. This
+ * is *not* exposed through Plasmic's `$ctx` because the values include
+ * non-serialisable functions and refs.
+ */
+
+import React from "react";
+import { AutocompleteCollection } from "./design-time-data";
+
+export interface EPAutocompleteContextValue {
+  state: {
+    query: string;
+    isOpen: boolean;
+    activeItemId: number | null;
+    collections: any[];
+    [key: string]: any;
+  };
+  collections: AutocompleteCollection[];
+  getInputProps: (...args: any[]) => any;
+  getPanelProps: (...args: any[]) => any;
+  getListProps: (...args: any[]) => any;
+  getItemProps: (...args: any[]) => any;
+  getRootProps: (...args: any[]) => any;
+  getEnvironmentProps: (...args: any[]) => any;
+  setQuery: (value: string) => void;
+  focus: () => void;
+  clear: () => void;
+  submit: () => void;
+}
+
+export const EPAutocompleteContext =
+  React.createContext<EPAutocompleteContextValue | null>(null);
+
+export function useEPAutocompleteContextOptional(): EPAutocompleteContextValue | null {
+  return React.useContext(EPAutocompleteContext);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
@@ -1,0 +1,329 @@
+/**
+ * EPSearchAutocomplete — provider for catalog-search query suggestions.
+ *
+ * Owns one autocomplete-core instance via `useEPAutocompleteState`. Renders
+ * a single positioning wrapper (`<div data-ep-autocomplete-root>`) plus a
+ * Plasmic DataProvider exposing `autocompleteData` ({ isOpen, query,
+ * collections }) for designer bindings. The three bridge components
+ * (Input, Panel, List) consume the prop-getters via the internal
+ * EPAutocompleteContext.
+ *
+ * Editor branch: renders mock collections without touching autocomplete-core
+ * or the EP client. Runtime branch: wires postMultiSearch from the EP
+ * shopper SDK and runs the live state machine.
+ */
+
+import { DataProvider, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useCallback, useImperativeHandle, useMemo } from "react";
+import { useCommerce } from "../elastic-path";
+import { Registerable } from "../registerable";
+import { getEPClient } from "../utils/getEPClient";
+import {
+  AutocompleteData,
+  MOCK_AUTOCOMPLETE_DATA,
+} from "./design-time-data";
+import {
+  EPAutocompleteContext,
+  EPAutocompleteContextValue,
+} from "./EPAutocompleteContext";
+import { useHeadlessStyling } from "./headless-styling";
+import {
+  useEPAutocompleteState,
+  UseEPAutocompleteStateConfig,
+} from "./useEPAutocompleteState";
+import {
+  MultiSearchBody,
+  MultiSearchResponse,
+} from "./predictionsSource";
+
+type PreviewState = "auto" | "withData";
+
+interface EPSearchAutocompleteProps {
+  children?: React.ReactNode;
+  className?: string;
+  predictionsField?: string;
+  debounceMs?: number;
+  enableRecentSearches?: boolean;
+  recentSearchesKey?: string;
+  recentSearchesLimit?: number;
+  /** Advanced: additional autocomplete-core plugins. Hidden in Studio. */
+  plugins?: any[];
+  previewState?: PreviewState;
+}
+
+interface EPSearchAutocompleteActions {
+  setQuery(value: string): void;
+  focus(): void;
+  clear(): void;
+}
+
+export const epSearchAutocompleteMeta: CodeComponentMeta<EPSearchAutocompleteProps> =
+  {
+    name: "plasmic-commerce-ep-search-autocomplete",
+    displayName: "EP Search Autocomplete",
+    description:
+      "Provider for query-suggestion autocomplete, sourced from EP catalog-search's autocomplete endpoint. Compose with EP Search Autocomplete Input, Panel, and List children. Must be inside EP Catalog Search Provider.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "vbox",
+            styles: { width: "100%" },
+            children: [
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-search-autocomplete-input",
+              },
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-search-autocomplete-panel",
+              },
+            ],
+          },
+        ],
+      },
+      predictionsField: {
+        type: "string",
+        defaultValue: "q",
+        displayName: "Predictions Field",
+        description:
+          "Suggestion field name in the EP autocomplete collection (default 'q').",
+      },
+      debounceMs: {
+        type: "number",
+        defaultValue: 300,
+        displayName: "Debounce (ms)",
+        description: "Milliseconds to wait before mirroring input → search query.",
+      },
+      enableRecentSearches: {
+        type: "boolean",
+        defaultValue: false,
+        displayName: "Enable Recent Searches",
+        description:
+          "When on, persists picked queries to localStorage via the autocomplete-core plugin. Off by default.",
+      },
+      recentSearchesKey: {
+        type: "string",
+        displayName: "Recent Searches Key",
+        description: "localStorage key for recent searches (default ep-recent-searches).",
+        advanced: true,
+      },
+      recentSearchesLimit: {
+        type: "number",
+        defaultValue: 3,
+        displayName: "Recent Searches Limit",
+        advanced: true,
+      },
+      plugins: {
+        type: "object",
+        displayName: "Plugins (advanced)",
+        description:
+          "Escape hatch: extra autocomplete-core plugins to inject. Most consumers do not need this.",
+        advanced: true,
+        hidden: () => true,
+      } as any,
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        advanced: true,
+      },
+    } as any,
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPSearchAutocomplete",
+    parentComponentName: "plasmic-commerce-ep-catalog-search-provider",
+    providesData: true,
+    refActions: {
+      setQuery: {
+        description: "Set the autocomplete query value programmatically.",
+        argTypes: [{ name: "value", type: "string" }],
+      },
+      focus: {
+        description: "Open the panel programmatically.",
+        argTypes: [],
+      },
+      clear: {
+        description: "Clear the query and close the panel.",
+        argTypes: [],
+      },
+    },
+  };
+
+export const EPSearchAutocomplete = React.forwardRef<
+  EPSearchAutocompleteActions,
+  EPSearchAutocompleteProps
+>(function EPSearchAutocomplete(props, ref) {
+  useHeadlessStyling();
+  const {
+    children,
+    className,
+    previewState = "auto",
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const useMock =
+    previewState === "withData" || (previewState === "auto" && inEditor);
+
+  if (useMock) {
+    return (
+      <MockAutocomplete ref={ref} className={className}>
+        {children}
+      </MockAutocomplete>
+    );
+  }
+
+  return (
+    <EPSearchAutocompleteInner
+      ref={ref}
+      className={className}
+      predictionsField={props.predictionsField ?? "q"}
+      debounceMs={props.debounceMs ?? 300}
+      enableRecentSearches={props.enableRecentSearches ?? false}
+      recentSearchesKey={props.recentSearchesKey}
+      recentSearchesLimit={props.recentSearchesLimit}
+      plugins={props.plugins}
+    >
+      {children}
+    </EPSearchAutocompleteInner>
+  );
+});
+
+const MockAutocomplete = React.forwardRef<
+  EPSearchAutocompleteActions,
+  { children?: React.ReactNode; className?: string }
+>(function MockAutocomplete({ children, className }, ref) {
+  useImperativeHandle(ref, () => ({
+    setQuery: () => undefined,
+    focus: () => undefined,
+    clear: () => undefined,
+  }));
+
+  const noop = () => undefined;
+  const ctx: EPAutocompleteContextValue = useMemo(
+    () => ({
+      state: {
+        query: MOCK_AUTOCOMPLETE_DATA.query,
+        isOpen: MOCK_AUTOCOMPLETE_DATA.isOpen,
+        activeItemId: 0,
+        collections: MOCK_AUTOCOMPLETE_DATA.collections.map((c) => ({
+          source: { sourceId: c.sourceId },
+          items: c.items,
+        })),
+      },
+      collections: MOCK_AUTOCOMPLETE_DATA.collections,
+      getInputProps: () => ({
+        value: MOCK_AUTOCOMPLETE_DATA.query,
+        onChange: noop,
+      }),
+      getPanelProps: () => ({}),
+      getListProps: () => ({ role: "listbox" }),
+      getItemProps: ({ item }: any) => ({
+        role: "option",
+        "aria-selected": "false",
+        onClick: noop,
+        "data-item-q": item?.q,
+      }),
+      getRootProps: () => ({}),
+      getEnvironmentProps: () => ({}),
+      setQuery: noop,
+      focus: noop,
+      clear: noop,
+      submit: noop,
+    }),
+    []
+  );
+
+  return (
+    <EPAutocompleteContext.Provider value={ctx}>
+      <DataProvider name="autocompleteData" data={MOCK_AUTOCOMPLETE_DATA}>
+        <div className={className} data-ep-autocomplete-root="">
+          {children}
+        </div>
+      </DataProvider>
+    </EPAutocompleteContext.Provider>
+  );
+});
+
+interface EPSearchAutocompleteInnerProps
+  extends Omit<UseEPAutocompleteStateConfig, "postMultiSearch"> {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const EPSearchAutocompleteInner = React.forwardRef<
+  EPSearchAutocompleteActions,
+  EPSearchAutocompleteInnerProps
+>(function EPSearchAutocompleteInner(props, ref) {
+  const { children, className, ...stateConfig } = props;
+
+  const { providerRef } = useCommerce();
+  const provider = providerRef?.current;
+  const epClient = getEPClient(provider);
+
+  const postMultiSearch = useCallback(
+    async (body: MultiSearchBody): Promise<MultiSearchResponse> => {
+      try {
+        const sdk = require("@epcc-sdk/sdks-shopper");
+        const result = await sdk.postMultiSearch({
+          client: epClient,
+          body,
+        });
+        return (result?.data ?? {}) as MultiSearchResponse;
+      } catch {
+        return {};
+      }
+    },
+    [epClient]
+  );
+
+  const hookOutput = useEPAutocompleteState({
+    ...stateConfig,
+    postMultiSearch,
+  });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setQuery: hookOutput.setQuery,
+      focus: hookOutput.focus,
+      clear: hookOutput.clear,
+    }),
+    [hookOutput.setQuery, hookOutput.focus, hookOutput.clear]
+  );
+
+  const publicData: AutocompleteData = useMemo(
+    () => ({
+      isOpen: !!hookOutput.state.isOpen,
+      query: hookOutput.state.query ?? "",
+      collections: hookOutput.collections,
+    }),
+    [hookOutput.state.isOpen, hookOutput.state.query, hookOutput.collections]
+  );
+
+  return (
+    <EPAutocompleteContext.Provider value={hookOutput}>
+      <DataProvider name="autocompleteData" data={publicData}>
+        <div className={className} data-ep-autocomplete-root="">
+          {children}
+        </div>
+      </DataProvider>
+    </EPAutocompleteContext.Provider>
+  );
+});
+
+export function registerEPSearchAutocomplete(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSearchAutocompleteProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPSearchAutocomplete,
+    customMeta ?? epSearchAutocompleteMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
@@ -8,6 +8,13 @@
  * or non-element child, we fall back to rendering it untouched — the
  * onSubmit / selection paths still work via the surrounding panel + list.
  *
+ * Also exposes a top-level `placeholder` prop so designers can set the
+ * placeholder text from the right rail without drilling into slot attrs.
+ * autocomplete-core's `getInputProps()` does not return a `placeholder`
+ * key, so we inject it ourselves; designers who'd rather hard-code it on
+ * the slot child can leave the prop blank — `cloneElement` preserves the
+ * existing attr.
+ *
  * No DOM is owned by this component beyond what the slot provides.
  */
 
@@ -25,8 +32,11 @@ type PreviewState = "auto" | "withData";
 interface EPSearchAutocompleteInputProps {
   children?: React.ReactNode;
   className?: string;
+  placeholder?: string;
   previewState?: PreviewState;
 }
+
+const DEFAULT_PLACEHOLDER = "Search products...";
 
 export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocompleteInputProps> =
   {
@@ -42,10 +52,16 @@ export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocomple
             type: "input",
             attrs: {
               type: "search",
-              placeholder: "Search products...",
             },
           },
         ],
+      },
+      placeholder: {
+        type: "string",
+        displayName: "Placeholder",
+        defaultValue: DEFAULT_PLACEHOLDER,
+        description:
+          "Shown when the input is empty. Overrides any placeholder set directly on the slot input.",
       },
       previewState: {
         type: "choice",
@@ -63,7 +79,7 @@ export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocomple
 export function EPSearchAutocompleteInput(
   props: EPSearchAutocompleteInputProps
 ) {
-  const { children, className } = props;
+  const { children, className, placeholder } = props;
   const ctx = useEPAutocompleteContextOptional();
 
   if (!ctx) {
@@ -74,22 +90,26 @@ export function EPSearchAutocompleteInput(
 
   const inputProps = ctx.getInputProps({});
   const child = React.Children.only(children as React.ReactElement);
+  const injected: Record<string, unknown> = {
+    ...inputProps,
+    className: [className, (child.props as any)?.className]
+      .filter(Boolean)
+      .join(" ") || undefined,
+    // Tell common password-manager extensions (1Password, LastPass,
+    // Bitwarden, Dashlane) to skip this input. Without these hints,
+    // some extensions stamp `caret-color: transparent !important` on
+    // the input to indicate autofill availability — which hides the
+    // user's typing caret on a search field where it doesn't belong.
+    "data-1p-ignore": "true",
+    "data-lpignore": "true",
+    "data-bwignore": "true",
+    "data-form-type": "other",
+  };
+  if (placeholder !== undefined && placeholder !== "") {
+    injected.placeholder = placeholder;
+  }
   const cloned = cloneWithInjectedHandlers(child, {
-    injected: {
-      ...inputProps,
-      className: [className, (child.props as any)?.className]
-        .filter(Boolean)
-        .join(" ") || undefined,
-      // Tell common password-manager extensions (1Password, LastPass,
-      // Bitwarden, Dashlane) to skip this input. Without these hints,
-      // some extensions stamp `caret-color: transparent !important` on
-      // the input to indicate autofill availability — which hides the
-      // user's typing caret on a search field where it doesn't belong.
-      "data-1p-ignore": "true",
-      "data-lpignore": "true",
-      "data-bwignore": "true",
-      "data-form-type": "other",
-    },
+    injected,
     compose: ["onChange", "onKeyDown", "onFocus", "onBlur"],
   });
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
@@ -79,7 +79,11 @@ export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocomple
 export function EPSearchAutocompleteInput(
   props: EPSearchAutocompleteInputProps
 ) {
-  const { children, className, placeholder } = props;
+  // Default at the function-arg level so existing component instances
+  // (dropped before the `placeholder` prop existed) still pick up the
+  // default — Plasmic does not retroactively apply meta defaultValue.
+  // Designers who want no placeholder set the prop to "" explicitly.
+  const { children, className, placeholder = DEFAULT_PLACEHOLDER } = props;
   const ctx = useEPAutocompleteContextOptional();
 
   if (!ctx) {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
@@ -1,0 +1,109 @@
+/**
+ * EPSearchAutocompleteInput — input bridge.
+ *
+ * Spreads `getInputProps()` onto the designer's slot input element via
+ * cloneElement (Pattern C — value, onChange, onKeyDown, onFocus, onBlur).
+ * Single-element-slot semantics: the slot must contain one valid React
+ * element (default `<input type="search">`). If a designer drops an array
+ * or non-element child, we fall back to rendering it untouched — the
+ * onSubmit / selection paths still work via the surrounding panel + list.
+ *
+ * No DOM is owned by this component beyond what the slot provides.
+ */
+
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../registerable";
+import { cloneWithInjectedHandlers } from "./cloneWithInjectedHandlers";
+import { useEPAutocompleteContextOptional } from "./EPAutocompleteContext";
+
+type PreviewState = "auto" | "withData";
+
+interface EPSearchAutocompleteInputProps {
+  children?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocompleteInputProps> =
+  {
+    name: "plasmic-commerce-ep-search-autocomplete-input",
+    displayName: "EP Search Autocomplete Input",
+    description:
+      "Input bridge for EP Search Autocomplete. Drop a Plasmic <input> into the slot and this component spreads value + onChange + keyboard handlers automatically. Must be inside EP Search Autocomplete.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "input",
+            attrs: {
+              type: "search",
+              placeholder: "Search products...",
+            },
+          },
+        ],
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        advanced: true,
+      },
+    } as any,
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPSearchAutocompleteInput",
+    parentComponentName: "plasmic-commerce-ep-search-autocomplete",
+  };
+
+export function EPSearchAutocompleteInput(
+  props: EPSearchAutocompleteInputProps
+) {
+  const { children, className } = props;
+  const ctx = useEPAutocompleteContextOptional();
+
+  if (!ctx) {
+    // Outside an EPSearchAutocomplete provider — render the slot raw so
+    // designers see *something* in the canvas even if the parent isn't set.
+    return <>{children}</>;
+  }
+
+  const inputProps = ctx.getInputProps({});
+  const child = React.Children.only(children as React.ReactElement);
+  const cloned = cloneWithInjectedHandlers(child, {
+    injected: {
+      ...inputProps,
+      className: [className, (child.props as any)?.className]
+        .filter(Boolean)
+        .join(" ") || undefined,
+      // Tell common password-manager extensions (1Password, LastPass,
+      // Bitwarden, Dashlane) to skip this input. Without these hints,
+      // some extensions stamp `caret-color: transparent !important` on
+      // the input to indicate autofill availability — which hides the
+      // user's typing caret on a search field where it doesn't belong.
+      "data-1p-ignore": "true",
+      "data-lpignore": "true",
+      "data-bwignore": "true",
+      "data-form-type": "other",
+    },
+    compose: ["onChange", "onKeyDown", "onFocus", "onBlur"],
+  });
+
+  return <>{cloned}</>;
+}
+
+export function registerEPSearchAutocompleteInput(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSearchAutocompleteInputProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPSearchAutocompleteInput,
+    customMeta ?? epSearchAutocompleteInputMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteList.tsx
@@ -1,0 +1,189 @@
+/**
+ * EPSearchAutocompleteList — repeater bridge.
+ *
+ * Renders `<ul {...getListProps()}>` with one `<li {...getItemProps(...)}>`
+ * per item in the configured source. Per-iteration `currentSuggestion`
+ * context is published via Plasmic DataProvider — designers compose row
+ * visuals from the slot's child elements, repeated via `repeatedElement`.
+ *
+ * `sourceId` (default unset) scopes to a single source. When unset, all
+ * sources flatten into a single list. When set, only items from the
+ * matching source are rendered.
+ */
+
+import {
+  DataProvider,
+  repeatedElement,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../registerable";
+import {
+  AutocompleteCollection,
+  AutocompleteSuggestionItem,
+  CurrentSuggestion,
+  MOCK_AUTOCOMPLETE_DATA,
+} from "./design-time-data";
+import { useEPAutocompleteContextOptional } from "./EPAutocompleteContext";
+
+type PreviewState = "auto" | "withData";
+
+interface EPSearchAutocompleteListProps {
+  children?: React.ReactNode;
+  className?: string;
+  sourceId?: string;
+  previewState?: PreviewState;
+}
+
+export const epSearchAutocompleteListMeta: CodeComponentMeta<EPSearchAutocompleteListProps> =
+  {
+    name: "plasmic-commerce-ep-search-autocomplete-list",
+    displayName: "EP Search Autocomplete List",
+    description:
+      "Repeats children once per autocomplete suggestion item. Click handlers and ARIA semantics are wired automatically. Use `sourceId` to scope the list to a single named source. Per-iteration $ctx.currentSuggestion exposes the item, isHighlighted, and source. Must be inside EP Search Autocomplete.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "text",
+            value: "Suggestion",
+            styles: { padding: "8px 12px" },
+          },
+        ],
+      },
+      sourceId: {
+        type: "string",
+        displayName: "Source ID",
+        description:
+          "Restrict to one source (e.g. 'predictions', 'recent'). Defaults to all sources.",
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPSearchAutocompleteList",
+    parentComponentName: "plasmic-commerce-ep-search-autocomplete",
+    providesData: true,
+  };
+
+interface FlatItem {
+  item: AutocompleteSuggestionItem;
+  source: string;
+  isHighlighted: boolean;
+  /** Real autocomplete-core source object (or a mock {sourceId} stub). */
+  rawSource: any;
+}
+
+function flattenCollections(
+  collections: AutocompleteCollection[],
+  rawCollections: any[],
+  activeItemId: number | null,
+  sourceFilter?: string
+): FlatItem[] {
+  const flat: FlatItem[] = [];
+  let absoluteIndex = 0;
+  collections.forEach((collection, ci) => {
+    if (sourceFilter && collection.sourceId !== sourceFilter) {
+      // still advance absoluteIndex past skipped items so highlight ids
+      // remain in lockstep with autocomplete-core's count
+      absoluteIndex += collection.items.length;
+      return;
+    }
+    const raw = rawCollections?.[ci]?.source ?? { sourceId: collection.sourceId };
+    collection.items.forEach((item) => {
+      flat.push({
+        item,
+        source: collection.sourceId,
+        isHighlighted: activeItemId === absoluteIndex,
+        rawSource: raw,
+      });
+      absoluteIndex += 1;
+    });
+  });
+  return flat;
+}
+
+export function EPSearchAutocompleteList(
+  props: EPSearchAutocompleteListProps
+) {
+  const { children, className, sourceId } = props;
+  const inEditor = !!usePlasmicCanvasContext();
+  const ctx = useEPAutocompleteContextOptional();
+
+  if (!ctx) return null;
+
+  // Editor mode: prefer mock collections so designers see populated rows
+  // even when the autocomplete-core hook hasn't been driven.
+  const mockMode =
+    inEditor &&
+    (!ctx.collections || ctx.collections.length === 0);
+
+  const collections = mockMode
+    ? MOCK_AUTOCOMPLETE_DATA.collections
+    : ctx.collections;
+  const rawCollections = ctx.state.collections ?? [];
+  const activeItemId = ctx.state.activeItemId;
+
+  const flat = flattenCollections(
+    collections,
+    mockMode ? [] : rawCollections,
+    typeof activeItemId === "number" ? activeItemId : null,
+    sourceId
+  );
+
+  const listProps = ctx.getListProps({});
+
+  return (
+    <ul
+      {...listProps}
+      className={className}
+      data-ep-autocomplete-list=""
+    >
+      {flat.map((entry, i) => {
+        const itemProps = ctx.getItemProps({
+          item: entry.item,
+          source: entry.rawSource,
+        });
+        const ctxValue: CurrentSuggestion = {
+          item: entry.item,
+          isHighlighted: entry.isHighlighted,
+          source: entry.source,
+          query: ctx.state.query ?? "",
+        };
+        return (
+          <li
+            {...itemProps}
+            key={`${entry.source}:${entry.item.q}:${i}`}
+          >
+            <DataProvider name="currentSuggestion" data={ctxValue}>
+              <DataProvider name="currentSuggestionIndex" data={i}>
+                {repeatedElement(i, children)}
+              </DataProvider>
+            </DataProvider>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function registerEPSearchAutocompleteList(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSearchAutocompleteListProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPSearchAutocompleteList,
+    customMeta ?? epSearchAutocompleteListMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * EPSearchAutocompletePanel — panel bridge.
+ *
+ * Owns the wrapper element for the autocomplete dropdown:
+ *   <div data-ep-autocomplete-panel> + spread getPanelProps()
+ * Renders only when `state.isOpen` is true at runtime; in the editor it
+ * always renders so designers see their layout. Includes one component-
+ * owned chrome element — the mobile close button at
+ * `data-ep-autocomplete-close` — gated by media query in the headless
+ * styling block. This is the documented L2 exception: a fresh drop on
+ * mobile would otherwise trap the shopper in a panel they cannot dismiss.
+ */
+
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../registerable";
+import { useEPAutocompleteContextOptional } from "./EPAutocompleteContext";
+
+type PreviewState = "auto" | "withData";
+
+interface EPSearchAutocompletePanelProps {
+  children?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocompletePanelProps> =
+  {
+    name: "plasmic-commerce-ep-search-autocomplete-panel",
+    displayName: "EP Search Autocomplete Panel",
+    description:
+      "Panel wrapper for the autocomplete dropdown. Renders only when the panel is open. Hosts the mobile close button (hidden on desktop via media query). Must be inside EP Search Autocomplete.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "component",
+            name: "plasmic-commerce-ep-search-autocomplete-list",
+          },
+        ],
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPSearchAutocompletePanel",
+    parentComponentName: "plasmic-commerce-ep-search-autocomplete",
+  };
+
+export function EPSearchAutocompletePanel(
+  props: EPSearchAutocompletePanelProps
+) {
+  const { children, className } = props;
+  const inEditor = !!usePlasmicCanvasContext();
+  const ctx = useEPAutocompleteContextOptional();
+
+  if (!ctx) {
+    return null;
+  }
+
+  // Editor: always render so designers can lay out the panel against
+  // mock collections. Runtime: only render when state.isOpen.
+  if (!inEditor && !ctx.state.isOpen) {
+    return null;
+  }
+
+  const panelProps = ctx.getPanelProps({});
+
+  return (
+    <div
+      {...panelProps}
+      className={className}
+      data-ep-autocomplete-panel=""
+    >
+      <button
+        type="button"
+        data-ep-autocomplete-close=""
+        aria-label="Close suggestions"
+        onClick={() => ctx.clear()}
+      >
+        Close
+      </button>
+      {children}
+    </div>
+  );
+}
+
+export function registerEPSearchAutocompletePanel(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSearchAutocompletePanelProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPSearchAutocompletePanel,
+    customMeta ?? epSearchAutocompletePanelMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
@@ -3,15 +3,29 @@
  *
  * Owns the wrapper element for the autocomplete dropdown:
  *   <div data-ep-autocomplete-panel> + spread getPanelProps()
- * Renders only when `state.isOpen` is true at runtime; in the editor it
- * always renders so designers see their layout. Includes one component-
- * owned chrome element — the mobile close button at
+ *
+ * Visibility rules:
+ *   Runtime  — render iff state.isOpen.
+ *   Canvas   — render iff the panel (or any descendant) is selected in
+ *              Studio's outline, OR the designer has set `open={true}` to
+ *              pin it open. Closed by default so the dropdown does not
+ *              cover neighbouring page content while editing other parts.
+ *
+ * The selection branch follows the @plasmicapp/host
+ * `usePlasmicCanvasComponentInfo` pattern used by react-aria's Popover,
+ * Modal, ComboBox, etc. — Plasmic Studio injects
+ * `__plasmic_selection_prop__` automatically.
+ *
+ * Includes one component-owned chrome element — the mobile close button at
  * `data-ep-autocomplete-close` — gated by media query in the headless
  * styling block. This is the documented L2 exception: a fresh drop on
  * mobile would otherwise trap the shopper in a panel they cannot dismiss.
  */
 
-import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import {
+  usePlasmicCanvasContext,
+  usePlasmicCanvasComponentInfo,
+} from "@plasmicapp/host";
 import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
@@ -19,12 +33,22 @@ import React from "react";
 import { Registerable } from "../registerable";
 import { useEPAutocompleteContextOptional } from "./EPAutocompleteContext";
 
-type PreviewState = "auto" | "withData";
-
 interface EPSearchAutocompletePanelProps {
   children?: React.ReactNode;
   className?: string;
-  previewState?: PreviewState;
+  /**
+   * Studio-only override: when true, force the panel to render in canvas
+   * even if it isn't selected. Useful for deep styling sessions where the
+   * designer wants the panel pinned open while editing siblings.
+   */
+  open?: boolean;
+  /** Injected automatically by Plasmic Studio. Do not set manually. */
+  __plasmic_selection_prop__?: {
+    isSelected?: boolean;
+    selectedSlotName?: string;
+  };
+  /** Injected automatically by Plasmic Studio. Do not set manually. */
+  plasmicNotifyAutoOpenedContent?: () => void;
 }
 
 export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocompletePanelProps> =
@@ -32,7 +56,7 @@ export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocomple
     name: "plasmic-commerce-ep-search-autocomplete-panel",
     displayName: "EP Search Autocomplete Panel",
     description:
-      "Panel wrapper for the autocomplete dropdown. Renders only when the panel is open. Hosts the mobile close button (hidden on desktop via media query). Must be inside EP Search Autocomplete.",
+      "Panel wrapper for the autocomplete dropdown. In Studio, opens when selected; closed otherwise so it doesn't cover surrounding page content. Hosts the mobile close button (hidden on desktop via media query). Must be inside EP Search Autocomplete.",
     props: {
       children: {
         type: "slot",
@@ -43,11 +67,12 @@ export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocomple
           },
         ],
       },
-      previewState: {
-        type: "choice",
-        options: ["auto", "withData"],
-        defaultValue: "auto",
-        displayName: "Preview State",
+      open: {
+        type: "boolean",
+        defaultValue: false,
+        displayName: "Force open (Studio only)",
+        description:
+          "Pin the panel open in the Studio canvas. No effect at runtime — runtime visibility is controlled by the autocomplete state machine.",
         advanced: true,
       },
     },
@@ -59,17 +84,32 @@ export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocomple
 export function EPSearchAutocompletePanel(
   props: EPSearchAutocompletePanelProps
 ) {
-  const { children, className } = props;
+  const {
+    children,
+    className,
+    open: openOverride,
+    __plasmic_selection_prop__,
+    plasmicNotifyAutoOpenedContent,
+  } = props;
   const inEditor = !!usePlasmicCanvasContext();
+  const isSelected =
+    usePlasmicCanvasComponentInfo?.({ __plasmic_selection_prop__ })
+      ?.isSelected ?? false;
   const ctx = useEPAutocompleteContextOptional();
+
+  const isOpenInCanvas = inEditor && (openOverride || isSelected);
+
+  React.useEffect(() => {
+    if (isOpenInCanvas) {
+      plasmicNotifyAutoOpenedContent?.();
+    }
+  }, [isOpenInCanvas, plasmicNotifyAutoOpenedContent]);
 
   if (!ctx) {
     return null;
   }
 
-  // Editor: always render so designers can lay out the panel against
-  // mock collections. Runtime: only render when state.isOpen.
-  if (!inEditor && !ctx.state.isOpen) {
+  if (inEditor ? !isOpenInCanvas : !ctx.state.isOpen) {
     return null;
   }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
@@ -17,6 +17,9 @@ import React from "react";
 
 /* ---------- mock variables (declared before jest.mock) ---------- */
 const mockUsePlasmicCanvasContext = jest.fn();
+const mockUsePlasmicCanvasComponentInfo = jest.fn().mockReturnValue({
+  isSelected: false,
+});
 const mockRepeatedElement = jest.fn(
   (_idx: number, children: React.ReactNode) => children
 );
@@ -174,6 +177,8 @@ jest.mock("@plasmicapp/host", () => ({
   ),
   useSelector: jest.fn(),
   usePlasmicCanvasContext: () => mockUsePlasmicCanvasContext(),
+  usePlasmicCanvasComponentInfo: (...args: any[]) =>
+    mockUsePlasmicCanvasComponentInfo(...args),
   repeatedElement: (...args: any[]) => mockRepeatedElement(...args),
 }));
 
@@ -251,6 +256,10 @@ function setEditorMode(inEditor: boolean) {
   }
 }
 
+function setIsSelected(isSelected: boolean) {
+  mockUsePlasmicCanvasComponentInfo.mockReturnValue({ isSelected });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   // mockClear leaves mockResolvedValueOnce queues intact across tests; reset
@@ -261,6 +270,7 @@ beforeEach(() => {
   });
   fakeAutocompleteInstances.length = 0;
   mockUsePlasmicCanvasContext.mockReturnValue(null);
+  mockUsePlasmicCanvasComponentInfo.mockReturnValue({ isSelected: false });
   mockUseSearchBox.mockReturnValue({
     query: "",
     refine: jest.fn(),
@@ -436,6 +446,72 @@ describe("EPSearchAutocompleteInput", () => {
 
     expect(fakeAutocompleteInstances[0].state.query).toBe("boot");
   });
+
+  it("injects the placeholder prop onto the slot input", () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput placeholder="Find boots…">
+          <input type="search" data-testid="user-input" />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("Find boots…");
+  });
+
+  it("placeholder prop overrides any placeholder set on the slot child", () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput placeholder="From component">
+          <input
+            type="search"
+            placeholder="From slot"
+            data-testid="user-input"
+          />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("From component");
+  });
+
+  it("preserves the slot's own placeholder when the prop is empty", () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput placeholder="">
+          <input
+            type="search"
+            placeholder="From slot"
+            data-testid="user-input"
+          />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("From slot");
+  });
+
+  it("meta declares a default placeholder so freshly-dropped components show one", () => {
+    const placeholderProp = (epSearchAutocompleteInputMeta.props as any)
+      .placeholder;
+    expect(placeholderProp.type).toBe("string");
+    expect(placeholderProp.defaultValue).toBe("Search products...");
+  });
 });
 
 describeHeadlessStylingContract({
@@ -525,8 +601,29 @@ describe("EPSearchAutocompletePanel", () => {
     expect(closeButton!.tagName.toLowerCase()).toBe("button");
   });
 
-  it("editor mode renders the panel unconditionally with mock content", () => {
+  it("editor mode hides the panel when not selected and not pinned open", () => {
     setEditorMode(true);
+    setIsSelected(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel>
+          <div data-testid="panel-content">panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    expect(
+      container.querySelector('[data-testid="panel-content"]')
+    ).toBeNull();
+    expect(
+      container.querySelector("[data-ep-autocomplete-panel]")
+    ).toBeNull();
+  });
+
+  it("editor mode renders the panel when the component is selected in Studio", () => {
+    setEditorMode(true);
+    setIsSelected(true);
 
     const { container } = render(
       <EPSearchAutocomplete>
@@ -540,6 +637,61 @@ describe("EPSearchAutocompletePanel", () => {
       container.querySelector('[data-testid="panel-content"]')
     ).not.toBeNull();
   });
+
+  it("editor mode renders the panel when `open` override is true", () => {
+    setEditorMode(true);
+    setIsSelected(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel open>
+          <div data-testid="panel-content">panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    expect(
+      container.querySelector('[data-testid="panel-content"]')
+    ).not.toBeNull();
+  });
+
+  it("calls plasmicNotifyAutoOpenedContent when the panel auto-opens via selection", () => {
+    setEditorMode(true);
+    setIsSelected(true);
+    const notify = jest.fn();
+
+    render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel
+          plasmicNotifyAutoOpenedContent={notify}
+        >
+          <div>panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    expect(notify).toHaveBeenCalled();
+  });
+
+  it("forwards __plasmic_selection_prop__ to usePlasmicCanvasComponentInfo", () => {
+    setEditorMode(true);
+    setIsSelected(true);
+    const selectionProp = { isSelected: true };
+
+    render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel
+          __plasmic_selection_prop__={selectionProp}
+        >
+          <div>panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    expect(mockUsePlasmicCanvasComponentInfo).toHaveBeenCalledWith({
+      __plasmic_selection_prop__: selectionProp,
+    });
+  });
 });
 
 describeHeadlessStylingContract({
@@ -547,8 +699,11 @@ describeHeadlessStylingContract({
   leafSelector: "[data-ep-autocomplete-panel]",
   setEditorMode,
   renderInEditor: ({ className }) => (
+    // The panel only renders in canvas when selected or pinned open. The
+    // contract test cares about className forwarding, not visibility logic
+    // — `open` pins it visible regardless of selection state.
     <EPSearchAutocomplete>
-      <EPSearchAutocompletePanel className={className}>
+      <EPSearchAutocompletePanel className={className} open>
         <div>panel</div>
       </EPSearchAutocompletePanel>
     </EPSearchAutocomplete>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
@@ -1,0 +1,677 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Component-level tests for the EPSearchAutocomplete compound — the
+ * provider plus the three bridge components (Input, Panel, List).
+ *
+ * The deep-module logic (autocomplete-core lifecycle, predictions source,
+ * debounced refine) lives in `useEPAutocompleteState` and `predictionsSource`
+ * and has its own dedicated tests. The tests here exercise the React-shaped
+ * surface: the headless styling contract, default-slot shapes, parent-
+ * component enforcement, mocked-state editor branch, and how the four
+ * components compose to deliver designer-visible behaviours (selection
+ * triggers refine, panel hides when closed, etc.).
+ */
+
+import React from "react";
+
+/* ---------- mock variables (declared before jest.mock) ---------- */
+const mockUsePlasmicCanvasContext = jest.fn();
+const mockRepeatedElement = jest.fn(
+  (_idx: number, children: React.ReactNode) => children
+);
+
+const mockUseSearchBox = jest.fn().mockReturnValue({
+  query: "",
+  refine: jest.fn(),
+  clear: jest.fn(),
+});
+
+const mockUseCommerce = jest.fn();
+
+interface FakeState {
+  query: string;
+  isOpen: boolean;
+  activeItemId: number | null;
+  collections: Array<{ source: { sourceId: string }; items: Array<any> }>;
+  status: string;
+}
+
+const fakeAutocompleteInstances: any[] = [];
+
+const mockCreateAutocomplete = jest.fn((config: any) => {
+  const state: FakeState = {
+    query: "",
+    isOpen: false,
+    activeItemId: null,
+    collections: [],
+    status: "idle",
+  };
+
+  let onStateChangeCalls = 0;
+  const notify = () => {
+    onStateChangeCalls += 1;
+    if (config.onStateChange) {
+      config.onStateChange({ state, prevState: state });
+    }
+  };
+
+  let sourcesConfig: any[] = config.getSources
+    ? config.getSources({ query: "", state }) ?? []
+    : [];
+
+  const refreshSources = async (query: string) => {
+    if (query.length === 0) {
+      state.collections = [];
+      state.isOpen = false;
+      notify();
+      return;
+    }
+    const items = await Promise.all(
+      sourcesConfig.map(async (src) => ({
+        source: { sourceId: src.sourceId },
+        items: await src.getItems({ query }),
+      }))
+    );
+    state.collections = items;
+    state.isOpen = items.some((c) => c.items.length > 0);
+    notify();
+  };
+
+  function setQuery(value: string) {
+    state.query = value;
+    notify();
+    void refreshSources(value);
+  }
+  function setIsOpen(value: boolean) {
+    state.isOpen = value;
+    notify();
+  }
+  function setActiveItemId(value: number | null) {
+    state.activeItemId = value;
+    notify();
+  }
+
+  const noop = () => undefined;
+  const instance: any = {
+    state,
+    setQuery,
+    setIsOpen,
+    setActiveItemId,
+    getInputProps: () => ({
+      value: state.query,
+      onChange: (event: any) => setQuery(event.currentTarget.value),
+      onKeyDown: noop,
+      onFocus: noop,
+      onBlur: noop,
+    }),
+    getPanelProps: (props?: any) => ({
+      ...(props ?? {}),
+      "data-ep-autocomplete-test": "panel",
+    }),
+    getListProps: () => ({ role: "listbox" }),
+    getItemProps: ({ item, source }: any) => ({
+      role: "option",
+      "aria-selected": "false",
+      onClick: () => {
+        const src = sourcesConfig.find(
+          (s) => s.sourceId === source.sourceId
+        );
+        src?.onSelect?.({ item, source: { sourceId: source.sourceId }, setQuery, setIsOpen, state });
+      },
+    }),
+    getRootProps: () => ({}),
+    getEnvironmentProps: () => ({}),
+    __triggerInput: async (value: string) => {
+      setQuery(value);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    __triggerSelect: (sourceId: string, itemIndex: number) => {
+      const collection = state.collections.find(
+        (c) => c.source.sourceId === sourceId
+      );
+      const item = collection?.items[itemIndex];
+      const src = sourcesConfig.find((s) => s.sourceId === sourceId);
+      if (item && src?.onSelect) {
+        src.onSelect({
+          item,
+          source: { sourceId },
+          setQuery,
+          setIsOpen,
+          state,
+        });
+      }
+    },
+    __sourcesConfig: () => sourcesConfig,
+    __onStateChangeCalls: () => onStateChangeCalls,
+  };
+
+  fakeAutocompleteInstances.push(instance);
+  return instance;
+});
+
+/* ---------- jest.mock calls ---------- */
+jest.mock("@plasmicapp/host", () => ({
+  DataProvider: ({
+    children,
+    name,
+    data,
+  }: {
+    children: React.ReactNode;
+    name: string;
+    data: any;
+  }) => (
+    <div
+      data-testid={`data-provider-${name}`}
+      data-provider-data={JSON.stringify(data, (_k, v) =>
+        typeof v === "function" ? "[fn]" : v
+      )}
+    >
+      {children}
+    </div>
+  ),
+  useSelector: jest.fn(),
+  usePlasmicCanvasContext: () => mockUsePlasmicCanvasContext(),
+  repeatedElement: (...args: any[]) => mockRepeatedElement(...args),
+}));
+
+jest.mock("@plasmicapp/host/registerComponent", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("../../elastic-path", () => ({
+  useCommerce: (...a: unknown[]) => mockUseCommerce(...a),
+}));
+
+jest.mock("react-instantsearch", () => ({
+  useSearchBox: (...a: unknown[]) => mockUseSearchBox(...a),
+}));
+
+jest.mock(
+  "@algolia/autocomplete-core",
+  () => ({
+    __esModule: true,
+    createAutocomplete: (...args: any[]) => mockCreateAutocomplete(...args),
+  }),
+  { virtual: true }
+);
+
+jest.mock("../../utils/getEPClient", () => ({
+  getEPClient: jest.fn().mockReturnValue({ baseUrl: "https://test.example" }),
+}));
+
+const mockPostMultiSearch = jest.fn().mockResolvedValue({
+  data: { results: [{ hits: [] }] },
+});
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  __esModule: true,
+  postMultiSearch: (...a: any[]) => mockPostMultiSearch(...a),
+}));
+
+/* ---------- code under test ---------- */
+import { render, act, fireEvent } from "@testing-library/react";
+import { describeHeadlessStylingContract } from "./headless-styling-contract";
+
+const {
+  EPSearchAutocomplete,
+  epSearchAutocompleteMeta,
+  registerEPSearchAutocomplete,
+} = require("../EPSearchAutocomplete") as typeof import("../EPSearchAutocomplete");
+
+const {
+  EPSearchAutocompleteInput,
+  epSearchAutocompleteInputMeta,
+  registerEPSearchAutocompleteInput,
+} = require("../EPSearchAutocompleteInput") as typeof import("../EPSearchAutocompleteInput");
+
+const {
+  EPSearchAutocompletePanel,
+  epSearchAutocompletePanelMeta,
+  registerEPSearchAutocompletePanel,
+} = require("../EPSearchAutocompletePanel") as typeof import("../EPSearchAutocompletePanel");
+
+const {
+  EPSearchAutocompleteList,
+  epSearchAutocompleteListMeta,
+  registerEPSearchAutocompleteList,
+} = require("../EPSearchAutocompleteList") as typeof import("../EPSearchAutocompleteList");
+
+const {
+  MOCK_AUTOCOMPLETE_DATA,
+} = require("../design-time-data") as typeof import("../design-time-data");
+
+function setEditorMode(inEditor: boolean) {
+  if (inEditor) {
+    mockUsePlasmicCanvasContext.mockReturnValue({});
+  } else {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // mockClear leaves mockResolvedValueOnce queues intact across tests; reset
+  // the postMultiSearch mock to flush anything left over.
+  mockPostMultiSearch.mockReset();
+  mockPostMultiSearch.mockResolvedValue({
+    data: { results: [{ hits: [] }] },
+  });
+  fakeAutocompleteInstances.length = 0;
+  mockUsePlasmicCanvasContext.mockReturnValue(null);
+  mockUseSearchBox.mockReturnValue({
+    query: "",
+    refine: jest.fn(),
+    clear: jest.fn(),
+  });
+  mockUseCommerce.mockReturnValue({
+    providerRef: { current: { client: {}, locale: "en-US" } },
+  });
+});
+
+/* ================================================================
+ * EPSearchAutocomplete provider — meta + editor mock branch
+ * ================================================================ */
+describe("EPSearchAutocomplete provider", () => {
+  it("meta enforces parentComponentName and exposes ref-actions", () => {
+    expect(epSearchAutocompleteMeta.name).toBe(
+      "plasmic-commerce-ep-search-autocomplete"
+    );
+    expect(epSearchAutocompleteMeta.parentComponentName).toBe(
+      "plasmic-commerce-ep-catalog-search-provider"
+    );
+    expect(epSearchAutocompleteMeta.providesData).toBe(true);
+    expect(epSearchAutocompleteMeta.refActions!.setQuery).toBeDefined();
+    expect(epSearchAutocompleteMeta.refActions!.focus).toBeDefined();
+    expect(epSearchAutocompleteMeta.refActions!.clear).toBeDefined();
+  });
+
+  it("publishes mock autocompleteData via DataProvider in editor", () => {
+    setEditorMode(true);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <div data-testid="user-content">child</div>
+      </EPSearchAutocomplete>
+    );
+
+    const provider = container.querySelector(
+      '[data-testid="data-provider-autocompleteData"]'
+    );
+    expect(provider).not.toBeNull();
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.isOpen).toBe(MOCK_AUTOCOMPLETE_DATA.isOpen);
+    expect(data.query).toBe(MOCK_AUTOCOMPLETE_DATA.query);
+    expect(data.collections[0].sourceId).toBe("predictions");
+  });
+
+  it("renders children and the data-ep-autocomplete-root wrapper", () => {
+    setEditorMode(true);
+
+    const { container, getByTestId } = render(
+      <EPSearchAutocomplete>
+        <div data-testid="user-content">child</div>
+      </EPSearchAutocomplete>
+    );
+
+    expect(container.querySelector("[data-ep-autocomplete-root]")).not.toBeNull();
+    expect(getByTestId("user-content")).not.toBeNull();
+  });
+
+  it("at runtime, drives createAutocomplete via useEPAutocompleteState", () => {
+    setEditorMode(false);
+
+    render(
+      <EPSearchAutocomplete>
+        <div>child</div>
+      </EPSearchAutocomplete>
+    );
+
+    expect(mockCreateAutocomplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("at runtime, publishes autocompleteData with collections from the hook", async () => {
+    setEditorMode(false);
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: { results: [{ hits: [{ q: "leather bag" }] }] },
+    });
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <div>child</div>
+      </EPSearchAutocomplete>
+    );
+
+    await act(async () => {
+      await fakeAutocompleteInstances[0].__triggerInput("leat");
+    });
+
+    const provider = container.querySelector(
+      '[data-testid="data-provider-autocompleteData"]'
+    );
+    const data = JSON.parse(
+      provider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.query).toBe("leat");
+    expect(data.isOpen).toBe(true);
+    expect(data.collections[0].items[0].q).toBe("leather bag");
+  });
+});
+
+/* ================================================================
+ * Headless styling contracts
+ * ================================================================ */
+describeHeadlessStylingContract({
+  componentName: "EPSearchAutocomplete",
+  leafSelector: "[data-ep-autocomplete-root]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchAutocomplete className={className}>
+      <div>child</div>
+    </EPSearchAutocomplete>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPSearchAutocomplete className={className}>
+      <div>child</div>
+    </EPSearchAutocomplete>
+  ),
+});
+
+/* ================================================================
+ * EPSearchAutocompleteInput — meta + Pattern C cloneElement
+ * ================================================================ */
+describe("EPSearchAutocompleteInput", () => {
+  it("meta enforces parentComponentName", () => {
+    expect(epSearchAutocompleteInputMeta.parentComponentName).toBe(
+      "plasmic-commerce-ep-search-autocomplete"
+    );
+  });
+
+  it("renders the slot's input and forwards getInputProps via cloneElement at runtime", () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput>
+          <input type="search" data-testid="user-input" />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe("");
+  });
+
+  it("typing in the slot input drives autocomplete-core's setQuery (and the DataProvider state)", async () => {
+    setEditorMode(false);
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: { results: [{ hits: [{ q: "boots" }] }] },
+    });
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput>
+          <input type="search" data-testid="user-input" />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "boot" } });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fakeAutocompleteInstances[0].state.query).toBe("boot");
+  });
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchAutocompleteInput",
+  leafSelector: "input",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchAutocomplete>
+      <EPSearchAutocompleteInput className={className}>
+        <input type="search" />
+      </EPSearchAutocompleteInput>
+    </EPSearchAutocomplete>
+  ),
+  renderAtRuntime: ({ className }) => (
+    <EPSearchAutocomplete>
+      <EPSearchAutocompleteInput className={className}>
+        <input type="search" />
+      </EPSearchAutocompleteInput>
+    </EPSearchAutocomplete>
+  ),
+});
+
+/* ================================================================
+ * EPSearchAutocompletePanel — visibility gated by state.isOpen
+ * ================================================================ */
+describe("EPSearchAutocompletePanel", () => {
+  it("meta enforces parentComponentName", () => {
+    expect(epSearchAutocompletePanelMeta.parentComponentName).toBe(
+      "plasmic-commerce-ep-search-autocomplete"
+    );
+  });
+
+  it("renders the panel only when state.isOpen is true at runtime", async () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel>
+          <div data-testid="panel-content">panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    // Initially closed (empty query).
+    expect(
+      container.querySelector('[data-testid="panel-content"]')
+    ).toBeNull();
+
+    // Type a query to open the panel.
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: { results: [{ hits: [{ q: "shoes" }] }] },
+    });
+    await act(async () => {
+      await fakeAutocompleteInstances[0].__triggerInput("sho");
+    });
+
+    expect(
+      container.querySelector('[data-testid="panel-content"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector("[data-ep-autocomplete-panel]")
+    ).not.toBeNull();
+  });
+
+  it("renders the mobile close button with data-ep-autocomplete-close at runtime when open", async () => {
+    setEditorMode(false);
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: { results: [{ hits: [{ q: "x" }] }] },
+    });
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel>
+          <div>panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    await act(async () => {
+      await fakeAutocompleteInstances[0].__triggerInput("x");
+    });
+
+    const closeButton = container.querySelector(
+      "[data-ep-autocomplete-close]"
+    );
+    expect(closeButton).not.toBeNull();
+    expect(closeButton!.tagName.toLowerCase()).toBe("button");
+  });
+
+  it("editor mode renders the panel unconditionally with mock content", () => {
+    setEditorMode(true);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompletePanel>
+          <div data-testid="panel-content">panel</div>
+        </EPSearchAutocompletePanel>
+      </EPSearchAutocomplete>
+    );
+
+    expect(
+      container.querySelector('[data-testid="panel-content"]')
+    ).not.toBeNull();
+  });
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchAutocompletePanel",
+  leafSelector: "[data-ep-autocomplete-panel]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchAutocomplete>
+      <EPSearchAutocompletePanel className={className}>
+        <div>panel</div>
+      </EPSearchAutocompletePanel>
+    </EPSearchAutocomplete>
+  ),
+});
+
+/* ================================================================
+ * EPSearchAutocompleteList — repeater + selection refine
+ * ================================================================ */
+describe("EPSearchAutocompleteList", () => {
+  it("meta enforces parentComponentName", () => {
+    expect(epSearchAutocompleteListMeta.parentComponentName).toBe(
+      "plasmic-commerce-ep-search-autocomplete"
+    );
+  });
+
+  it("renders one <li> per item in the configured source at runtime", async () => {
+    setEditorMode(false);
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            hits: [
+              { q: "leather bag" },
+              { q: "leather wallet" },
+              { q: "leather shoes" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteList>
+          <div data-testid="row">row</div>
+        </EPSearchAutocompleteList>
+      </EPSearchAutocomplete>
+    );
+
+    await act(async () => {
+      await fakeAutocompleteInstances[0].__triggerInput("leat");
+    });
+
+    const items = container.querySelectorAll('[role="option"]');
+    expect(items).toHaveLength(3);
+  });
+
+  it("publishes per-iteration currentSuggestion via DataProvider at runtime", async () => {
+    setEditorMode(false);
+    mockPostMultiSearch.mockResolvedValueOnce({
+      data: {
+        results: [{ hits: [{ q: "leather bag" }] }],
+      },
+    });
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteList>
+          <span data-testid="row">row</span>
+        </EPSearchAutocompleteList>
+      </EPSearchAutocomplete>
+    );
+
+    await act(async () => {
+      await fakeAutocompleteInstances[0].__triggerInput("leat");
+    });
+
+    const suggestionProvider = container.querySelector(
+      '[data-testid="data-provider-currentSuggestion"]'
+    );
+    expect(suggestionProvider).not.toBeNull();
+    const data = JSON.parse(
+      suggestionProvider!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.item.q).toBe("leather bag");
+    expect(typeof data.isHighlighted).toBe("boolean");
+    expect(data.source).toBe("predictions");
+  });
+
+  it("renders mock items in editor mode", () => {
+    setEditorMode(true);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteList>
+          <span>row</span>
+        </EPSearchAutocompleteList>
+      </EPSearchAutocomplete>
+    );
+
+    const items = container.querySelectorAll('[role="option"]');
+    expect(items.length).toBe(MOCK_AUTOCOMPLETE_DATA.collections[0].items.length);
+  });
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSearchAutocompleteList",
+  leafSelector: "[data-ep-autocomplete-list]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSearchAutocomplete>
+      <EPSearchAutocompleteList className={className}>
+        <span>row</span>
+      </EPSearchAutocompleteList>
+    </EPSearchAutocomplete>
+  ),
+});
+
+/* ================================================================
+ * Registerable smoke tests
+ * ================================================================ */
+describe("autocomplete component registrations", () => {
+  it("each register* function calls registerComponent", () => {
+    const registerComponent = require("@plasmicapp/host/registerComponent")
+      .default as jest.Mock;
+    registerComponent.mockClear();
+
+    registerEPSearchAutocomplete();
+    registerEPSearchAutocompleteInput();
+    registerEPSearchAutocompletePanel();
+    registerEPSearchAutocompleteList();
+
+    expect(registerComponent).toHaveBeenCalledTimes(4);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/autocomplete-components.test.tsx
@@ -447,6 +447,23 @@ describe("EPSearchAutocompleteInput", () => {
     expect(fakeAutocompleteInstances[0].state.query).toBe("boot");
   });
 
+  it("injects the default placeholder when the prop is undefined (existing instances)", () => {
+    setEditorMode(false);
+
+    const { container } = render(
+      <EPSearchAutocomplete>
+        <EPSearchAutocompleteInput>
+          <input type="search" data-testid="user-input" />
+        </EPSearchAutocompleteInput>
+      </EPSearchAutocomplete>
+    );
+
+    const input = container.querySelector(
+      '[data-testid="user-input"]'
+    ) as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("Search products...");
+  });
+
   it("injects the placeholder prop onto the slot input", () => {
     setEditorMode(false);
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/predictionsSource.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/predictionsSource.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for predictionsSource — the pure factory that builds an
+ * autocomplete-core source descriptor wired against EP's postMultiSearch.
+ *
+ * The factory has zero React/DOM dependencies. Tests pass a fake
+ * postMultiSearch callable in and assert on the request body it receives
+ * and the items returned from `getItems`.
+ */
+
+import {
+  predictionsSource,
+  PredictionsSourceItem,
+} from "../predictionsSource";
+
+type MultiSearchResponse = {
+  results: Array<{ hits: Array<Record<string, unknown>> }>;
+};
+
+function makeOkResponse(hits: Array<Record<string, unknown>>): MultiSearchResponse {
+  return { results: [{ hits }] };
+}
+
+describe("predictionsSource", () => {
+  it("calls postMultiSearch with the autocomplete request shape and the configured predictionsField", async () => {
+    const postMultiSearch = jest.fn().mockResolvedValue(makeOkResponse([]));
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch,
+    });
+
+    await source.getItems({ query: "leat" });
+
+    expect(postMultiSearch).toHaveBeenCalledTimes(1);
+    const body = postMultiSearch.mock.calls[0][0];
+    expect(body).toMatchObject({
+      searches: [
+        expect.objectContaining({
+          type: "autocomplete",
+          q: "leat",
+          include_fields: "q",
+          highlight_full_fields: "q",
+        }),
+      ],
+    });
+  });
+
+  it("forwards a custom predictionsField into include_fields and highlight_full_fields", async () => {
+    const postMultiSearch = jest.fn().mockResolvedValue(makeOkResponse([]));
+    const source = predictionsSource({
+      predictionsField: "suggestion",
+      postMultiSearch,
+    });
+
+    await source.getItems({ query: "a" });
+
+    const body = postMultiSearch.mock.calls[0][0];
+    expect(body.searches[0]).toMatchObject({
+      include_fields: "suggestion",
+      highlight_full_fields: "suggestion",
+    });
+  });
+
+  it("maps response.results[0].hits onto items, preserving the raw hit on _raw", async () => {
+    // Plain hits without a `document` wrapper still flatten directly.
+    const hit1 = {
+      q: "leather bag",
+      _highlightResult: { q: { value: "<em>leather</em> bag" } },
+    };
+    const hit2 = { q: "leather wallet" };
+    const postMultiSearch = jest
+      .fn()
+      .mockResolvedValue(makeOkResponse([hit1, hit2]));
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch,
+    });
+
+    const items = (await source.getItems({ query: "leat" })) as PredictionsSourceItem[];
+
+    expect(items).toHaveLength(2);
+    expect(items[0]._raw).toBe(hit1);
+    expect(items[1]._raw).toBe(hit2);
+  });
+
+  it("flattens EP/Typesense hit.document fields onto the item for designer ergonomics", async () => {
+    const hit = {
+      document: { q: "green", id: "abc", count: 10 },
+      highlight: { q: { value: "<mark>green</mark>" } },
+      highlights: [{ field: "q", value: "<mark>green</mark>" }],
+    };
+    const postMultiSearch = jest.fn().mockResolvedValue(makeOkResponse([hit]));
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch,
+    });
+
+    const items = (await source.getItems({ query: "gre" })) as PredictionsSourceItem[];
+
+    expect(items[0].q).toBe("green");
+    expect(items[0].id).toBe("abc");
+    expect(items[0].count).toBe(10);
+    // raw hit preserved so designers can reach highlight HTML if needed
+    expect(items[0]._raw).toBe(hit);
+  });
+
+  it("returns [] when postMultiSearch rejects (does not propagate the error)", async () => {
+    const postMultiSearch = jest
+      .fn()
+      .mockRejectedValue(new Error("boom"));
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch,
+    });
+
+    const items = await source.getItems({ query: "leat" });
+
+    expect(items).toEqual([]);
+  });
+
+  it("returns [] when response has no results array", async () => {
+    const postMultiSearch = jest.fn().mockResolvedValue({});
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch,
+    });
+
+    const items = await source.getItems({ query: "leat" });
+
+    expect(items).toEqual([]);
+  });
+
+  it("exposes sourceId 'predictions' on the descriptor", () => {
+    const source = predictionsSource({
+      predictionsField: "q",
+      postMultiSearch: jest.fn(),
+    });
+    expect(source.sourceId).toBe("predictions");
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/useEPAutocompleteState.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/useEPAutocompleteState.test.tsx
@@ -1,0 +1,553 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the deep-module hook that owns the autocomplete-core lifecycle.
+ *
+ * The hook is the single point of integration between
+ * `@algolia/autocomplete-core` and the EP catalog-search query state. The
+ * four React components consume the hook output and never touch
+ * `createAutocomplete` directly — that boundary is what we test here.
+ *
+ * `@algolia/autocomplete-core` is mocked: a small fake replicates the
+ * state-machine contract (createAutocomplete returns prop-getters,
+ * `setQuery`/`setIsOpen` mutate state, every mutation calls onStateChange).
+ * `react-instantsearch` is mocked the same way the existing component
+ * tests mock it.
+ */
+
+import React from "react";
+import { render, act } from "@testing-library/react";
+
+/* ---------- mock variables ---------- */
+const mockUseSearchBox = jest.fn();
+
+interface FakeState {
+  query: string;
+  isOpen: boolean;
+  activeItemId: number | null;
+  collections: Array<{ source: { sourceId: string }; items: Array<any> }>;
+  status: string;
+}
+
+interface FakeAutocompleteInstance {
+  state: FakeState;
+  setIsOpen: (value: boolean) => void;
+  setQuery: (value: string) => void;
+  setActiveItemId: (value: number | null) => void;
+  getInputProps: (props?: any) => any;
+  getPanelProps: (props?: any) => any;
+  getListProps: (props?: any) => any;
+  getItemProps: (props: any) => any;
+  getRootProps: (props?: any) => any;
+  getEnvironmentProps: (props?: any) => any;
+  // test-only helpers
+  __triggerInput: (value: string) => Promise<void>;
+  __triggerSubmit: () => void;
+  __triggerSelect: (sourceId: string, itemIndex: number) => void;
+  __sourcesConfig: Array<{ sourceId: string; getItems: any; onSelect?: any }>;
+  __onStateChangeCalls: number;
+}
+
+const fakeInstances: FakeAutocompleteInstance[] = [];
+
+const mockCreateAutocomplete = jest.fn((config: any) => {
+  const state: FakeState = {
+    query: "",
+    isOpen: false,
+    activeItemId: null,
+    collections: [],
+    status: "idle",
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noop = () => {};
+
+  let onStateChangeCalls = 0;
+
+  const notify = () => {
+    onStateChangeCalls += 1;
+    if (config.onStateChange) {
+      config.onStateChange({ state, prevState: state });
+    }
+  };
+
+  // Sources are populated synchronously from config.getSources() so the
+  // hook's first render leaves sourcesConfig observable without an await.
+  // Real autocomplete-core only calls getSources lazily on setQuery — but
+  // the fake materialises them eagerly because tests rely on them.
+  let sourcesConfig: any[] = config.getSources
+    ? config.getSources({ query: "", state, setQuery, setIsOpen }) ?? []
+    : [];
+
+  const refreshSources = async (query: string) => {
+    if (query.length === 0) {
+      state.collections = [];
+      state.isOpen = false;
+      notify();
+      return;
+    }
+    const items = await Promise.all(
+      sourcesConfig.map(async (src) => ({
+        source: { sourceId: src.sourceId },
+        items: await src.getItems({ query }),
+      }))
+    );
+    state.collections = items;
+    state.isOpen = items.some((c) => c.items.length > 0);
+    notify();
+  };
+
+  function setQuery(value: string) {
+    state.query = value;
+    notify();
+    void refreshSources(value);
+  }
+  function setIsOpen(value: boolean) {
+    state.isOpen = value;
+    notify();
+  }
+  function setActiveItemId(value: number | null) {
+    state.activeItemId = value;
+    notify();
+  }
+
+  const instance: FakeAutocompleteInstance = {
+    state,
+    setQuery,
+    setIsOpen,
+    setActiveItemId,
+    getInputProps: () => ({
+      value: state.query,
+      onChange: (event: { currentTarget: { value: string } }) =>
+        setQuery(event.currentTarget.value),
+      onKeyDown: noop,
+      onFocus: noop,
+      onBlur: noop,
+    }),
+    getPanelProps: (props?: any) => ({ ...(props ?? {}) }),
+    getListProps: (props?: any) => ({ ...(props ?? {}), role: "listbox" }),
+    getItemProps: ({ item, source }: any) => ({
+      role: "option",
+      "aria-selected": "false",
+      onClick: () => {
+        const src = sourcesConfig.find(
+          (s) => s.sourceId === source.sourceId
+        );
+        if (src?.onSelect) {
+          src.onSelect({ item, source, setQuery, setIsOpen, state });
+        }
+      },
+      "data-item-id": item?.q,
+    }),
+    getRootProps: (props?: any) => ({ ...(props ?? {}) }),
+    getEnvironmentProps: (props?: any) => ({ ...(props ?? {}) }),
+    __sourcesConfig: sourcesConfig,
+    get __onStateChangeCalls() {
+      return onStateChangeCalls;
+    },
+    async __triggerInput(value: string) {
+      // Simulate `getInputProps().onChange` to exercise the integration.
+      setQuery(value);
+      // Wait for refreshSources to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    __triggerSubmit() {
+      // Submit without an active item — the hook's submit handler should
+      // refine with current state.query.
+      // The real autocomplete-core surfaces this via onSubmit on
+      // getFormProps — we expose a hook-level handler to keep the test
+      // isolated from the prop-getter wiring detail.
+    },
+    __triggerSelect(sourceId: string, itemIndex: number) {
+      const collection = state.collections.find(
+        (c) => c.source.sourceId === sourceId
+      );
+      const item = collection?.items[itemIndex];
+      const src = sourcesConfig.find((s) => s.sourceId === sourceId);
+      if (item && src?.onSelect) {
+        src.onSelect({
+          item,
+          source: { sourceId },
+          setQuery,
+          setIsOpen,
+          state,
+        });
+      }
+    },
+  };
+
+  // Patch sources back so the fake reflects the actual config after
+  // the async getSources() resolves.
+  Object.defineProperty(instance, "__sourcesConfig", {
+    get: () => sourcesConfig,
+  });
+
+  fakeInstances.push(instance);
+  return instance;
+});
+
+jest.mock(
+  "@algolia/autocomplete-core",
+  () => ({
+    __esModule: true,
+    createAutocomplete: (...args: any[]) => mockCreateAutocomplete(...args),
+  }),
+  { virtual: true }
+);
+
+jest.mock("react-instantsearch", () => ({
+  useSearchBox: (...a: unknown[]) => mockUseSearchBox(...a),
+}));
+
+/* ---------- code under test ---------- */
+import {
+  useEPAutocompleteState,
+  UseEPAutocompleteStateConfig,
+} from "../useEPAutocompleteState";
+
+/* ---------- harness ---------- */
+type CapturedHookOutput = ReturnType<typeof useEPAutocompleteState>;
+
+function HookHarness({
+  config,
+  capture,
+}: {
+  config: UseEPAutocompleteStateConfig;
+  capture: (output: CapturedHookOutput) => void;
+}) {
+  const output = useEPAutocompleteState(config);
+  capture(output);
+  return null;
+}
+
+function makePostMultiSearch(items: Array<{ q: string }>) {
+  return jest.fn().mockResolvedValue({ results: [{ hits: items }] });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fakeInstances.length = 0;
+  mockUseSearchBox.mockReturnValue({
+    query: "",
+    refine: jest.fn(),
+    clear: jest.fn(),
+  });
+});
+
+describe("useEPAutocompleteState", () => {
+  it("initialises createAutocomplete with the predictions source and exposes prop-getters", () => {
+    const postMultiSearch = makePostMultiSearch([{ q: "leather bag" }]);
+    let captured: CapturedHookOutput | null = null;
+
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={(o) => {
+          captured = o;
+        }}
+      />
+    );
+
+    expect(mockCreateAutocomplete).toHaveBeenCalledTimes(1);
+    expect(captured).not.toBeNull();
+    expect(typeof captured!.getInputProps).toBe("function");
+    expect(typeof captured!.getPanelProps).toBe("function");
+    expect(typeof captured!.getListProps).toBe("function");
+    expect(typeof captured!.getItemProps).toBe("function");
+    expect(typeof captured!.setQuery).toBe("function");
+    expect(typeof captured!.clear).toBe("function");
+  });
+
+  it("with enableRecentSearches=false, registers exactly the predictions source", () => {
+    const postMultiSearch = makePostMultiSearch([]);
+    let captured: CapturedHookOutput | null = null;
+
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={(o) => {
+          captured = o;
+        }}
+      />
+    );
+
+    const instance = fakeInstances[0];
+    expect(instance.__sourcesConfig).toHaveLength(1);
+    expect(instance.__sourcesConfig[0].sourceId).toBe("predictions");
+  });
+
+  it("publishes collections for the predictions source after typing", async () => {
+    const postMultiSearch = makePostMultiSearch([
+      { q: "leather bag" },
+      { q: "leather wallet" },
+    ]);
+    const captures: CapturedHookOutput[] = [];
+
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={(o) => captures.push(o)}
+      />
+    );
+
+    await act(async () => {
+      await fakeInstances[0].__triggerInput("leat");
+    });
+
+    const last = captures[captures.length - 1];
+    expect(last.collections).toHaveLength(1);
+    expect(last.collections[0].sourceId).toBe("predictions");
+    expect(last.collections[0].items).toHaveLength(2);
+    expect(last.collections[0].items[0].q).toBe("leather bag");
+  });
+
+  it("debounces useSearchBox().refine — many keystrokes produce one call with the latest value", async () => {
+    jest.useFakeTimers();
+    const refine = jest.fn();
+    mockUseSearchBox.mockReturnValue({ query: "", refine, clear: jest.fn() });
+
+    const postMultiSearch = makePostMultiSearch([]);
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 250,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={() => {}}
+      />
+    );
+
+    await act(async () => {
+      await fakeInstances[0].__triggerInput("l");
+      await fakeInstances[0].__triggerInput("le");
+      await fakeInstances[0].__triggerInput("lea");
+    });
+
+    expect(refine).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith("lea");
+
+    jest.useRealTimers();
+  });
+
+  it("selection invokes refine immediately with item[predictionsField] and closes the panel", async () => {
+    const refine = jest.fn();
+    mockUseSearchBox.mockReturnValue({ query: "", refine, clear: jest.fn() });
+    const postMultiSearch = makePostMultiSearch([
+      { q: "leather bag" },
+      { q: "leather wallet" },
+    ]);
+
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={() => {}}
+      />
+    );
+
+    await act(async () => {
+      await fakeInstances[0].__triggerInput("leat");
+    });
+
+    refine.mockClear();
+    act(() => {
+      fakeInstances[0].__triggerSelect("predictions", 0);
+    });
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith("leather bag");
+    expect(fakeInstances[0].state.isOpen).toBe(false);
+  });
+
+  it("submit() — refines with the current input value and closes the panel", async () => {
+    const refine = jest.fn();
+    mockUseSearchBox.mockReturnValue({ query: "", refine, clear: jest.fn() });
+    const postMultiSearch = makePostMultiSearch([{ q: "leather" }]);
+
+    let captured: CapturedHookOutput | null = null;
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={(o) => {
+          captured = o;
+        }}
+      />
+    );
+
+    await act(async () => {
+      await fakeInstances[0].__triggerInput("leat");
+    });
+
+    refine.mockClear();
+    act(() => {
+      captured!.submit();
+    });
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith("leat");
+    expect(fakeInstances[0].state.isOpen).toBe(false);
+  });
+
+  it("initial input value mirrors useSearchBox().query", async () => {
+    mockUseSearchBox.mockReturnValue({
+      query: "boots",
+      refine: jest.fn(),
+      clear: jest.fn(),
+    });
+    const postMultiSearch = makePostMultiSearch([{ q: "boots" }]);
+
+    await act(async () => {
+      render(
+        <HookHarness
+          config={{
+            predictionsField: "q",
+            debounceMs: 300,
+            enableRecentSearches: false,
+            postMultiSearch,
+          }}
+          capture={() => {}}
+        />
+      );
+      // Flush the deferred setQuery effect and the async source refresh.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The hook should call setQuery("boots") on the autocomplete-core
+    // instance, so the state reflects the existing refinement.
+    expect(fakeInstances[0].state.query).toBe("boots");
+  });
+
+  it("clear() — empties query, closes panel, and clears the underlying useSearchBox", async () => {
+    const refine = jest.fn();
+    const clearRefine = jest.fn();
+    mockUseSearchBox.mockReturnValue({
+      query: "leat",
+      refine,
+      clear: clearRefine,
+    });
+    const postMultiSearch = makePostMultiSearch([{ q: "leather" }]);
+
+    let captured: CapturedHookOutput | null = null;
+    await act(async () => {
+      render(
+        <HookHarness
+          config={{
+            predictionsField: "q",
+            debounceMs: 300,
+            enableRecentSearches: false,
+            postMultiSearch,
+          }}
+          capture={(o) => {
+            captured = o;
+          }}
+        />
+      );
+      // Flush the deferred initial-mirror effect + async source refresh.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      captured!.clear();
+    });
+
+    expect(fakeInstances[0].state.query).toBe("");
+    expect(fakeInstances[0].state.isOpen).toBe(false);
+    expect(clearRefine).toHaveBeenCalledTimes(1);
+  });
+
+  it("setQuery() — drives autocomplete-core's setQuery (parity with the input onChange path)", async () => {
+    const postMultiSearch = makePostMultiSearch([{ q: "leather" }]);
+
+    let captured: CapturedHookOutput | null = null;
+    render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 300,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={(o) => {
+          captured = o;
+        }}
+      />
+    );
+
+    await act(async () => {
+      captured!.setQuery("hat");
+      // settle async getItems
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fakeInstances[0].state.query).toBe("hat");
+  });
+
+  it("unmount cancels the pending debounce and never calls refine", async () => {
+    jest.useFakeTimers();
+    const refine = jest.fn();
+    mockUseSearchBox.mockReturnValue({ query: "", refine, clear: jest.fn() });
+    const postMultiSearch = makePostMultiSearch([]);
+
+    const { unmount } = render(
+      <HookHarness
+        config={{
+          predictionsField: "q",
+          debounceMs: 250,
+          enableRecentSearches: false,
+          postMultiSearch,
+        }}
+        capture={() => {}}
+      />
+    );
+
+    await act(async () => {
+      await fakeInstances[0].__triggerInput("lea");
+    });
+
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(refine).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
@@ -413,3 +413,51 @@ export const MOCK_SORT_BY_DATA: SortByData = {
     { value: "name:asc", label: "Name: A to Z" },
   ],
 };
+
+// ---------------------------------------------------------------------------
+// AutocompleteData — shape exposed by EPSearchAutocomplete provider
+// ---------------------------------------------------------------------------
+
+export interface AutocompleteSuggestionItem {
+  /** Raw suggestion text under the configured predictionsField. */
+  q: string;
+  /** Original adapter hit, preserved so designers can reach into highlight markup. */
+  _raw?: Record<string, unknown>;
+}
+
+export interface AutocompleteCollection {
+  sourceId: string;
+  items: AutocompleteSuggestionItem[];
+}
+
+export interface AutocompleteData {
+  /** Whether the panel should be rendered (mirrors autocomplete-core state). */
+  isOpen: boolean;
+  /** Current query string in the autocomplete input. */
+  query: string;
+  /** Per-source item collections — each source renders its own list. */
+  collections: AutocompleteCollection[];
+}
+
+export const MOCK_AUTOCOMPLETE_DATA: AutocompleteData = {
+  isOpen: true,
+  query: "leat",
+  collections: [
+    {
+      sourceId: "predictions",
+      items: [
+        { q: "leather bag" },
+        { q: "leather wallet" },
+        { q: "leather card holder" },
+      ],
+    },
+  ],
+};
+
+// Per-iteration context published by EPSearchAutocompleteList.
+export interface CurrentSuggestion {
+  item: AutocompleteSuggestionItem;
+  isHighlighted: boolean;
+  source: string;
+  query: string;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/headless-styling.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/headless-styling.ts
@@ -30,6 +30,76 @@ const STYLE_BLOCK = `
   flex-wrap: wrap;
   gap: 8px;
 }
+:where([data-ep-autocomplete-root]) {
+  position: relative;
+  width: 100%;
+}
+/* Hide the browser-native clear cross that input[type=search] adds on
+ * focus/hover. Designers wire their own clear control via the
+ * "clear" ref-action and the slot. */
+[data-ep-autocomplete-root] input[type="search"]::-webkit-search-cancel-button,
+[data-ep-autocomplete-root] input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+:where([data-ep-autocomplete-panel]) {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin-top: 4px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  padding: 4px 0;
+}
+/* Plasmic generates per-element classes with specificity (0,1,0) that
+ * include browser-default ul styles (list-style, padding, margin). :where()
+ * has (0,0,0) and loses, so anchor these resets to the data-attribute
+ * directly — same (0,1,0) specificity as Plasmic's class but with
+ * source-order precedence on our side. Designers who need to override can
+ * still target the list with their own class plus a more-specific selector
+ * (e.g. their parent class). */
+ul[data-ep-autocomplete-list] {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+[data-ep-autocomplete-list] > li {
+  cursor: pointer;
+  padding: 0;
+  list-style: none;
+}
+[data-ep-autocomplete-list] > li:hover,
+[data-ep-autocomplete-list] > li[aria-selected="true"] {
+  background: #f5f5f5;
+}
+:where([data-ep-autocomplete-close]) {
+  display: none;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+@media (max-width: 680px) {
+  :where([data-ep-autocomplete-panel]) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    max-height: none;
+  }
+  :where([data-ep-autocomplete-close]) {
+    display: inline-flex;
+  }
+}
 `;
 
 let injected = false;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/index.ts
@@ -27,6 +27,22 @@ export {
   EPCurrentRefinements,
   registerEPCurrentRefinements,
 } from "./EPCurrentRefinements";
+export {
+  EPSearchAutocomplete,
+  registerEPSearchAutocomplete,
+} from "./EPSearchAutocomplete";
+export {
+  EPSearchAutocompleteInput,
+  registerEPSearchAutocompleteInput,
+} from "./EPSearchAutocompleteInput";
+export {
+  EPSearchAutocompletePanel,
+  registerEPSearchAutocompletePanel,
+} from "./EPSearchAutocompletePanel";
+export {
+  EPSearchAutocompleteList,
+  registerEPSearchAutocompleteList,
+} from "./EPSearchAutocompleteList";
 
 export type {
   CatalogSearchData,
@@ -39,4 +55,8 @@ export type {
   ClearRefinementsData,
   CurrentRefinementChip,
   CurrentRefinementType,
+  AutocompleteData,
+  AutocompleteCollection,
+  AutocompleteSuggestionItem,
+  CurrentSuggestion,
 } from "./design-time-data";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/predictionsSource.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/predictionsSource.ts
@@ -1,0 +1,82 @@
+/**
+ * predictionsSource — autocomplete-core source descriptor for EP query suggestions.
+ *
+ * Pure factory: takes a `postMultiSearch` callable plus the configured
+ * suggestion field name, returns the descriptor `@algolia/autocomplete-core`
+ * expects under `sources`. Owns the request-body shape (the `type=autocomplete`
+ * multi-search body) and the response → items mapping. Errors from the
+ * adapter become an empty list rather than a thrown rejection — autocomplete
+ * UI must not crash a search page when the autocomplete collection is missing
+ * or the network drops.
+ */
+
+export interface PredictionsSourceConfig {
+  predictionsField: string;
+  postMultiSearch: (body: MultiSearchBody) => Promise<MultiSearchResponse>;
+}
+
+export interface MultiSearchBody {
+  searches: Array<{
+    type: "autocomplete";
+    q: string;
+    include_fields: string;
+    highlight_full_fields: string;
+  }>;
+}
+
+export interface MultiSearchResponse {
+  results?: Array<{ hits?: Array<Record<string, unknown>> }>;
+}
+
+export interface PredictionsSourceItem extends Record<string, unknown> {
+  _raw: Record<string, unknown>;
+}
+
+export interface PredictionsSourceDescriptor {
+  sourceId: "predictions";
+  getItems: (params: { query: string }) => Promise<PredictionsSourceItem[]>;
+}
+
+export function predictionsSource(
+  config: PredictionsSourceConfig
+): PredictionsSourceDescriptor {
+  const { predictionsField, postMultiSearch } = config;
+
+  return {
+    sourceId: "predictions",
+    async getItems({ query }) {
+      try {
+        const response = await postMultiSearch({
+          searches: [
+            {
+              type: "autocomplete",
+              q: query,
+              include_fields: predictionsField,
+              highlight_full_fields: predictionsField,
+            },
+          ],
+        });
+        const hits = response?.results?.[0]?.hits ?? [];
+        return hits.map((hit) => {
+          // EP/Typesense responses wrap suggestion fields under `document`
+          // and highlight markup under `highlight`. When that shape is
+          // present, flatten `document` so designers can bind
+          // `$ctx.currentSuggestion.item.q` directly. Otherwise fall back
+          // to spreading the hit as-is. The raw hit is preserved on `_raw`
+          // either way (e.g. for highlight HTML at `_raw.highlight.q.value`).
+          const wrappedDocument =
+            hit && typeof hit === "object" && "document" in hit
+              ? (hit as { document?: Record<string, unknown> }).document
+              : undefined;
+          const flattened =
+            wrappedDocument && typeof wrappedDocument === "object"
+              ? wrappedDocument
+              : hit;
+          return { ...flattened, _raw: hit };
+        });
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/useEPAutocompleteState.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/useEPAutocompleteState.ts
@@ -1,0 +1,227 @@
+/**
+ * useEPAutocompleteState — deep-module hook owning autocomplete-core lifecycle.
+ *
+ * The four EP autocomplete React components consume this hook and never call
+ * `createAutocomplete` directly. The hook hides the state-machine setup,
+ * source construction, debounced live-mirror to `useSearchBox().refine`,
+ * selection-time immediate refine, and React-state subscription behind a
+ * single signature.
+ *
+ * Inputs are pure (no React types beyond ref boundary). Outputs are the
+ * autocomplete-core prop-getters plus a small set of imperative handlers
+ * the provider exposes as Plasmic ref-actions.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+} from "react";
+import {
+  predictionsSource,
+  MultiSearchBody,
+  MultiSearchResponse,
+} from "./predictionsSource";
+import { AutocompleteCollection } from "./design-time-data";
+
+export interface UseEPAutocompleteStateConfig {
+  predictionsField: string;
+  debounceMs: number;
+  enableRecentSearches: boolean;
+  recentSearchesKey?: string;
+  recentSearchesLimit?: number;
+  plugins?: any[];
+  postMultiSearch: (body: MultiSearchBody) => Promise<MultiSearchResponse>;
+}
+
+export interface UseEPAutocompleteStateResult {
+  state: any;
+  collections: AutocompleteCollection[];
+  getInputProps: (...args: any[]) => any;
+  getPanelProps: (...args: any[]) => any;
+  getListProps: (...args: any[]) => any;
+  getItemProps: (...args: any[]) => any;
+  getRootProps: (...args: any[]) => any;
+  getEnvironmentProps: (...args: any[]) => any;
+  setQuery: (value: string) => void;
+  focus: () => void;
+  clear: () => void;
+  submit: () => void;
+}
+
+export function useEPAutocompleteState(
+  config: UseEPAutocompleteStateConfig
+): UseEPAutocompleteStateResult {
+  const {
+    predictionsField,
+    debounceMs,
+    enableRecentSearches,
+    plugins,
+    postMultiSearch,
+  } = config;
+
+  const { useSearchBox } = require("react-instantsearch");
+  const {
+    query: instantSearchQuery,
+    refine,
+    clear: refineClear,
+  } = useSearchBox();
+
+  // Stable refs keep the instance handlers from going stale across renders.
+  const refineRef = useRef(refine);
+  refineRef.current = refine;
+  const refineClearRef = useRef(refineClear);
+  refineClearRef.current = refineClear;
+  const debounceMsRef = useRef(debounceMs);
+  debounceMsRef.current = debounceMs;
+  const predictionsFieldRef = useRef(predictionsField);
+  predictionsFieldRef.current = predictionsField;
+
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastMirroredQuery = useRef<string>(instantSearchQuery ?? "");
+  const [, forceRender] = useReducer((x: number) => x + 1, 0);
+
+  // autocomplete-core's createAutocomplete() does not expose `state` on the
+  // returned instance — state is delivered to subscribers via onStateChange.
+  // Maintain our own ref-tracked snapshot so render reads always see a value
+  // (default empty until the first state notification arrives).
+  const stateRef = useRef<any>({
+    query: instantSearchQuery ?? "",
+    isOpen: false,
+    activeItemId: null,
+    collections: [],
+    status: "idle",
+  });
+
+  const cancelDebounce = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+  }, []);
+
+  const scheduleRefine = useCallback(
+    (next: string) => {
+      cancelDebounce();
+      debounceTimer.current = setTimeout(() => {
+        refineRef.current(next);
+        debounceTimer.current = null;
+      }, debounceMsRef.current);
+    },
+    [cancelDebounce]
+  );
+
+  const instanceRef = useRef<any>(null);
+  if (instanceRef.current === null) {
+    const source = predictionsSource({ predictionsField, postMultiSearch });
+    const { createAutocomplete } = require("@algolia/autocomplete-core");
+
+    instanceRef.current = createAutocomplete({
+      onStateChange: ({ state }: any) => {
+        stateRef.current = state;
+        if (state.query !== lastMirroredQuery.current) {
+          lastMirroredQuery.current = state.query;
+          scheduleRefine(state.query);
+        }
+        forceRender();
+      },
+      getSources: () => [
+        {
+          sourceId: "predictions",
+          getItems: ({ query }: { query: string }) =>
+            source.getItems({ query }),
+          // autocomplete-core's default returns state.query — meaning a
+          // click would leave the input unchanged. Surface the item's
+          // suggestion field so selection updates the input value AND the
+          // URL via the live-mirror refine.
+          getItemInputValue: ({ item }: any) =>
+            (item?.[predictionsFieldRef.current] as string | undefined) ?? "",
+          onSelect: ({ item, setIsOpen }: any) => {
+            cancelDebounce();
+            const value =
+              (item?.[predictionsFieldRef.current] as string | undefined) ??
+              "";
+            lastMirroredQuery.current = value;
+            refineRef.current(value);
+            setIsOpen(false);
+          },
+        },
+      ],
+      plugins: plugins ?? [],
+    });
+  }
+
+  // Mirror the existing useSearchBox query into the autocomplete-core
+  // instance once on mount. Done in an effect (not at render time) so
+  // the resulting state notification stays inside React's update cycle.
+  const initialMirrorDone = useRef(false);
+  useEffect(() => {
+    if (initialMirrorDone.current) return;
+    initialMirrorDone.current = true;
+    if (instantSearchQuery) {
+      lastMirroredQuery.current = instantSearchQuery;
+      instanceRef.current.setQuery(instantSearchQuery);
+    }
+    // intentional: empty deps — runs once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cancelDebounce();
+    };
+  }, [cancelDebounce]);
+
+  const instance = instanceRef.current;
+
+  const setQueryAction = useCallback(
+    (value: string) => {
+      instance.setQuery(value);
+    },
+    [instance]
+  );
+
+  const focusAction = useCallback(() => {
+    instance.setIsOpen(true);
+  }, [instance]);
+
+  const clearAction = useCallback(() => {
+    cancelDebounce();
+    lastMirroredQuery.current = "";
+    instance.setQuery("");
+    instance.setIsOpen(false);
+    refineClearRef.current();
+  }, [cancelDebounce, instance]);
+
+  const submit = useCallback(() => {
+    cancelDebounce();
+    const v: string = stateRef.current?.query ?? "";
+    lastMirroredQuery.current = v;
+    refineRef.current(v);
+    instance.setIsOpen(false);
+  }, [cancelDebounce, instance]);
+
+  const currentState = stateRef.current;
+  const collections: AutocompleteCollection[] = (
+    currentState?.collections ?? []
+  ).map((c: any) => ({
+    sourceId: c.source?.sourceId ?? c.sourceId,
+    items: c.items,
+  }));
+
+  return {
+    state: currentState,
+    collections,
+    getInputProps: instance.getInputProps,
+    getPanelProps: instance.getPanelProps,
+    getListProps: instance.getListProps,
+    getItemProps: instance.getItemProps,
+    getRootProps: instance.getRootProps,
+    getEnvironmentProps: instance.getEnvironmentProps,
+    setQuery: setQueryAction,
+    focus: focusAction,
+    clear: clearAction,
+    submit,
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -53,6 +53,10 @@ import { registerEPSearchStats } from "./catalog-search/EPSearchStats";
 import { registerEPSearchSortBy } from "./catalog-search/EPSearchSortBy";
 import { registerEPClearRefinements } from "./catalog-search/EPClearRefinements";
 import { registerEPCurrentRefinements } from "./catalog-search/EPCurrentRefinements";
+import { registerEPSearchAutocomplete } from "./catalog-search/EPSearchAutocomplete";
+import { registerEPSearchAutocompleteInput } from "./catalog-search/EPSearchAutocompleteInput";
+import { registerEPSearchAutocompletePanel } from "./catalog-search/EPSearchAutocompletePanel";
+import { registerEPSearchAutocompleteList } from "./catalog-search/EPSearchAutocompleteList";
 import { registerEPCatalogSearchProvider } from "./catalog-search/EPCatalogSearchProvider";
 import { Registerable } from "./registerable";
 
@@ -159,6 +163,10 @@ export function registerAll(loader?: Registerable) {
   registerEPSearchPagination(loader);
   registerEPClearRefinements(loader);
   registerEPCurrentRefinements(loader);
+  registerEPSearchAutocomplete(loader);
+  registerEPSearchAutocompleteInput(loader);
+  registerEPSearchAutocompletePanel(loader);
+  registerEPSearchAutocompleteList(loader);
   registerEPCatalogSearchProvider(loader);
 
   // Legacy monolithic bundle configurator

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,26 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.1.tgz#2447a230bfe072c1659e6815129c03cf170710e3"
   integrity sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==
 
+"@algolia/autocomplete-core@^1.17.7":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz#7c84c771d28643fb00d09026c05013fb97aeea23"
+  integrity sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==
+  dependencies:
+    "@algolia/autocomplete-plugin-algolia-insights" "1.19.8"
+    "@algolia/autocomplete-shared" "1.19.8"
+
+"@algolia/autocomplete-plugin-algolia-insights@1.19.8":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz#f60d21edbe2a42e6d4e2215430733e3f51641471"
+  integrity sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.19.8"
+
+"@algolia/autocomplete-shared@1.19.8":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz#5d723d8bdb448efbb1b0e1c7ff94cc18e5b1dc0e"
+  integrity sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==
+
 "@algolia/events@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@algolia/events/-/events-4.0.1.tgz#fd39e7477e7bc703d7f893b556f676c032af3950"


### PR DESCRIPTION
Closes #327

## Summary

Ships the four-component `EPSearchAutocomplete` compound — Provider, Input, Panel, List — wrapping `@algolia/autocomplete-core` for EP catalog-search. Designers compose the chrome via slots; the provider mirrors the autocomplete query into `useSearchBox().refine` on a debounce so existing URL / hits / filters wiring keeps working unchanged.

- **Provider** (`EPSearchAutocomplete`) — owns autocomplete-core, exposes `$ctx.autocompleteData` (`isOpen`, `query`, `collections`) and ref-actions (`setQuery`, `focus`, `clear`).
- **Input** (`EPSearchAutocompleteInput`) — single-element-slot bridge; spreads `getInputProps()` onto the slot child via `cloneElement` and bakes `data-1p-ignore` / `data-lpignore` / `data-bwignore` / `data-form-type=other` so password-manager extensions don't blank the caret. Exposes a top-level `placeholder` prop (defaults to `"Search products..."`, runtime fallback so existing placements pick it up).
- **Panel** (`EPSearchAutocompletePanel`) — renders only when `state.isOpen` at runtime. In Studio canvas, follows the `usePlasmicCanvasComponentInfo` selection-driven pattern (same as react-aria's Popover/Modal/ComboBox): closed by default, opens when the panel node is selected in the outline. Advanced `open` prop pins it visible during deep styling sessions. Mobile close-button as L2 escape hatch.
- **List** (`EPSearchAutocompleteList`) — `<ul>`/`<li>` repeater with `getListProps`/`getItemProps`, per-iteration `currentSuggestion` `DataProvider`, optional `sourceId` filter.

Deep modules behind the React surface:

- `predictionsSource.ts` — pure source factory; flattens EP/Typesense `hit.document` so designers bind `item.q` directly.
- `useEPAutocompleteState.ts` — owns autocomplete-core lifecycle, debounced live-mirror `refine`, selection-time immediate refine, ref-action handlers. Custom `getItemInputValue` returns `item[predictionsField]` instead of autocomplete-core's default (which returns `state.query` and would leave the input unchanged on click).

Headless-styling contract gains panel/list/native-clear-cross-hide rules plus a mobile breakpoint, all `:where()`-zero-specificity except the `<ul>` reset which needs `(0,1,0)` to beat Plasmic's per-element classes.

Optional `@algolia/autocomplete-plugin-recent-searches` peer dep declared for designers who want recent-searches; not required.

## Test plan

- [x] 175/175 catalog-search jest tests pass (`yarn test plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/`)
- [x] End-to-end runtime verified on local Plasmic project `9iSL9GyrJNp9ebWzxaHtM5` ProductList page: pill input shows placeholder when empty → typing fires debounced refine → POST `/catalog/multi-search` autocomplete body → panel opens → click selection updates input + URL + closes panel → clear ref-action works.
- [ ] Reviewer: drop `EP Search Autocomplete` from the registry into a search page, verify the default slot tree renders out-of-the-box with placeholder visible.
- [ ] Reviewer: in Studio canvas, verify the panel is closed by default and opens only when the panel node is selected in the outline (no longer covers neighbouring page content while editing siblings).
- [ ] Reviewer: verify password-manager extensions (1Password / LastPass / Bitwarden) don't override the caret on the input.