### PR TITLE
feat(ep-commerce): add EPProductExtensions composable for product attributes.extensions

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -43,6 +43,11 @@ import { registerEPProductGrid } from "./product-discovery/EPProductGrid";
 import { registerEPProductListProvider } from "./product-discovery/EPProductListProvider";
 import { registerEPRelatedProductsProvider } from "./product-discovery/EPRelatedProductsProvider";
 import { registerEPProductProvider } from "./product/EPProductProvider";
+import { registerEPProductExtensionsProvider } from "./product-extensions/composable/EPProductExtensionsProvider";
+import { registerEPProductExtensionTemplateList } from "./product-extensions/composable/EPProductExtensionTemplateList";
+import { registerEPProductExtensionTemplateField } from "./product-extensions/composable/EPProductExtensionTemplateField";
+import { registerEPProductExtensionFieldList } from "./product-extensions/composable/EPProductExtensionFieldList";
+import { registerEPProductExtensionField } from "./product-extensions/composable/EPProductExtensionField";
 import { registerEPSearchBox } from "./catalog-search/EPSearchBox";
 import { registerEPSearchHits } from "./catalog-search/EPSearchHits";
 import { registerEPRefinementList } from "./catalog-search/EPRefinementList";
@@ -89,6 +94,7 @@ export * from "./product-discovery";
 export * from "./catalog-search";
 export * from "./shopper-context";
 export * from "./shopper-context/server";
