### PR TITLE
perf(cms): eliminate redundant DB queries on public CMS read path

### DIFF
--- a/platform/wab/src/wab/server/db/DbMgr.spec.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.spec.ts
@@ -534,7 +534,8 @@ describe("DbMgr.CMS", () => {
     }
 
     if (query.limit === undefined || query.limit === 0) {
-      const count = await db.countCmsRows(tableId, query, opts);
+      const table = await db.getCmsTableById(tableId);
+      const count = await db.countCmsRowsForTable(table, query, opts);
       expect(count).toEqual(expected.length);
     }
   };

--- a/platform/wab/src/wab/server/db/DbMgr.ts
+++ b/platform/wab/src/wab/server/db/DbMgr.ts
@@ -7151,8 +7151,12 @@ export class DbMgr implements MigrationDbMgr {
    * For consistency, we always return the most oldest table that has not been
    * deleted nor archived.
    */
-  async getCmsTableByIdentifier(dbId: CmsDatabaseId, identifier: string) {
-    await this.checkCmsDatabasePerms(dbId, "viewer");
+  async getCmsTableByIdentifier(
+    dbId: CmsDatabaseId,
+    identifier: string,
+    accessLevel: AccessLevel = "viewer"
+  ) {
+    await this.checkCmsDatabasePerms(dbId, accessLevel);
     return ensureFound(
       await this.cmsTables()
         .createQueryBuilder("t")
@@ -7557,16 +7561,29 @@ export class DbMgr implements MigrationDbMgr {
     if (query.limit && query.limit < 0) {
       throw new Error("limit field cannot be negative");
     }
-
     const table = await this.getCmsTableById(tableId);
     await this.checkCmsDatabasePerms(
       table.databaseId,
       opts.useDraft ? "content" : "viewer"
     );
+    return this.queryCmsRowsForTable(table, query, opts);
+  }
+
+  async queryCmsRowsForTable(
+    table: CmsTable,
+    query: ApiCmsQuery,
+    opts: { useDraft?: boolean } = {}
+  ) {
+    if (query.offset && query.offset < 0) {
+      throw new Error("offset field cannot be negative");
+    }
+    if (query.limit && query.limit < 0) {
+      throw new Error("limit field cannot be negative");
+    }
 
     let builder = this.cmsRows()
       .createQueryBuilder("r")
-      .where("r.tableId = :tableId", { tableId })
+      .where("r.tableId = :tableId", { tableId: table.id })
       .andWhere("r.deletedAt IS NULL");
 
     if (!opts.useDraft) {
@@ -7613,19 +7630,14 @@ export class DbMgr implements MigrationDbMgr {
     return await builder.getMany();
   }
 
-  async countCmsRows(
-    tableId: CmsTableId,
+  async countCmsRowsForTable(
+    table: CmsTable,
     query: Pick<ApiCmsQuery, "where">,
     opts: { useDraft?: boolean } = {}
   ) {
-    const table = await this.getCmsTableById(tableId);
-    await this.checkCmsDatabasePerms(
-      table.databaseId,
-      opts.useDraft ? "content" : "viewer"
-    );
     let builder = this.cmsRows()
       .createQueryBuilder("r")
-      .where("r.tableId = :tableId", { tableId })
+      .where("r.tableId = :tableId", { tableId: table.id })
       .andWhere("r.deletedAt IS NULL");
 
     if (!opts.useDraft) {

--- a/platform/wab/src/wab/server/routes/cms.ts
+++ b/platform/wab/src/wab/server/routes/cms.ts
@@ -34,19 +34,35 @@ import { Request, Response } from "express-serve-static-core";
 import { differenceBy } from "lodash";
 
 const s = initServer();
+function unresolvedTemplateError(identifier: string) {
+  if (!/\{\{.*\}\}/.test(identifier)) {return null;}
+  return {
+    status: 400 as const,
+    body: {
+      error: {
+        statusCode: 400,
+        message: `Table identifier "${identifier}" contains unresolved template variables`,
+      },
+    },
+  };
+}
+
 export const publicCmsReadsServer = s.router(publicCmsReadsContract, {
   queryTable: async ({ params, query, req }) => {
+    const templateError = unresolvedTemplateError(params.tableIdentifier);
+    if (templateError) {return templateError;}
     const dbMgr = userDbMgr(req);
+    const useDraft = query.draft === "1";
     const table = await dbMgr.getCmsTableByIdentifier(
       params.dbId,
-      params.tableIdentifier
+      params.tableIdentifier,
+      useDraft ? "content" : "viewer"
     );
 
     const cmsQuery = query.q || {};
     const locale = fixLocale(query.locale ?? "");
-    const useDraft = query.draft === "1";
     const queryOpts = { useDraft };
-    const rows = await dbMgr.queryCmsRows(table.id, cmsQuery, queryOpts);
+    const rows = await dbMgr.queryCmsRowsForTable(table, cmsQuery, queryOpts);
 
     const rowCache = new CmsRowCache(dbMgr, queryOpts);
     rowCache.fill(table.id, rows);
@@ -142,15 +158,18 @@ export const publicCmsReadsServer = s.router(publicCmsReadsContract, {
     };
   },
   countTable: async ({ params, query, req }) => {
+    const templateError = unresolvedTemplateError(params.tableIdentifier);
+    if (templateError) {return templateError;}
     const dbMgr = userDbMgr(req);
+    const useDraft = query.draft === "1";
     const table = await dbMgr.getCmsTableByIdentifier(
       params.dbId,
-      params.tableIdentifier
+      params.tableIdentifier,
+      useDraft ? "content" : "viewer"
     );
 
     const cmsQuery = query.q || {};
-    const useDraft = query.draft === "1";
-    const count = await dbMgr.countCmsRows(table.id, cmsQuery, { useDraft });
+    const count = await dbMgr.countCmsRowsForTable(table, cmsQuery, { useDraft });
     return {
       status: 200,
       body: {
@@ -274,6 +293,12 @@ export async function publicCreateRows(req: Request, res: Response) {
   const mgr = userDbMgr(req);
   const dbId = req.params.dbId as CmsDatabaseId;
   const tableIdentifier = req.params.tableIdentifier;
+
+  const templateError = unresolvedTemplateError(tableIdentifier);
+  if (templateError) {
+    res.status(400).json(templateError.body);
+    return;
+  }
 
   const table = await mgr.getCmsTableByIdentifier(dbId, tableIdentifier);
   const db = await mgr.getCmsDatabaseById(dbId);


### PR DESCRIPTION
Every published CMS table read was executing up to 9 DB queries per request due to duplicate table lookups and permission checks across getCmsTableByIdentifier and queryCmsRows/countCmsRows.

Consolidates to 4 queries (cms_database + workspace + cms_table + cms_row) by:

- Adding an accessLevel parameter to getCmsTableByIdentifier so the draft vs published permission check happens once upfront at the right level, rather than being repeated inside the row query functions.
- Extracting queryCmsRowsForTable and countCmsRowsForTable which accept a pre-loaded CmsTable and skip the redundant lookup and perm check.
- Updating queryTable and countTable in the public read router to use the ForTable variants after getCmsTableByIdentifier.
- Removing the countCmsRows wrapper (no production callers remain) and updating the spec to call countCmsRowsForTable directly.

queryCmsRows (by tableId) is preserved unchanged for cmse.ts and CmsRowCache which only have a tableId at call time.
