### PR TITLE
feat(ep): restrict resource-creation endpoints to admin emails only

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -1566,16 +1566,18 @@ export function addMainAppServerRoutes(
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
     withNext(listProjects)
   );
-  app.post("/api/v1/projects", cmCors, withNext(createProject));
+  app.post("/api/v1/projects", cmCors, adminOnly, withNext(createProject));
   app.post(
     "/api/v1/projects/create-project-with-hostless-packages",
+    adminOnly,
     withNext(createProjectWithHostlessPackages)
   );
-  app.post("/api/v1/projects/:projectId/clone", cmCors, createWriteRateLimiter(), withNext(cloneProject));
+  app.post("/api/v1/projects/:projectId/clone", cmCors, adminOnly, createWriteRateLimiter(), withNext(cloneProject));
   app.post(
     "/api/v1/templates/:projectId/clone",
     cmCors,
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
+    adminOnly,
     withNext(clonePublishedTemplate)
   );
   // Import includes capabilities to keep the project id, allow data source op issuing,
@@ -1691,6 +1693,7 @@ export function addMainAppServerRoutes(
   app.post(
     "/api/v1/teams",
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
+    adminOnly,
     withNext(teamRoutes.createTeam)
   );
   app.get(
@@ -1744,6 +1747,7 @@ export function addMainAppServerRoutes(
     "/api/v1/workspaces",
     cmCors,
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
+    adminOnly,
     createWorkspace
   );
   app.get("/api/v1/workspaces/:workspaceId", cmCors, getWorkspace);

--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -1566,18 +1566,16 @@ export function addMainAppServerRoutes(
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
     withNext(listProjects)
   );
-  app.post("/api/v1/projects", cmCors, adminOnly, withNext(createProject));
+  app.post("/api/v1/projects", cmCors, withNext(createProject));
   app.post(
     "/api/v1/projects/create-project-with-hostless-packages",
-    adminOnly,
     withNext(createProjectWithHostlessPackages)
   );
-  app.post("/api/v1/projects/:projectId/clone", cmCors, adminOnly, createWriteRateLimiter(), withNext(cloneProject));
+  app.post("/api/v1/projects/:projectId/clone", cmCors, createWriteRateLimiter(), withNext(cloneProject));
   app.post(
     "/api/v1/templates/:projectId/clone",
     cmCors,
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
-    adminOnly,
     withNext(clonePublishedTemplate)
   );
   // Import includes capabilities to keep the project id, allow data source op issuing,


### PR DESCRIPTION
## What does this MR do?

Restricts workspace and team creation to users listed in \`ADMIN_EMAILS\` only, using the existing \`adminOnly\` middleware. Project endpoints remain open — EP provisioned users need to create and manage projects themselves.

## Changes

- \`POST /api/v1/teams\` — now requires \`adminOnly\`
- \`POST /api/v1/workspaces\` — now requires \`adminOnly\`

## Design decisions

\`adminOnly\` was chosen over a new email-domain guard because admin identity is already defined by the \`ADMIN_EMAILS\` env var and used consistently for all \`/api/v1/admin/*\` routes. No schema changes or new config is needed.

## Testing

Manually verify: a non-admin session hitting \`POST /api/v1/teams\` or \`POST /api/v1/workspaces\` should receive \`403 Forbidden\`; an admin session should succeed as before. Project creation endpoints should be unaffected for all authenticated users.