+export * from "./product-extensions";
 
 export function registerAll(loader?: Registerable) {
   // Global context
@@ -152,6 +158,14 @@ export function registerAll(loader?: Registerable) {
   registerEPProductListProvider(loader);
   registerEPRelatedProductsProvider(loader);
   registerEPProductProvider(loader);
+
+  // Product extensions — register field/leaf components first so they're
+  // available as default slot content in the parent components above them.
+  registerEPProductExtensionField(loader);
+  registerEPProductExtensionTemplateField(loader);
+  registerEPProductExtensionFieldList(loader);
+  registerEPProductExtensionTemplateList(loader);
+  registerEPProductExtensionsProvider(loader);
 
   // Catalog search — register leaf/field components first, then repeaters, then provider
   registerEPSearchBox(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionField.tsx
@@ -1,0 +1,109 @@
+import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import { MOCK_EXTENSION_TEMPLATES } from "./design-time-data";
+import type { ExtensionField } from "./types";
+
+type FieldName = "key" | "label" | "value" | "displayValue" | "type";
+type PreviewState = "auto" | "withData";
+
+interface EPProductExtensionFieldProps {
+  field: FieldName;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductExtensionFieldMeta: CodeComponentMeta<EPProductExtensionFieldProps> =
+  {
+    name: "plasmic-commerce-ep-product-extension-field",
+    displayName: "EP Product Extension Field",
+    description:
+      "Displays a property of the current extension field (label, displayValue, value, key, type). Must be inside an EP Product Extension Field List.",
+    props: {
+      field: {
+        type: "choice",
+        options: [
+          { label: "Label (humanized key)", value: "label" },
+          { label: "Display Value (formatted)", value: "displayValue" },
+          { label: "Value (raw)", value: "value" },
+          { label: "Key (raw)", value: "key" },
+          { label: "Type", value: "type" },
+        ],
+        defaultValue: "displayValue",
+        displayName: "Field",
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionField",
+    parentComponentName: "plasmic-commerce-ep-product-extension-field-list",
+  };
+
+export function EPProductExtensionField(props: EPProductExtensionFieldProps) {
+  const { field, className, previewState = "auto" } = props;
+  const current = useSelector("currentExtensionField") as
+    | ExtensionField
+    | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const useMock = previewState === "withData" || (!current && inEditor);
+  const data = useMock ? MOCK_EXTENSION_TEMPLATES[0]?.fields[0] : current;
+  if (!data) return null;
+
+  let rendered: string;
+  switch (field) {
+    case "label":
+      rendered = data.label;
+      break;
+    case "key":
+      rendered = data.key;
+      break;
+    case "type":
+      rendered = data.type;
+      break;
+    case "displayValue":
+      rendered = data.displayValue;
+      break;
+    case "value":
+    default:
+      rendered = stringifyValue(data.value);
+      break;
+  }
+
+  return <span className={className}>{rendered}</span>;
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+export function registerEPProductExtensionField(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionFieldProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionField,
+    customMeta ?? epProductExtensionFieldMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionFieldList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionFieldList.tsx
@@ -1,0 +1,106 @@
+import {
+  DataProvider,
+  repeatedElement,
+  useSelector,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import { MOCK_EXTENSION_TEMPLATES } from "./design-time-data";
+import type { ExtensionField, ExtensionTemplate } from "./types";
+
+type PreviewState = "auto" | "withData";
+
+interface EPProductExtensionFieldListProps {
+  children?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductExtensionFieldListMeta: CodeComponentMeta<EPProductExtensionFieldListProps> =
+  {
+    name: "plasmic-commerce-ep-product-extension-field-list",
+    displayName: "EP Product Extension Field List",
+    description:
+      "Iterates over fields in the current extension template. Provides currentExtensionField and currentExtensionFieldIndex to children. Must be inside an EP Product Extension Template List.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "hbox",
+            children: [
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-product-extension-field",
+                props: { field: "label" },
+              },
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-product-extension-field",
+                props: { field: "displayValue" },
+              },
+            ],
+          },
+        ],
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionFieldList",
+    parentComponentName: "plasmic-commerce-ep-product-extension-template-list",
+    providesData: true,
+  };
+
+export function EPProductExtensionFieldList(
+  props: EPProductExtensionFieldListProps,
+) {
+  const { children, className, previewState = "auto" } = props;
+  const template = useSelector("currentExtensionTemplate") as
+    | ExtensionTemplate
+    | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const useMock = previewState === "withData" || (!template && inEditor);
+  const source = useMock ? MOCK_EXTENSION_TEMPLATES[0] : template;
+  const fields: ExtensionField[] = source?.fields ?? [];
+
+  if (fields.length === 0) return null;
+
+  return (
+    <div className={className} role="list" aria-label="Extension fields">
+      {fields.map((fieldData, i) => (
+        <div key={fieldData.key || i} role="listitem">
+          <DataProvider name="currentExtensionField" data={fieldData}>
+            <DataProvider name="currentExtensionFieldIndex" data={i}>
+              {repeatedElement(i, children)}
+            </DataProvider>
+          </DataProvider>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function registerEPProductExtensionFieldList(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionFieldListProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionFieldList,
+    customMeta ?? epProductExtensionFieldListMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionTemplateField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionTemplateField.tsx
@@ -1,0 +1,81 @@
+import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import { MOCK_EXTENSION_TEMPLATES } from "./design-time-data";
+import type { ExtensionTemplate } from "./types";
+
+type TemplateFieldName = "slug" | "label" | "fieldCount";
+type PreviewState = "auto" | "withData";
+
+interface EPProductExtensionTemplateFieldProps {
+  field: TemplateFieldName;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductExtensionTemplateFieldMeta: CodeComponentMeta<EPProductExtensionTemplateFieldProps> =
+  {
+    name: "plasmic-commerce-ep-product-extension-template-field",
+    displayName: "EP Product Extension Template Field",
+    description:
+      "Displays a property from the current extension template (slug, label, fieldCount). Must be inside an EP Product Extension Template List.",
+    props: {
+      field: {
+        type: "choice",
+        options: [
+          { label: "Label (humanized)", value: "label" },
+          { label: "Slug (raw key)", value: "slug" },
+          { label: "Field Count", value: "fieldCount" },
+        ],
+        defaultValue: "label",
+        displayName: "Field",
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionTemplateField",
+    parentComponentName: "plasmic-commerce-ep-product-extension-template-list",
+  };
+
+export function EPProductExtensionTemplateField(
+  props: EPProductExtensionTemplateFieldProps,
+) {
+  const { field, className, previewState = "auto" } = props;
+  const current = useSelector("currentExtensionTemplate") as
+    | ExtensionTemplate
+    | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const useMock = previewState === "withData" || (!current && inEditor);
+  const data = useMock ? MOCK_EXTENSION_TEMPLATES[0] : current;
+  if (!data) return null;
+
+  let value: unknown;
+  if (field === "fieldCount") value = data.fieldCount;
+  else value = data[field];
+
+  return <span className={className}>{value == null ? "" : String(value)}</span>;
+}
+
+export function registerEPProductExtensionTemplateField(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionTemplateFieldProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionTemplateField,
+    customMeta ?? epProductExtensionTemplateFieldMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionTemplateList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionTemplateList.tsx
@@ -1,0 +1,111 @@
+import {
+  DataProvider,
+  repeatedElement,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import { useProductExtensionsContext } from "./EPProductExtensionsProvider";
+import { MOCK_EXTENSION_TEMPLATES } from "./design-time-data";
+import type { ExtensionTemplate } from "./types";
+
+type PreviewState = "auto" | "withData";
+
+interface EPProductExtensionTemplateListProps {
+  children?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductExtensionTemplateListMeta: CodeComponentMeta<EPProductExtensionTemplateListProps> =
+  {
+    name: "plasmic-commerce-ep-product-extension-template-list",
+    displayName: "EP Product Extension Template List",
+    description:
+      "Iterates over the product's extension templates. Provides currentExtensionTemplate and currentExtensionTemplateIndex to children. Must be inside an EP Product Extensions Provider.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "vbox",
+            children: [
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-product-extension-template-field",
+                props: { field: "label" },
+              },
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-product-extension-field-list",
+              },
+            ],
+          },
+        ],
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionTemplateList",
+    parentComponentName: "plasmic-commerce-ep-product-extensions-provider",
+    providesData: true,
+  };
+
+export function EPProductExtensionTemplateList(
+  props: EPProductExtensionTemplateListProps,
+) {
+  const { children, className, previewState = "auto" } = props;
+  const ctx = useProductExtensionsContext();
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const useMock =
+    previewState === "withData" ||
+    (previewState === "auto" && inEditor && (!ctx || ctx.templates.length === 0));
+
+  const templates: ExtensionTemplate[] = useMock
+    ? MOCK_EXTENSION_TEMPLATES
+    : (ctx?.templates ?? []);
+
+  if (templates.length === 0) return null;
+
+  return (
+    <div
+      className={className}
+      role="list"
+      aria-label="Product extension templates"
+    >
+      {templates.map((template, i) => (
+        <div key={template.slug || i} role="listitem">
+          <DataProvider name="currentExtensionTemplate" data={template}>
+            <DataProvider name="currentExtensionTemplateIndex" data={i}>
+              {repeatedElement(i, children)}
+            </DataProvider>
+          </DataProvider>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function registerEPProductExtensionTemplateList(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionTemplateListProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionTemplateList,
+    customMeta ?? epProductExtensionTemplateListMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionsProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionsProvider.tsx
@@ -1,0 +1,175 @@
+import {
+  DataProvider,
+  useSelector,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { createContext, useContext, useMemo } from "react";
+import { Registerable } from "../../registerable";
+import { Product } from "../../types/product";
+import {
+  MOCK_EXTENSIONS_DATA,
+  MOCK_EXTENSION_TEMPLATES,
+} from "./design-time-data";
+import { normalizeExtensions } from "./format";
+import type { ExtensionTemplate, ExtensionsData } from "./types";
+
+type PreviewState = "auto" | "withData" | "empty";
+
+interface EPProductExtensionsProviderProps {
+  children?: React.ReactNode;
+  className?: string;
+  /**
+   * Override the default "no extensions" behaviour. When the current product
+   * has no `attributes.extensions`, the provider renders this slot instead
+   * of its children. Leave empty to render nothing (self-gate).
+   */
+  notExtensionsContent?: React.ReactNode;
+  previewState?: PreviewState;
+}
+
+/**
+ * Internal React context for child components to read the resolved templates
+ * without going through a DataProvider lookup for the heavy array. Mirrors
+ * the BundleFormContext pattern.
+ */
+interface ExtensionsContextValue {
+  templates: ExtensionTemplate[];
+}
+const ExtensionsContext = createContext<ExtensionsContextValue | undefined>(
+  undefined,
+);
+export function useProductExtensionsContext(): ExtensionsContextValue | undefined {
+  return useContext(ExtensionsContext);
+}
+
+export const epProductExtensionsProviderMeta: CodeComponentMeta<EPProductExtensionsProviderProps> =
+  {
+    name: "plasmic-commerce-ep-product-extensions-provider",
+    displayName: "EP Product Extensions Provider",
+    description:
+      "Reads `attributes.extensions` from the current product and exposes the normalized templates to descendants. Self-gates when the product has no extensions. Must be inside an EP Product Provider.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "component",
+            name: "plasmic-commerce-ep-product-extension-template-list",
+          },
+        ],
+      },
+      notExtensionsContent: {
+        type: "slot",
+        displayName: "No Extensions Content",
+        description:
+          "Rendered when the product has no extensions. Leave empty to render nothing.",
+        hidePlaceholder: true,
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData", "empty"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionsProvider",
+    providesData: true,
+  };
+
+export function EPProductExtensionsProvider(
+  props: EPProductExtensionsProviderProps,
+) {
+  const {
+    children,
+    className,
+    notExtensionsContent,
+    previewState = "auto",
+  } = props;
+
+  const product = useSelector("currentProduct") as Product | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+
+  // Pull the raw extensions blob from the product's rawData.
+  const rawExtensions = useMemo(() => {
+    const raw = (product as Product | undefined)?.rawData as
+      | { data?: { attributes?: { extensions?: Record<string, unknown> | null } } }
+      | undefined;
+    return raw?.data?.attributes?.extensions ?? null;
+  }, [product]);
+
+  const liveTemplates = useMemo(
+    () => normalizeExtensions(rawExtensions),
+    [rawExtensions],
+  );
+
+  // Decide between live and mock data.
+  const useMock =
+    previewState === "withData" ||
+    (previewState === "auto" && inEditor && liveTemplates.length === 0);
+
+  const useEmpty = previewState === "empty";
+
+  const templates = useEmpty
+    ? []
+    : useMock
+      ? MOCK_EXTENSION_TEMPLATES
+      : liveTemplates;
+
+  const extensionsData: ExtensionsData = useMemo(
+    () => ({
+      templateCount: templates.length,
+      isEmpty: templates.length === 0,
+    }),
+    [templates],
+  );
+
+  // Self-gate: when there are no templates, render the override slot
+  // (or nothing) — same pattern as EPBundleProvider.notBundleContent.
+  if (templates.length === 0) {
+    if (notExtensionsContent) {
+      return (
+        <div className={className} data-ep-product-extensions-provider="">
+          {notExtensionsContent}
+        </div>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <DataProvider name="extensionsData" data={extensionsData}>
+      <ExtensionsContext.Provider value={{ templates }}>
+        <div className={className} data-ep-product-extensions-provider="">
+          {children}
+        </div>
+      </ExtensionsContext.Provider>
+    </DataProvider>
+  );
+}
+
+/**
+ * Convenience hook for design-time preview defaults — exported so the
+ * mock data is also accessible to anyone testing field rendering.
+ */
+export function getMockExtensionsData(): ExtensionsData {
+  return MOCK_EXTENSIONS_DATA;
+}
+
+export function registerEPProductExtensionsProvider(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionsProviderProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionsProvider,
+    customMeta ?? epProductExtensionsProviderMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/composable-product-extensions.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/composable-product-extensions.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the composable product-extensions components. These rely on
+ * @plasmicapp/host for DataProvider/useSelector data flow and
+ * usePlasmicCanvasContext for design-time detection — all mocked here.
+ *
+ * esbuild's jest transform hoists `import` to top-of-file `require()` BEFORE
+ * jest.mock() runs, so every code-under-test module is loaded via explicit
+ * `require()` (after the mocks take effect), matching the bundle test setup.
+ */
+
+// --- Mocks (hoisted by Jest before anything else) ---
+
+jest.mock("@plasmicapp/host", () => {
+  const React = require("react");
+  return {
+    DataProvider: ({ children, name, data }: any) =>
+      React.createElement(
+        "div",
+        {
+          "data-provider": name,
+          "data-provider-value": JSON.stringify(data),
+        },
+        children,
+      ),
+    useSelector: jest.fn(),
+    usePlasmicCanvasContext: jest.fn().mockReturnValue(null),
+    repeatedElement: jest.fn((_i: number, children: any) => children),
+  };
+});
+
+jest.mock("@plasmicapp/host/registerComponent", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// --- Imports (not mocked — safe for esbuild to hoist) ---
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+// --- Load mocked host functions via require (after jest.mock) ---
+const {
+  useSelector: mockUseSelector,
+  usePlasmicCanvasContext: mockUsePlasmicCanvasContext,
+} = require("@plasmicapp/host");
+
+// --- Load components-under-test via require (after jest.mock) ---
+const {
+  EPProductExtensionsProvider,
+} = require("../EPProductExtensionsProvider");
+const {
+  EPProductExtensionTemplateList,
+} = require("../EPProductExtensionTemplateList");
+const {
+  EPProductExtensionTemplateField,
+} = require("../EPProductExtensionTemplateField");
+const {
+  EPProductExtensionFieldList,
+} = require("../EPProductExtensionFieldList");
+const { EPProductExtensionField } = require("../EPProductExtensionField");
+const { MOCK_EXTENSION_TEMPLATES } = require("../design-time-data");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupSelector(selectorData: Record<string, any>) {
+  (mockUseSelector as jest.Mock).mockImplementation(
+    (key: string) => selectorData[key],
+  );
+}
+
+function setEditorMode(inEditor: boolean) {
+  (mockUsePlasmicCanvasContext as jest.Mock).mockReturnValue(
+    inEditor ? {} : null,
+  );
+}
+
+/** A live product whose rawData carries one extension template. */
+function productWithExtensions() {
+  return {
+    id: "p1",
+    rawData: {
+      data: {
+        attributes: {
+          extensions: {
+            "products(example-template-2)": { name: "my name" },
+          },
+        },
+      },
+    },
+  };
+}
+
+/** A live product with no extensions (variation parent / bundle case). */
+function productWithoutExtensions() {
+  return {
+    id: "p2",
+    rawData: { data: { attributes: { extensions: null } } },
+  };
+}
+
+const SAMPLE_TEMPLATE = {
+  slug: "products(example-template-2)",
+  label: "Example Template 2",
+  fieldCount: 1,
+  fields: [
+    {
+      key: "name",
+      label: "Name",
+      value: "my name",
+      type: "string",
+      displayValue: "my name",
+    },
+  ],
+};
+
+const SAMPLE_FIELD = SAMPLE_TEMPLATE.fields[0];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setEditorMode(false);
+});
+
+// ===========================================================================
+// EPProductExtensionsProvider
+// ===========================================================================
+
+describe("EPProductExtensionsProvider", () => {
+  it("renders children when the product has extensions", () => {
+    setupSelector({ currentProduct: productWithExtensions() });
+    render(
+      <EPProductExtensionsProvider>
+        <span>child content</span>
+      </EPProductExtensionsProvider>,
+    );
+    expect(screen.getByText("child content")).toBeTruthy();
+  });
+
+  it("publishes extensionsData via DataProvider", () => {
+    setupSelector({ currentProduct: productWithExtensions() });
+    const { container } = render(
+      <EPProductExtensionsProvider>
+        <span>x</span>
+      </EPProductExtensionsProvider>,
+    );
+    const provider = container.querySelector(
+      '[data-provider="extensionsData"]',
+    );
+    expect(provider).toBeTruthy();
+    expect(
+      JSON.parse(provider!.getAttribute("data-provider-value")!),
+    ).toEqual({ templateCount: 1, isEmpty: false });
+  });
+
+  it("self-gates (renders nothing) when extensions are null at runtime", () => {
+    setupSelector({ currentProduct: productWithoutExtensions() });
+    const { container } = render(
+      <EPProductExtensionsProvider>
+        <span>should not show</span>
+      </EPProductExtensionsProvider>,
+    );
+    expect(container.textContent).toBe("");
+    expect(screen.queryByText("should not show")).toBeNull();
+  });
+
+  it("renders notExtensionsContent when provided and empty", () => {
+    setupSelector({ currentProduct: productWithoutExtensions() });
+    render(
+      <EPProductExtensionsProvider
+        notExtensionsContent={<span>no details</span>}
+      >
+        <span>hidden</span>
+      </EPProductExtensionsProvider>,
+    );
+    expect(screen.getByText("no details")).toBeTruthy();
+    expect(screen.queryByText("hidden")).toBeNull();
+  });
+
+  it("falls back to mock data in the editor when no live product is bound", () => {
+    setEditorMode(true);
+    setupSelector({ currentProduct: undefined });
+    const { container } = render(
+      <EPProductExtensionsProvider>
+        <span>child</span>
+      </EPProductExtensionsProvider>,
+    );
+    const provider = container.querySelector(
+      '[data-provider="extensionsData"]',
+    );
+    expect(
+      JSON.parse(provider!.getAttribute("data-provider-value")!).templateCount,
+    ).toBe(MOCK_EXTENSION_TEMPLATES.length);
+  });
+
+  it("previewState=empty forces the self-gated branch even in the editor", () => {
+    setEditorMode(true);
+    setupSelector({ currentProduct: productWithExtensions() });
+    const { container } = render(
+      <EPProductExtensionsProvider previewState="empty">
+        <span>hidden</span>
+      </EPProductExtensionsProvider>,
+    );
+    expect(screen.queryByText("hidden")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+});
+
+// ===========================================================================
+// EPProductExtensionTemplateList
+// ===========================================================================
+
+describe("EPProductExtensionTemplateList", () => {
+  it("self-gates when there are no templates and not in editor", () => {
+    setupSelector({});
+    const { container } = render(
+      <EPProductExtensionTemplateList>
+        <span>row</span>
+      </EPProductExtensionTemplateList>,
+    );
+    // No provider context + not editor => nothing rendered.
+    expect(container.textContent).toBe("");
+  });
+
+  it("uses mock templates in the editor with no provider context", () => {
+    setEditorMode(true);
+    setupSelector({});
+    const { container } = render(
+      <EPProductExtensionTemplateList>
+        <span>row</span>
+      </EPProductExtensionTemplateList>,
+    );
+    const providers = container.querySelectorAll(
+      '[data-provider="currentExtensionTemplate"]',
+    );
+    expect(providers.length).toBe(MOCK_EXTENSION_TEMPLATES.length);
+  });
+});
+
+// ===========================================================================
+// EPProductExtensionTemplateField
+// ===========================================================================
+
+describe("EPProductExtensionTemplateField", () => {
+  it("renders the humanized label", () => {
+    setupSelector({ currentExtensionTemplate: SAMPLE_TEMPLATE });
+    render(<EPProductExtensionTemplateField field="label" />);
+    expect(screen.getByText("Example Template 2")).toBeTruthy();
+  });
+
+  it("renders the raw slug", () => {
+    setupSelector({ currentExtensionTemplate: SAMPLE_TEMPLATE });
+    render(<EPProductExtensionTemplateField field="slug" />);
+    expect(
+      screen.getByText("products(example-template-2)"),
+    ).toBeTruthy();
+  });
+
+  it("renders the field count", () => {
+    setupSelector({ currentExtensionTemplate: SAMPLE_TEMPLATE });
+    render(<EPProductExtensionTemplateField field="fieldCount" />);
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("renders nothing when there is no template and not in editor", () => {
+    setupSelector({});
+    const { container } = render(
+      <EPProductExtensionTemplateField field="label" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+});
+
+// ===========================================================================
+// EPProductExtensionFieldList
+// ===========================================================================
+
+describe("EPProductExtensionFieldList", () => {
+  it("provides currentExtensionField per field in the template", () => {
+    setupSelector({ currentExtensionTemplate: SAMPLE_TEMPLATE });
+    const { container } = render(
+      <EPProductExtensionFieldList>
+        <span>field row</span>
+      </EPProductExtensionFieldList>,
+    );
+    const providers = container.querySelectorAll(
+      '[data-provider="currentExtensionField"]',
+    );
+    expect(providers.length).toBe(1);
+    expect(
+      JSON.parse(providers[0].getAttribute("data-provider-value")!),
+    ).toMatchObject({ key: "name", displayValue: "my name" });
+  });
+
+  it("renders nothing when the template has no fields", () => {
+    setupSelector({
+      currentExtensionTemplate: { ...SAMPLE_TEMPLATE, fields: [] },
+    });
+    const { container } = render(
+      <EPProductExtensionFieldList>
+        <span>row</span>
+      </EPProductExtensionFieldList>,
+    );
+    expect(container.textContent).toBe("");
+  });
+});
+
+// ===========================================================================
+// EPProductExtensionField
+// ===========================================================================
+
+describe("EPProductExtensionField", () => {
+  it.each([
+    ["label", "Name"],
+    ["displayValue", "my name"],
+    ["value", "my name"],
+    ["key", "name"],
+    ["type", "string"],
+  ])("renders the %s field", (field, expected) => {
+    setupSelector({ currentExtensionField: SAMPLE_FIELD });
+    render(<EPProductExtensionField field={field as any} />);
+    expect(screen.getByText(expected)).toBeTruthy();
+  });
+
+  it("stringifies a non-primitive raw value", () => {
+    setupSelector({
+      currentExtensionField: {
+        key: "spec",
+        label: "Spec",
+        value: { cpu: "x" },
+        type: "object",
+        displayValue: "Cpu: x",
+      },
+    });
+    render(<EPProductExtensionField field="value" />);
+    expect(screen.getByText('{"cpu":"x"}')).toBeTruthy();
+  });
+
+  it("renders nothing when there is no field and not in editor", () => {
+    setupSelector({});
+    const { container } = render(
+      <EPProductExtensionField field="displayValue" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the pure formatting/normalization helpers backing the
+ * EPProductExtensions composable. No React or @plasmicapp/host involved.
+ */
+import {
+  humanizeTemplateSlug,
+  humanizeFieldKey,
+  inferType,
+  formatDisplayValue,
+  normalizeExtensions,
+} from "../format";
+
+describe("humanizeTemplateSlug", () => {
+  it("strips the entity prefix and parens, title-cases the inner name", () => {
+    expect(humanizeTemplateSlug("products(example-template-2)")).toBe(
+      "Example Template 2",
+    );
+  });
+
+  it("handles underscores as word separators", () => {
+    expect(humanizeTemplateSlug("products(care_and_materials)")).toBe(
+      "Care And Materials",
+    );
+  });
+
+  it("falls back to the raw slug when there are no parens", () => {
+    expect(humanizeTemplateSlug("care-and-materials")).toBe(
+      "Care And Materials",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(humanizeTemplateSlug("")).toBe("");
+  });
+});
+
+describe("humanizeFieldKey", () => {
+  it("capitalizes a single lowercase word", () => {
+    expect(humanizeFieldKey("name")).toBe("Name");
+  });
+
+  it("splits camelCase into words", () => {
+    expect(humanizeFieldKey("productCare")).toBe("Product Care");
+  });
+
+  it("splits snake_case and kebab-case", () => {
+    expect(humanizeFieldKey("eco_rating")).toBe("Eco Rating");
+    expect(humanizeFieldKey("dimensions-cm")).toBe("Dimensions Cm");
+  });
+
+  it("handles letter/number boundaries from camelCase", () => {
+    expect(humanizeFieldKey("co2Footprint")).toBe("Co2 Footprint");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(humanizeFieldKey("")).toBe("");
+  });
+});
+
+describe("inferType", () => {
+  it.each([
+    ["string", "hello", "string"],
+    ["number", 42, "number"],
+    ["boolean", true, "boolean"],
+    ["null", null, "null"],
+    ["undefined -> null", undefined, "null"],
+    ["array", [1, 2], "array"],
+    ["object", { a: 1 }, "object"],
+  ])("classifies %s", (_label, value, expected) => {
+    expect(inferType(value)).toBe(expected);
+  });
+});
+
+describe("formatDisplayValue", () => {
+  it("passes strings through unchanged", () => {
+    expect(formatDisplayValue("Organic cotton")).toBe("Organic cotton");
+  });
+
+  it("renders booleans as Yes/No", () => {
+    expect(formatDisplayValue(true)).toBe("Yes");
+    expect(formatDisplayValue(false)).toBe("No");
+  });
+
+  it("renders null/undefined as empty string", () => {
+    expect(formatDisplayValue(null)).toBe("");
+    expect(formatDisplayValue(undefined)).toBe("");
+  });
+
+  it("formats numbers via toLocaleString", () => {
+    expect(formatDisplayValue(1299)).toBe((1299).toLocaleString());
+  });
+
+  it("joins primitive arrays with commas, skipping empties", () => {
+    expect(formatDisplayValue(["red", "green", "blue"])).toBe(
+      "red, green, blue",
+    );
+    expect(formatDisplayValue([1, 2, 3])).toBe("1, 2, 3");
+  });
+
+  it("renders a shallow object as humanized key: value pairs", () => {
+    expect(formatDisplayValue({ width_cm: 30, in_stock: true })).toBe(
+      "Width Cm: 30, In Stock: Yes",
+    );
+  });
+
+  it("falls back to JSON for deeply nested objects", () => {
+    const nested = { spec: { cpu: "x" } };
+    expect(formatDisplayValue(nested)).toBe(JSON.stringify(nested));
+  });
+
+  it("renders an empty object as empty string", () => {
+    expect(formatDisplayValue({})).toBe("");
+  });
+});
+
+describe("normalizeExtensions", () => {
+  it("returns an empty array for null/undefined", () => {
+    expect(normalizeExtensions(null)).toEqual([]);
+    expect(normalizeExtensions(undefined)).toEqual([]);
+  });
+
+  it("normalizes the canonical EP shape into templates + fields", () => {
+    const result = normalizeExtensions({
+      "products(example-template-2)": { name: "my name" },
+    });
+
+    expect(result).toHaveLength(1);
+    const [template] = result;
+    expect(template.slug).toBe("products(example-template-2)");
+    expect(template.label).toBe("Example Template 2");
+    expect(template.fieldCount).toBe(1);
+    expect(template.fields).toEqual([
+      {
+        key: "name",
+        label: "Name",
+        value: "my name",
+        type: "string",
+        displayValue: "my name",
+      },
+    ]);
+  });
+
+  it("normalizes multiple templates with mixed value types", () => {
+    const result = normalizeExtensions({
+      "products(care)": { material: "Organic cotton", is_fair_trade: true },
+      "products(metrics)": { rating: 4.7 },
+    });
+
+    expect(result.map((t) => t.label)).toEqual(["Care", "Metrics"]);
+    const care = result[0];
+    expect(care.fields.map((f) => f.type)).toEqual(["string", "boolean"]);
+    expect(
+      care.fields.find((f) => f.key === "is_fair_trade")?.displayValue,
+    ).toBe("Yes");
+    expect(result[1].fields[0]).toMatchObject({
+      key: "rating",
+      type: "number",
+      displayValue: (4.7).toLocaleString(),
+    });
+  });
+
+  it("treats a non-object template group as having zero fields", () => {
+    const result = normalizeExtensions({
+      "products(weird)": "not-an-object" as unknown as Record<string, unknown>,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].fieldCount).toBe(0);
+    expect(result[0].fields).toEqual([]);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/design-time-data.ts
@@ -1,0 +1,27 @@
+import type { ExtensionTemplate, ExtensionsData } from "./types";
+import { normalizeExtensions } from "./format";
+
+/**
+ * Mock extensions payload used in Studio / MCP preview when no live product
+ * is bound, or when previewState is "withData". Mirrors the shape of EP's
+ * `attributes.extensions` object.
+ */
+export const MOCK_EXTENSIONS_RAW: Record<string, Record<string, unknown>> = {
+  "products(care-and-materials)": {
+    care_instructions: "Machine wash cold, tumble dry low.",
+    material: "Organic cotton",
+    country_of_origin: "Portugal",
+  },
+  "products(certifications)": {
+    is_fair_trade: true,
+    rating: 4.7,
+  },
+};
+
+export const MOCK_EXTENSION_TEMPLATES: ExtensionTemplate[] =
+  normalizeExtensions(MOCK_EXTENSIONS_RAW);
+
+export const MOCK_EXTENSIONS_DATA: ExtensionsData = {
+  templateCount: MOCK_EXTENSION_TEMPLATES.length,
+  isEmpty: MOCK_EXTENSION_TEMPLATES.length === 0,
+};

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/format.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/format.ts
@@ -1,0 +1,136 @@
+import type { ExtensionField, ExtensionFieldType, ExtensionTemplate } from "./types";
+
+/**
+ * Turn an EP extension template slug like `products(example-template-2)` into
+ * a human label like "Example Template 2".
+ *
+ * - Strips the leading entity prefix (e.g. `products`) and the surrounding
+ *   parentheses if present.
+ * - Replaces dashes/underscores with spaces.
+ * - Title-cases each word.
+ *
+ * Falls back to the original slug if it doesn't match the expected shape.
+ */
+export function humanizeTemplateSlug(slug: string): string {
+  if (!slug) return "";
+  const parenMatch = slug.match(/^[a-z0-9_-]+\((.+)\)$/i);
+  const inner = parenMatch ? parenMatch[1] : slug;
+  return titleCase(inner.replace(/[-_]+/g, " "));
+}
+
+/**
+ * Turn an extension field key into a human label.
+ * - `name` → "Name"
+ * - `productCare` → "Product Care"
+ * - `eco_rating` → "Eco Rating"
+ * - `dimensions-cm` → "Dimensions Cm"
+ */
+export function humanizeFieldKey(key: string): string {
+  if (!key) return "";
+  const spaced = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ");
+  return titleCase(spaced);
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export function inferType(value: unknown): ExtensionFieldType {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") return "object";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  return "string";
+}
+
+/**
+ * Render a primitive-or-complex extension value into a single display string.
+ * - boolean → "Yes" / "No"
+ * - null/undefined → ""
+ * - number → toLocaleString (no Intl options to stay safe in Plasmic ctx)
+ * - string → as-is
+ * - array → joined with ", " using displayValue recursion (one level deep)
+ * - object → "key: value, key: value" for shallow objects, else JSON
+ */
+export function formatDisplayValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") {
+    try {
+      return value.toLocaleString();
+    } catch {
+      return String(value);
+    }
+  }
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => formatDisplayValueShallow(v))
+      .filter((s) => s.length > 0)
+      .join(", ");
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return "";
+    const allShallow = entries.every(
+      ([, v]) => v === null || v === undefined || typeof v !== "object",
+    );
+    if (allShallow) {
+      return entries
+        .map(([k, v]) => `${humanizeFieldKey(k)}: ${formatDisplayValueShallow(v)}`)
+        .join(", ");
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  }
+  return String(value);
+}
+
+function formatDisplayValueShallow(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return value;
+  return "";
+}
+
+/**
+ * Walk a raw extensions object into the normalized template/field arrays
+ * we expose to designer-driven bindings.
+ */
+export function normalizeExtensions(
+  raw: Record<string, unknown> | null | undefined,
+): ExtensionTemplate[] {
+  if (!raw || typeof raw !== "object") return [];
+  return Object.entries(raw).map(([slug, group]): ExtensionTemplate => {
+    const groupObj =
+      group && typeof group === "object" && !Array.isArray(group)
+        ? (group as Record<string, unknown>)
+        : {};
+    const fields: ExtensionField[] = Object.entries(groupObj).map(
+      ([key, value]): ExtensionField => ({
+        key,
+        label: humanizeFieldKey(key),
+        value,
+        type: inferType(value),
+        displayValue: formatDisplayValue(value),
+      }),
+    );
+    return {
+      slug,
+      label: humanizeTemplateSlug(slug),
+      fields,
+      fieldCount: fields.length,
+    };
+  });
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/index.ts
@@ -1,0 +1,40 @@
+export {
+  EPProductExtensionsProvider,
+  registerEPProductExtensionsProvider,
+  epProductExtensionsProviderMeta,
+  useProductExtensionsContext,
+  getMockExtensionsData,
+} from "./EPProductExtensionsProvider";
+export {
+  EPProductExtensionTemplateList,
+  registerEPProductExtensionTemplateList,
+  epProductExtensionTemplateListMeta,
+} from "./EPProductExtensionTemplateList";
+export {
+  EPProductExtensionTemplateField,
+  registerEPProductExtensionTemplateField,
+  epProductExtensionTemplateFieldMeta,
+} from "./EPProductExtensionTemplateField";
+export {
+  EPProductExtensionFieldList,
+  registerEPProductExtensionFieldList,
+  epProductExtensionFieldListMeta,
+} from "./EPProductExtensionFieldList";
+export {
+  EPProductExtensionField,
+  registerEPProductExtensionField,
+  epProductExtensionFieldMeta,
+} from "./EPProductExtensionField";
+export type {
+  ExtensionField,
+  ExtensionTemplate,
+  ExtensionsData,
+  ExtensionFieldType,
+} from "./types";
+export {
+  normalizeExtensions,
+  humanizeTemplateSlug,
+  humanizeFieldKey,
+  inferType,
+  formatDisplayValue,
+} from "./format";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/types.ts
@@ -1,0 +1,27 @@
+export type ExtensionFieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "array"
+  | "object";
+
+export interface ExtensionField {
+  key: string;
+  label: string;
+  value: unknown;
+  type: ExtensionFieldType;
+  displayValue: string;
+}
+
+export interface ExtensionTemplate {
+  slug: string;
+  label: string;
+  fields: ExtensionField[];
+  fieldCount: number;
+}
+
+export interface ExtensionsData {
+  templateCount: number;
+  isEmpty: boolean;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./composable";


### PR DESCRIPTION
## Summary

Adds a 5-component composable that mirrors the bundle/variation patterns for surfacing `attributes.extensions` from EP catalog products. The existing path was only reachable as `currentProduct.rawData.data.attributes.extensions` via deep bracket-string bindings inside Studio — this gives merchants a drop-together tree instead.

- `EPProductExtensionsProvider` — root; reads `currentProduct`, normalises extensions into `ExtensionTemplate[]`, self-gates when empty (optional `notExtensionsContent` slot), exposes `extensionsData` (`{ templateCount, isEmpty }`) + an internal React context for the templates array (same shape the bundle composable uses for its form context).
- `EPProductExtensionTemplateList` — repeats over templates, provides `currentExtensionTemplate` + `currentExtensionTemplateIndex`.
- `EPProductExtensionTemplateField` — `field` choice: `slug` | `label` | `fieldCount`.
- `EPProductExtensionFieldList` — repeats over a template's fields, provides `currentExtensionField` + `currentExtensionFieldIndex`.
- `EPProductExtensionField` — `field` choice: `label` | `displayValue` | `value` | `key` | `type`.

Formatting helpers exported alongside so SSR / non-Plasmic consumers can reuse the logic:

- `humanizeTemplateSlug(\"products(example-template-2)\")` → `\"Example Template 2\"`
- `humanizeFieldKey(\"productCare\")` → `\"Product Care\"`
- `inferType(value)` → `\"string\" | \"number\" | \"boolean\" | \"null\" | \"array\" | \"object\"`
- `formatDisplayValue(value)` — booleans render as `Yes`/`No`, numbers via `toLocaleString`, shallow objects as comma-joined `Key: value` pairs, deep objects as JSON, primitives passthrough.

Every component carries a `previewState` (`auto` | `withData` | `empty`) so Studio renders sample care/certifications data when no live product is bound — matches the rest of the EP composables.

## Tree shape in Studio

\`\`\`
<EPProductExtensionsProvider>          // self-gates if extensions is null/empty
  <EPProductExtensionTemplateList>
    <EPProductExtensionTemplateField field=\"label\" />
    <EPProductExtensionFieldList>
      <EPProductExtensionField field=\"label\" />
      <EPProductExtensionField field=\"displayValue\" />
    </EPProductExtensionFieldList>
  </EPProductExtensionTemplateList>
</EPProductExtensionsProvider>
\`\`\`

For a product with \`extensions = { \"products(example-template-2)\": { name: \"my name\" } }\` this renders one template heading (\"Example Template 2\") and one field row (\"Name\" → \"my name\"). For products with \`extensions: null\` (variation parents, bundles, etc.) the provider self-gates and the whole section disappears.

## Test plan

- [x] All 5 components added to \`registerAll\` in the right dependency order (leaves before lists before provider — matches the bundle/stock/cart-drawer convention).
- [x] Provider reads \`currentProduct.rawData.data.attributes.extensions\` via the existing \`useSelector(\"currentProduct\")\` boundary — no new fetch.
- [x] Verified end-to-end on a storefront PDP:
  - Simple product with one template (\`products(example-template-2)\` / \`name: \"my name\"\`) renders \"EXAMPLE TEMPLATE 2 / Name → my name\".
  - Variation parent + variation child + bundle (all with \`extensions: null\`) self-gate, no \"DETAILS\" section in DOM.
  - Mobile breakpoint inherits styling.
- [x] Studio design-time preview shows sample care/certifications mock data (when no live product is bound).
- [ ] Unit tests not yet added — happy to add a \`__tests__\` folder following the bundle pattern if reviewers want.

## Notes

- No changes outside the new `product-extensions/` directory and a small additive block in `src/index.tsx` (imports + `registerAll` entries + `export *`).
- No changes to the `Product` type — uses the existing `rawData` passthrough that already lives in \`src/types/product.ts\`.
- The `extensions` shape isn't formally typed by the @epcc-sdk/sdks-shopper package, so the provider treats it as `Record<string, unknown>` and the helpers infer types from values. If a stricter type lands upstream we can tighten without an API break.