### PR TITLE
feat(ep-commerce): per-variation input rendering via EPVariationCase (#336)

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -7,7 +7,10 @@ import { registerEPMultiLocationStock } from "./registerEPMultiLocationStock";
 import { registerEPProductVariantPicker } from "./registerEPProductVariantPicker";
 import { registerEPCheckout } from "./registerCheckout";
 import { registerEPVariationPicker } from "./variant-picker/EPVariationPicker";
+import { registerEPVariationCase } from "./variant-picker/EPVariationCase";
 import { registerEPVariationOptionList } from "./variant-picker/EPVariationOptionList";
+import { registerEPVariationOptionSelect } from "./variant-picker/EPVariationOptionSelect";
+import { registerEPVariationOptionRadioGroup } from "./variant-picker/EPVariationOptionRadioGroup";
 import { registerEPVariationOptionTrigger } from "./variant-picker/EPVariationOptionTrigger";
 import { registerEPVariationField } from "./variant-picker/EPVariationField";
 import { registerEPVariationOptionField } from "./variant-picker/EPVariationOptionField";
@@ -102,12 +105,15 @@ export function registerAll(loader?: Registerable) {
   registerShopperContext(loader);
 
   // New composable variant picker
-  // Register field components first so they're available as default slot content
+  // Register field/leaf components first so they're available as default slot content
   registerEPVariationField(loader);
   registerEPVariationOptionField(loader);
-  registerEPVariationPicker(loader);
-  registerEPVariationOptionList(loader);
   registerEPVariationOptionTrigger(loader);
+  registerEPVariationOptionList(loader);
+  registerEPVariationOptionSelect(loader);
+  registerEPVariationOptionRadioGroup(loader);
+  registerEPVariationCase(loader);
+  registerEPVariationPicker(loader);
 
   // Cart provider — exposes $ctx.cart to descendants
   registerEPCartProvider(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationCase.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationCase.tsx
@@ -1,0 +1,106 @@
+import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useEffect } from "react";
+import { Registerable } from "../registerable";
+import { createLogger } from "../utils/logger";
+import { useVariationPicker } from "./VariationPickerContext";
+
+const log = createLogger("EPVariationCase");
+
+interface EPVariationCaseProps {
+  children?: React.ReactNode;
+  className?: string;
+  forVariation?: string;
+}
+
+export const epVariationCaseMeta: CodeComponentMeta<EPVariationCaseProps> = {
+  name: "plasmic-commerce-ep-variation-case",
+  displayName: "EP Variation Case",
+  description:
+    "Slot host scoped to one variation (e.g. Language, Format). Set 'For variation' to render only when iterating that variation. Leave blank to render as the fallback for variations not handled by any sibling. Must be inside an EP Variation Picker.",
+  props: {
+    children: {
+      type: "slot",
+      defaultValue: [
+        {
+          type: "vbox",
+          styles: { gap: "8px", padding: "4px 0" },
+          children: [
+            {
+              type: "component",
+              name: "plasmic-commerce-ep-variation-field",
+              props: { field: "name" },
+            },
+            {
+              type: "component",
+              name: "plasmic-commerce-ep-variation-option-list",
+            },
+          ],
+        },
+      ],
+    },
+    forVariation: {
+      type: "string",
+      displayName: "For variation",
+      description:
+        "Variation name (matches the variation's display name in EP, e.g. 'Language', 'Format'). Leave blank to make this the fallback for any variation not handled by a sibling.",
+    },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPVariationCase",
+};
+
+export function EPVariationCase(props: EPVariationCaseProps) {
+  const { children, className, forVariation } = props;
+
+  const picker = useVariationPicker();
+  const currentVariation = useSelector("currentVariation") as
+    | { id: string; name: string }
+    | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const trimmedForVariation = forVariation?.trim();
+  const isKeyed = !!trimmedForVariation;
+
+  const registerClaim = picker?.registerClaim;
+  useEffect(() => {
+    if (!isKeyed || !registerClaim) return;
+    return registerClaim(trimmedForVariation!);
+  }, [isKeyed, trimmedForVariation, registerClaim]);
+
+  if (inEditor && !currentVariation) {
+    // Show children at design time when not inside a real picker iteration,
+    // so the designer can see and edit the slot content.
+    return <div className={className}>{children}</div>;
+  }
+
+  if (!currentVariation || !picker) {
+    return null;
+  }
+
+  const shouldRender = isKeyed
+    ? currentVariation.name === trimmedForVariation
+    : !picker.claimedVariations.has(currentVariation.name);
+
+  if (!shouldRender) {
+    log.debug("Skipping variation", {
+      forVariation: trimmedForVariation ?? "(fallback)",
+      currentVariation: currentVariation.name,
+      claimedVariations: Array.from(picker.claimedVariations),
+    } as Record<string, unknown>);
+    return null;
+  }
+
+  return <div className={className}>{children}</div>;
+}
+
+export function registerEPVariationCase(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPVariationCaseProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPVariationCase, customMeta ?? epVariationCaseMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationOptionRadioGroup.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationOptionRadioGroup.tsx
@@ -1,0 +1,159 @@
+import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useId } from "react";
+import { Registerable } from "../registerable";
+import { createLogger } from "../utils/logger";
+import { MOCK_VARIATION_OPTIONS } from "../utils/design-time-data";
+import { useVariationPicker } from "./VariationPickerContext";
+
+const log = createLogger("EPVariationOptionRadioGroup");
+
+type PreviewState = "auto" | "withOptions";
+
+interface EPVariationOptionRadioGroupProps {
+  className?: string;
+  itemClassName?: string;
+  labelClassName?: string;
+  inputClassName?: string;
+  groupLabel?: string;
+  previewState?: PreviewState;
+}
+
+export const epVariationOptionRadioGroupMeta: CodeComponentMeta<EPVariationOptionRadioGroupProps> =
+  {
+    name: "plasmic-commerce-ep-variation-option-radio-group",
+    displayName: "EP Variation Option Radio Group",
+    description:
+      "Native <input type='radio'> renderer for one variation (e.g. Format). Reads the current variation from context. Must be inside an EP Variation Case (or directly inside an EP Variation Picker).",
+    props: {
+      itemClassName: {
+        type: "string",
+        displayName: "Item class",
+        description: "CSS class applied to each radio row wrapper.",
+        advanced: true,
+      },
+      labelClassName: {
+        type: "string",
+        displayName: "Label class",
+        description: "CSS class applied to each option's label.",
+        advanced: true,
+      },
+      inputClassName: {
+        type: "string",
+        displayName: "Input class",
+        description: "CSS class applied to each <input> element.",
+        advanced: true,
+      },
+      groupLabel: {
+        type: "string",
+        displayName: "Accessible Label",
+        description:
+          "Accessible label for the radio group. Defaults to the variation name.",
+        advanced: true,
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withOptions"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPVariationOptionRadioGroup",
+  };
+
+export function EPVariationOptionRadioGroup(
+  props: EPVariationOptionRadioGroupProps
+) {
+  const {
+    className,
+    itemClassName,
+    labelClassName,
+    inputClassName,
+    groupLabel,
+    previewState = "auto",
+  } = props;
+
+  const picker = useVariationPicker();
+  const inEditor = !!usePlasmicCanvasContext();
+  const reactId = useId();
+
+  const currentVariation = useSelector("currentVariation") as
+    | {
+        id: string;
+        name: string;
+        values: { label: string; hexColors?: string[] }[];
+      }
+    | undefined;
+
+  const mockVariation = MOCK_VARIATION_OPTIONS[0];
+  const useMock =
+    previewState === "withOptions" ||
+    (previewState === "auto" && !currentVariation && inEditor);
+
+  const effectiveVariation = useMock
+    ? {
+        id: mockVariation.id,
+        name: mockVariation.displayName,
+        values: mockVariation.values,
+      }
+    : currentVariation;
+
+  if (useMock) {
+    log.debug("Using mock variation for design-time preview");
+  }
+
+  if (!effectiveVariation?.values) {
+    return null;
+  }
+
+  const selectedLabel = picker?.selectedValues[effectiveVariation.id];
+  const label = groupLabel || effectiveVariation.name;
+  const radioName = `variation_${effectiveVariation.id}_${reactId}`;
+
+  return (
+    <div className={className} role="radiogroup" aria-label={label}>
+      {effectiveVariation.values.map((option) => {
+        const id = `${radioName}_${option.label}`;
+        const isSelected = selectedLabel === option.label;
+        return (
+          <div key={option.label} className={itemClassName}>
+            <input
+              type="radio"
+              id={id}
+              name={radioName}
+              value={option.label}
+              checked={isSelected}
+              className={inputClassName}
+              onChange={() => {
+                if (picker && effectiveVariation) {
+                  picker.selectOption(effectiveVariation.id, option.label);
+                }
+              }}
+            />
+            <label htmlFor={id} className={labelClassName}>
+              {option.label}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function registerEPVariationOptionRadioGroup(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPVariationOptionRadioGroupProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPVariationOptionRadioGroup,
+    customMeta ?? epVariationOptionRadioGroupMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationOptionSelect.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationOptionSelect.tsx
@@ -1,0 +1,141 @@
+import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../registerable";
+import { createLogger } from "../utils/logger";
+import { MOCK_VARIATION_OPTIONS } from "../utils/design-time-data";
+import { useVariationPicker } from "./VariationPickerContext";
+
+const log = createLogger("EPVariationOptionSelect");
+
+type PreviewState = "auto" | "withOptions";
+
+interface EPVariationOptionSelectProps {
+  className?: string;
+  groupLabel?: string;
+  placeholder?: string;
+  previewState?: PreviewState;
+}
+
+export const epVariationOptionSelectMeta: CodeComponentMeta<EPVariationOptionSelectProps> =
+  {
+    name: "plasmic-commerce-ep-variation-option-select",
+    displayName: "EP Variation Option Select",
+    description:
+      "Native <select> renderer for one variation (e.g. Language). Reads the current variation from context. Must be inside an EP Variation Case (or directly inside an EP Variation Picker).",
+    props: {
+      groupLabel: {
+        type: "string",
+        displayName: "Accessible Label",
+        description:
+          "Accessible label for the select. Defaults to the variation name.",
+        advanced: true,
+      },
+      placeholder: {
+        type: "string",
+        displayName: "Placeholder",
+        description:
+          "Text for the empty/disabled placeholder option. Defaults to 'Choose {variation name}...'.",
+        advanced: true,
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withOptions"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state with sample data for design-time editing",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPVariationOptionSelect",
+  };
+
+export function EPVariationOptionSelect(props: EPVariationOptionSelectProps) {
+  const { className, groupLabel, placeholder, previewState = "auto" } = props;
+
+  const picker = useVariationPicker();
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const currentVariation = useSelector("currentVariation") as
+    | {
+        id: string;
+        name: string;
+        values: { label: string; hexColors?: string[] }[];
+      }
+    | undefined;
+
+  const mockVariation = MOCK_VARIATION_OPTIONS[0];
+  const useMock =
+    previewState === "withOptions" ||
+    (previewState === "auto" && !currentVariation && inEditor);
+
+  const effectiveVariation = useMock
+    ? {
+        id: mockVariation.id,
+        name: mockVariation.displayName,
+        values: mockVariation.values,
+      }
+    : currentVariation;
+
+  if (useMock) {
+    log.debug("Using mock variation for design-time preview");
+  }
+
+  if (!effectiveVariation?.values) {
+    return null;
+  }
+
+  const selectedLabel = picker?.selectedValues[effectiveVariation.id] ?? "";
+  const label = groupLabel || effectiveVariation.name;
+  const placeholderText = placeholder || `Choose ${effectiveVariation.name}...`;
+
+  return (
+    <select
+      className={className}
+      style={CHEVRON_STYLE}
+      value={selectedLabel}
+      aria-label={label}
+      onChange={(e) => {
+        if (picker && effectiveVariation) {
+          picker.selectOption(effectiveVariation.id, e.target.value);
+        }
+      }}
+    >
+      <option value="" disabled>
+        {placeholderText}
+      </option>
+      {effectiveVariation.values.map((option) => (
+        <option key={option.label} value={option.label}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// Custom chevron survives Tailwind/normalize.css `appearance: none` resets.
+const CHEVRON_SVG =
+  "data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%236b7280' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E";
+
+const CHEVRON_STYLE: React.CSSProperties = {
+  backgroundImage: `url("${CHEVRON_SVG}")`,
+  backgroundRepeat: "no-repeat",
+  backgroundPosition: "right 12px center",
+  backgroundSize: "10px 6px",
+};
+
+export function registerEPVariationOptionSelect(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPVariationOptionSelectProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPVariationOptionSelect,
+    customMeta ?? epVariationOptionSelectMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationPicker.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/EPVariationPicker.tsx
@@ -40,19 +40,8 @@ export const epVariationPickerMeta: CodeComponentMeta<EPVariationPickerProps> = 
       type: "slot",
       defaultValue: [
         {
-          type: "vbox",
-          styles: { gap: "8px", padding: "4px 0" },
-          children: [
-            {
-              type: "component",
-              name: "plasmic-commerce-ep-variation-field",
-              props: { field: "name" },
-            },
-            {
-              type: "component",
-              name: "plasmic-commerce-ep-variation-option-list",
-            },
-          ],
+          type: "component",
+          name: "plasmic-commerce-ep-variation-case",
         },
       ],
     },
@@ -142,30 +131,58 @@ export function EPVariationPicker(props: EPVariationPickerProps) {
   const [lastInitializedVariantId, setLastInitializedVariantId] = useState<
     string | undefined
   >(undefined);
+  const [claimedVariations, setClaimedVariations] = useState<Set<string>>(
+    () => new Set<string>()
+  );
 
-  // Initialize from resolved default variant ID
+  const registerClaim = useCallback((variationName: string) => {
+    setClaimedVariations((prev) => {
+      if (prev.has(variationName)) return prev;
+      const next = new Set(prev);
+      next.add(variationName);
+      return next;
+    });
+    return () => {
+      setClaimedVariations((prev) => {
+        if (!prev.has(variationName)) return prev;
+        const next = new Set(prev);
+        next.delete(variationName);
+        return next;
+      });
+    };
+  }, []);
+
+  // Initialize from resolved default variant ID — or fall back to first variant
+  // when none is supplied, so trigger highlights match the auto-selected variant
+  // exposed via the URL writer below.
   useEffect(() => {
-    if (
-      resolvedDefaultVariantId &&
-      resolvedDefaultVariantId !== lastInitializedVariantId &&
-      effectiveProduct?.variants
-    ) {
-      const targetVariant = effectiveProduct.variants.find(
-        (v) => v.id === resolvedDefaultVariantId
-      );
-      if (targetVariant) {
-        const initialValues: Record<string, string> = {};
-        targetVariant.options?.forEach((option) => {
-          const value = option.values?.[0]?.label;
-          if (value) {
-            initialValues[option.id] = value;
-          }
-        });
-        setSelectedValues(initialValues);
-        setLastInitializedVariantId(resolvedDefaultVariantId);
+    if (!effectiveProduct?.variants?.length) return;
+    if (Object.keys(selectedValues).length > 0) return;
+
+    const target = resolvedDefaultVariantId
+      ? effectiveProduct.variants.find((v) => v.id === resolvedDefaultVariantId)
+      : effectiveProduct.variants[0];
+    if (!target) return;
+    const targetId = String(target.id);
+    if (targetId === lastInitializedVariantId) return;
+
+    const initialValues: Record<string, string> = {};
+    target.options?.forEach((option) => {
+      const value = option.values?.[0]?.label;
+      if (value) {
+        initialValues[option.id] = value;
       }
-    }
-  }, [resolvedDefaultVariantId, effectiveProduct, lastInitializedVariantId]);
+    });
+    if (Object.keys(initialValues).length === 0) return;
+
+    setSelectedValues(initialValues);
+    setLastInitializedVariantId(targetId);
+  }, [
+    resolvedDefaultVariantId,
+    effectiveProduct,
+    lastInitializedVariantId,
+    selectedValues,
+  ]);
 
   const selectOption = useCallback(
     (variationId: string, optionLabel: string) => {
@@ -234,8 +251,10 @@ export function EPVariationPicker(props: EPVariationPickerProps) {
       selectedValues,
       selectOption,
       selectedVariant,
+      claimedVariations,
+      registerClaim,
     }),
-    [selectedValues, selectOption, selectedVariant]
+    [selectedValues, selectOption, selectedVariant, claimedVariations, registerClaim]
   );
 
   if (!variations || variations.length === 0) {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/VariationPickerContext.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/VariationPickerContext.tsx
@@ -5,6 +5,8 @@ export interface VariationPickerContextValue {
   selectedValues: Record<string, string>;
   selectOption: (variationId: string, optionLabel: string) => void;
   selectedVariant: ProductVariant | undefined;
+  claimedVariations: ReadonlySet<string>;
+  registerClaim: (variationName: string) => () => void;
 }
 
 export const VariationPickerContext =

--- a/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/variant-picker/index.ts
@@ -1,5 +1,8 @@
 export { registerEPVariationPicker, EPVariationPicker } from "./EPVariationPicker";
+export { registerEPVariationCase, EPVariationCase } from "./EPVariationCase";
 export { registerEPVariationOptionList, EPVariationOptionList } from "./EPVariationOptionList";
+export { registerEPVariationOptionSelect, EPVariationOptionSelect } from "./EPVariationOptionSelect";
+export { registerEPVariationOptionRadioGroup, EPVariationOptionRadioGroup } from "./EPVariationOptionRadioGroup";
 export { registerEPVariationOptionTrigger, EPVariationOptionTrigger } from "./EPVariationOptionTrigger";
 export { registerEPVariationField, EPVariationField } from "./EPVariationField";
 export { registerEPVariationOptionField, EPVariationOptionField } from "./EPVariationOptionField";


### PR DESCRIPTION
## Summary

Closes #336.

Adds a per-variation "input pattern" capability to `EPVariationPicker` so each variation on a product can render with its own input style — primarily so a storefront's PDP can render Language as a native `<select>` and Format as native radios, while other variations continue to render as the existing card/chip pattern.

The shape is the **Discriminated Slot Children** pattern, modelled after HTML's `<picture>/<source>`. Consumers compose:

```jsx
<EPVariationPicker>
  <EPVariationCase forVariation="Language">
    <EPVariationField field="name" />
    <EPVariationOptionSelect />
  </EPVariationCase>

  <EPVariationCase forVariation="Format">
    <EPVariationField field="name" />
    <EPVariationOptionRadioGroup />
  </EPVariationCase>

  <EPVariationCase>{/* un-keyed = fallback for any other variation */}
    <EPVariationField field="name" />
    <EPVariationOptionList />
  </EPVariationCase>
</EPVariationPicker>
```

### What's new

- **`EPVariationCase`** — slot host with optional `forVariation` prop. Keyed cases render only when iterating their named variation; un-keyed cases act as the fallback for any variation no keyed sibling has claimed.
- **`EPVariationOptionSelect`** — atomic native `<select>` renderer for one variation.
- **`EPVariationOptionRadioGroup`** — atomic native radio-group renderer for one variation.
- `VariationPickerContext` now exposes `claimedVariations: ReadonlySet<string>` and `registerClaim(variationName) => unregister`. Keyed `EPVariationCase` instances self-register on mount; the fallback consults the registry to decide whether to render. **No `React.Children` scanning**, so Plasmic's runtime div wrapping doesn't break the filter.
- Picker default `children` slot now contains a single un-keyed `EPVariationCase` wrapping the existing `Field + EPVariationOptionList`. **Zero-config N-variation usage is unchanged.**

### Picker hydration fix

While wiring this I noticed the picker's init `useEffect` wasn't populating `selectedValues` when no `defaultVariantId` resolved, leaving option triggers un-highlighted on first load even though a variant was effectively in use. Fixed in the same effect: falls back to `variants[0]` and populates `selectedValues` accordingly. Bundled here because the new `EPVariationCase` registration would re-trigger the bug in any consumer that adopts the new pattern.

### Naming

The component is named `EPVariationCase` (switch/case analogy: "this is the case for variation X"), matching the existing `Variation` namespace in this package. Earlier drafts of this PR used `EPVariationAxis` — that's been renamed to align with the rest of the surface (`EPVariationField`, `EPVariationOptionList`, etc.) and to keep "variation" as the single domain term consumers see.

### Ordering

Preserved from EP. The picker still iterates `product.options[]` in EP order; `forVariation` only decides which subtree renders during each iteration. Reorder in the EP catalog to change display order.

### Backwards compatibility

Existing projects using `<EPVariationOptionList>` directly under the picker continue to work — the new default `children` content is semantically identical to the prior default content. `EPVariationOptionList`'s `selectionMode="dropdown"` branch is **not** removed; new use is steered to `EPVariationOptionSelect`.

### Alternatives considered

Rejected during design grilling:

- **`selectionModeByVariation: Record<variationName, mode>` config prop.** Awkward Plasmic Studio authoring (no first-class UI for `Record<string, enum>`), config split between picker prop and child components, silent failure on typo.
- **Per-variation explicit instances with no fallback.** Forces explicit declaration of every variation even when overriding one.
- **Render-prop children (Shopify Hydrogen `VariantSelector` shape).** Unauthorable in Plasmic Studio.

## Test plan

- [ ] Build the package: `yarn build` in `plasmicpkgs/commerce-providers/elastic-path` — verify no TS errors.
- [ ] Drop `EPVariationPicker` on a Plasmic page with a 2-variation product (e.g. ISO 5495:2005 with Language × Format). Default children renders chip pattern for both variations.
- [ ] Add `<EPVariationCase forVariation="Language"><EPVariationOptionSelect/></EPVariationCase>` and `<EPVariationCase forVariation="Format"><EPVariationOptionRadioGroup/></EPVariationCase>` inside the picker. Confirm Language renders as `<select>`, Format as native radios.
- [ ] Confirm the picker still emits the same `useFormContext` field names (`variation_<axisId>`, `ProductVariant`).
- [ ] Confirm `?variant=` URL round-trip works through the new renderers.
- [ ] Confirm no infinite-render loops by checking the dev-tools console after selecting an option.
- [ ] Confirm zero-config drop-in (no `EPVariationCase` instances authored) renders the picker with the default fallback chip pattern across N variations.