### PR TITLE
fix(ep-commerce): mark EPProductProvider as providesData

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/product/EPProductProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product/EPProductProvider.tsx
@@ -137,6 +137,7 @@ export const epProductProviderMeta: CodeComponentMeta<EPProductProviderProps> =
           "Controls which state is rendered inside Studio / MCP preview. `auto` uses real data when available, falling back to a mock product.",
       },
     },
+    providesData: true,
     importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
     importName: "EPProductProvider",
   };


### PR DESCRIPTION
## Summary
- One-line meta fix on `EPProductProvider`: `providesData: true`.
- Without it Plasmic compiles the component's `children` slot inline at the parent's render scope, so `$ctx.currentProduct.*` bindings inside the slot evaluate where `currentProduct` doesn't exist yet (the `<DataProvider name="currentProduct">` the component publishes only takes effect for descendants).
- With it, the compiler wraps the slot in a descendant function-component with its own `useDataEnv()` — `currentProduct` resolves correctly and PDPs that wire `product` to a Plasmic Server Query (`$q.<name>.data`) actually render the product data instead of throwing `TypeError: Cannot read properties of undefined (reading 'name')`.
- Matches every sibling data-providing component in the same package (`EPCartProvider`, `EPBundleProvider`, `EPVariationPicker`, `EPProductListProvider`, etc. — all 11 already declare `providesData: true`). Looks like the flag was simply missed when `EPProductProvider` was first added.

## Test plan
- [ ] In a consumer app with a Plasmic page whose `EPProductProvider.product` is bound to `$q.<query>.data` (Server Query returning a `Product`), pre-fix: page render throws `Cannot read properties of undefined (reading 'name')` from any binding inside the provider's slot.
- [ ] After this fix + a rebuild of `@elasticpath/plasmic-ep-commerce-elastic-path`, the same page renders the product's `name`, `description`, `price`, `image` etc. correctly.
- [ ] Existing consumers of `EPProductProvider` that use the legacy client-fetch path (`productId` prop, no `product` prop binding) keep working — `providesData: true` is purely additive at the Studio code-gen level and doesn't change runtime behaviour for the component itself.