### PR TITLE
fix(ep-commerce): inherit price currency from first child variant

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/test/normalize.spec.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/test/normalize.spec.ts
@@ -188,6 +188,68 @@ describe('normalize utilities', () => {
       expect(variant3?.options[1].values[0].label).toBe('Red');
     });
 
+    it('should inherit price + currency from first child when PXM parent has no display_price', () => {
+      // PXM "base-product" variation parents carry no display_price of their
+      // own; only the child variants do. Previously getProductPrice fell
+      // through to money(0) → {value:0, currencyCode:"USD"}, which broke
+      // non-USD stores. The parent should now inherit from the first child.
+      const parentWithoutPrice: ProductData = {
+        data: {
+          ...mockProductData.data!,
+          meta: {
+            ...mockProductData.data!.meta,
+            display_price: undefined,
+          },
+        },
+      };
+      const childrenChf: ProductListData = {
+        data: [
+          {
+            id: 'child-chf-1',
+            type: 'product',
+            attributes: { name: 'CHF child', status: 'live' },
+            meta: {
+              display_price: {
+                without_tax: { amount: 13500, currency: 'CHF' },
+              },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeProduct(parentWithoutPrice, 'en-US', childrenChf);
+
+      expect(result.price.value).toBe(135); // 13500 cents
+      expect(result.price.currencyCode).toBe('CHF');
+    });
+
+    it('should fall back to money(0) when neither parent nor any child has a price', () => {
+      const parentWithoutPrice: ProductData = {
+        data: {
+          ...mockProductData.data!,
+          meta: {
+            ...mockProductData.data!.meta,
+            display_price: undefined,
+          },
+        },
+      };
+      const pricelessChildren: ProductListData = {
+        data: [
+          {
+            id: 'child-x',
+            type: 'product',
+            attributes: { name: 'No price child', status: 'live' },
+            meta: {},
+          },
+        ],
+      };
+
+      const result = normalizeProduct(parentWithoutPrice, 'en-US', pricelessChildren);
+
+      expect(result.price.value).toBe(0);
+      expect(result.price.currencyCode).toBe('USD');
+    });
+
     it('should handle missing variation_matrix gracefully', () => {
       const productWithoutMatrix: ProductData = {
         data: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize.ts
@@ -148,25 +148,32 @@ const normalizeProductImages = (product: ProductData) => {
   return images;
 };
 
-const getProductPrice = (product: ProductData) => {
-  // Try meta.display_price first (newer format)
+const getProductPrice = (
+  product: ProductData,
+  childProducts?: ProductListData
+) => {
+  // Primary: parent product carries its own display_price (simple products,
+  // or PXM groups where pricing is replicated up the tree).
   if (product.data?.meta?.display_price?.without_tax) {
     return money(
-      product.data?.meta?.display_price.without_tax.amount,
-      product.data?.meta?.display_price.without_tax.currency
+      product.data.meta.display_price.without_tax.amount,
+      product.data.meta.display_price.without_tax.currency
     );
   }
 
-  // Try meta.price array
-  if (product.data?.meta?.display_price?.without_tax) {
-    const price = product.data?.meta?.display_price?.without_tax;
-    return money(price.amount, price.currency);
-  }
-
-  // Try direct price array (legacy)
-  if (product.data?.meta?.display_price?.without_tax) {
-    const price = product.data?.meta?.display_price?.without_tax;
-    return money(price.amount, price.currency);
+  // Fallback: PXM variation parent ("base-product") products carry no
+  // display_price of their own — every variant child does. Inherit currency
+  // (and a representative amount) from the first child that has a price so
+  // that `Product.price.currencyCode` resolves to the right value instead of
+  // falling back to the money() default of USD.
+  const firstChildWithPrice = childProducts?.data?.find(
+    (c) => c?.meta?.display_price?.without_tax?.amount != null
+  );
+  if (firstChildWithPrice?.meta?.display_price?.without_tax) {
+    return money(
+      firstChildWithPrice.meta.display_price.without_tax.amount,
+      firstChildWithPrice.meta.display_price.without_tax.currency
+    );
   }
 
   return money(0);
@@ -199,7 +206,7 @@ export const normalizeProduct = (
   }
 
   // Build variants from child products if available
-  const parentPrice = getProductPrice(product);
+  const parentPrice = getProductPrice(product, childProducts);
 
   let variants: ProductVariant[] = [
     {
@@ -289,7 +296,7 @@ export const normalizeProduct = (
     slug,
     path: `/${slug}`,
     description,
-    price: getProductPrice(product),
+    price: getProductPrice(product, childProducts),
     images: normalizeProductImages(product),
     variants,
     options,


### PR DESCRIPTION
## Summary

Fixes #334.

`getProductPrice()` in `normalize.ts` had three identical `display_price` checks (copy-paste residue from a refactor) and fell through to `money(0)` — which defaults the currency to `USD` — whenever the parent product carried no `display_price` of its own. That fallback fires on every PXM "base-product" variation parent: all real prices live on the child variants, the parent meta has no `display_price`. Result: `Product.price.currencyCode` always came back as `USD` for these parents regardless of the store's actual currency, silently breaking non-USD storefronts.

This PR:

1. Removes the two dead duplicate `display_price` branches.
2. Adds a fallback that inherits `{amount, currency}` from the first child variant in `childProducts` carrying a `display_price.without_tax`.
3. Threads `childProducts` through both call sites in `normalizeProduct`.
4. Adds two regression tests:
   - parent without `display_price` + CHF-priced child → `Product.price = { value: 135, currencyCode: "CHF" }`
   - parent + all children priceless → preserves existing `money(0)` default

## Test plan

- [x] `yarn test` — 1712 passed (was 1710 + 2 new tests)
- [x] Verified end-to-end in a downstream storefront (iso-storefront) — PDP for a PXM-variant CHF product now shows "CHF 135" instead of "USD 0", with the binding resolving via the natural `$ctx.currentProduct.price.currencyCode` path (no hardcode).
- [ ] CI on this PR

## Backwards compatibility

`getProductPrice` was an internal-module function; the only external surface is `normalizeProduct`, whose signature is unchanged. Existing storefronts on parent products that DO carry their own `display_price` are unaffected — the primary branch still runs first.