### PR TITLE
feat(ep-commerce): field-display components EPProductField + EPProductExtensionValue (#338)

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -51,6 +51,8 @@ import { registerEPProductExtensionTemplateList } from "./product-extensions/com
 import { registerEPProductExtensionTemplateField } from "./product-extensions/composable/EPProductExtensionTemplateField";
 import { registerEPProductExtensionFieldList } from "./product-extensions/composable/EPProductExtensionFieldList";
 import { registerEPProductExtensionField } from "./product-extensions/composable/EPProductExtensionField";
+import { registerEPProductField } from "./product-extensions/composable/EPProductField";
+import { registerEPProductExtensionValue } from "./product-extensions/composable/EPProductExtensionValue";
 import { registerEPSearchBox } from "./catalog-search/EPSearchBox";
 import { registerEPSearchHits } from "./catalog-search/EPSearchHits";
 import { registerEPRefinementList } from "./catalog-search/EPRefinementList";
@@ -172,6 +174,9 @@ export function registerAll(loader?: Registerable) {
   registerEPProductExtensionFieldList(loader);
   registerEPProductExtensionTemplateList(loader);
   registerEPProductExtensionsProvider(loader);
+  // Field-display components — pick one field by address (siblings to the iteration components above).
+  registerEPProductField(loader);
+  registerEPProductExtensionValue(loader);
 
   // Catalog search — register leaf/field components first, then repeaters, then provider
   registerEPSearchBox(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionValue.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionValue.tsx
@@ -1,0 +1,183 @@
+import registerComponent, {
+  CanvasComponentProps,
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import {
+  FORMAT_CHOICE_OPTIONS,
+  SHOW_CHOICE_OPTIONS,
+  buildFieldOptions,
+  buildTemplateOptions,
+} from "./field-catalog";
+import type { FormatSpec } from "./format";
+import type { ExtensionTemplate } from "./types";
+import { FieldDisplay, useResolvedField } from "./useResolvedField";
+
+type ShowFacet = "value" | "label";
+type PreviewState = "auto" | "withData";
+
+interface ExtensionValueContextData {
+  templates: ExtensionTemplate[];
+}
+
+interface EPProductExtensionValueProps
+  extends CanvasComponentProps<ExtensionValueContextData> {
+  template?: string;
+  field?: string;
+  templateOverride?: string;
+  fieldOverride?: string;
+  show?: ShowFacet;
+  format?: FormatSpec;
+  locale?: string;
+  children?: React.ReactNode;
+  notPresentContent?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductExtensionValueMeta: CodeComponentMeta<EPProductExtensionValueProps> =
+  {
+    name: "plasmic-commerce-ep-product-extension-value",
+    displayName: "EP Product Extension Value",
+    description:
+      "Displays one extension field picked by template then field from dropdowns populated from the current product — no `products(...)` slug or field key typed by hand. The specific-spot counterpart to the iterating EP Product Extension Field. Renders the formatted value as text by default; drop children to gate a section on presence and compose against the resolved value. Must be inside an EP Product Provider.",
+    props: {
+      template: {
+        type: "choice",
+        displayName: "Template",
+        description:
+          "Extension template, from the current product's resolved templates.",
+        options: (_props, ctx) =>
+          buildTemplateOptions(ctx?.templates as ExtensionTemplate[] | undefined),
+        allowSearch: true,
+      },
+      field: {
+        type: "choice",
+        displayName: "Field",
+        description: "Field within the selected template.",
+        options: (props, ctx) =>
+          buildFieldOptions(
+            ctx?.templates as ExtensionTemplate[] | undefined,
+            props.templateOverride || props.template,
+          ),
+        allowSearch: true,
+      },
+      show: {
+        type: "choice",
+        options: SHOW_CHOICE_OPTIONS,
+        defaultValue: "value",
+        displayName: "Show",
+        description:
+          "Render the field's value, or its humanized label (for label:value pairs).",
+      },
+      format: {
+        type: "choice",
+        options: FORMAT_CHOICE_OPTIONS,
+        defaultValue: "auto",
+        displayName: "Format",
+        description: "How to format the value.",
+      },
+      locale: {
+        type: "string",
+        displayName: "Locale",
+        description:
+          "BCP-47 locale for currency/date/number formatting. Bind to the page language; defaults to en-US.",
+        advanced: true,
+      },
+      templateOverride: {
+        type: "string",
+        displayName: "Template (override)",
+        description:
+          "Free-text template slug, e.g. products(iso-standard). Overrides the dropdown — use when the sample product lacks the template.",
+        advanced: true,
+      },
+      fieldOverride: {
+        type: "string",
+        displayName: "Field (override)",
+        description:
+          "Free-text field key. Overrides the dropdown — use when the sample product lacks the field.",
+        advanced: true,
+      },
+      children: {
+        type: "slot",
+        displayName: "Children (section)",
+        description:
+          "Optional. When present, this becomes a section that renders only when the field is present; descendants read $ctx.currentFieldValue / currentFieldHasValue.",
+        hidePlaceholder: true,
+      },
+      notPresentContent: {
+        type: "slot",
+        displayName: "Not Present Content",
+        description:
+          "Rendered when the field is absent on the current product. Leave empty to render nothing.",
+        hidePlaceholder: true,
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description: "Force sample data for design-time editing.",
+        advanced: true,
+      },
+    },
+    providesData: true,
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPProductExtensionValue",
+  };
+
+export function EPProductExtensionValue(props: EPProductExtensionValueProps) {
+  const {
+    template,
+    field,
+    templateOverride,
+    fieldOverride,
+    show = "value",
+    format = "auto",
+    locale,
+    children,
+    notPresentContent,
+    className,
+    previewState = "auto",
+    setControlContextData,
+  } = props;
+
+  const templateSlug = (templateOverride || template || "").trim();
+  const fieldKey = (fieldOverride || field || "").trim();
+
+  const { resolved, templates, inEditor } = useResolvedField({
+    kind: "extension",
+    templateSlug,
+    fieldKey,
+    format,
+    locale,
+    forceMock: previewState === "withData",
+  });
+
+  setControlContextData?.({ templates });
+
+  return (
+    <FieldDisplay
+      resolved={resolved}
+      show={show}
+      children={children}
+      notPresentContent={notPresentContent}
+      className={className}
+      inEditor={inEditor}
+      dataAttr="data-ep-product-extension-value"
+    />
+  );
+}
+
+export function registerEPProductExtensionValue(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductExtensionValueProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPProductExtensionValue,
+    customMeta ?? epProductExtensionValueMeta,
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionsProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductExtensionsProvider.tsx
@@ -13,7 +13,7 @@ import {
   MOCK_EXTENSIONS_DATA,
   MOCK_EXTENSION_TEMPLATES,
 } from "./design-time-data";
-import { normalizeExtensions } from "./format";
+import { extractRawExtensions, normalizeExtensions } from "./format";
 import type { ExtensionTemplate, ExtensionsData } from "./types";
 
 type PreviewState = "auto" | "withData" | "empty";
@@ -96,17 +96,9 @@ export function EPProductExtensionsProvider(
   const product = useSelector("currentProduct") as Product | undefined;
   const inEditor = !!usePlasmicCanvasContext();
 
-  // Pull the raw extensions blob from the product's rawData.
-  const rawExtensions = useMemo(() => {
-    const raw = (product as Product | undefined)?.rawData as
-      | { data?: { attributes?: { extensions?: Record<string, unknown> | null } } }
-      | undefined;
-    return raw?.data?.attributes?.extensions ?? null;
-  }, [product]);
-
   const liveTemplates = useMemo(
-    () => normalizeExtensions(rawExtensions),
-    [rawExtensions],
+    () => normalizeExtensions(extractRawExtensions(product)),
+    [product],
   );
 
   // Decide between live and mock data.

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductField.tsx
@@ -1,0 +1,133 @@
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import {
+  FORMAT_CHOICE_OPTIONS,
+  SHOW_CHOICE_OPTIONS,
+  buildLeafOptions,
+} from "./field-catalog";
+import type { FormatSpec } from "./format";
+import { FieldDisplay, useResolvedField } from "./useResolvedField";
+
+type ShowFacet = "value" | "label";
+type PreviewState = "auto" | "withData";
+
+interface EPProductFieldProps {
+  field?: string;
+  show?: ShowFacet;
+  format?: FormatSpec;
+  locale?: string;
+  children?: React.ReactNode;
+  notPresentContent?: React.ReactNode;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+export const epProductFieldMeta: CodeComponentMeta<EPProductFieldProps> = {
+  name: "plasmic-commerce-ep-product-field",
+  displayName: "EP Product Field",
+  description:
+    "Displays one top-level product field (name, price, first image, …) picked from a dropdown — no `$ctx.currentProduct…` path. Renders the formatted value as text by default; drop children to gate a whole section on the field's presence and compose against the resolved value. Must be inside an EP Product Provider.",
+  props: {
+    field: {
+      type: "choice",
+      options: buildLeafOptions(),
+      defaultValue: "name",
+      displayName: "Field",
+      description: "Which top-level product field to display.",
+      allowSearch: true,
+    },
+    show: {
+      type: "choice",
+      options: SHOW_CHOICE_OPTIONS,
+      defaultValue: "value",
+      displayName: "Show",
+      description:
+        "Render the field's value, or its humanized label (for label:value pairs).",
+    },
+    format: {
+      type: "choice",
+      options: FORMAT_CHOICE_OPTIONS,
+      defaultValue: "auto",
+      displayName: "Format",
+      description:
+        "How to format the value. Auto uses the field's natural format (e.g. price → currency).",
+    },
+    locale: {
+      type: "string",
+      displayName: "Locale",
+      description:
+        "BCP-47 locale for currency/date/number formatting. Bind to the page language; defaults to en-US.",
+      advanced: true,
+    },
+    children: {
+      type: "slot",
+      displayName: "Children (section)",
+      description:
+        "Optional. When present, this becomes a section that renders only when the field is present; descendants read $ctx.currentFieldValue / currentFieldHasValue.",
+      hidePlaceholder: true,
+    },
+    notPresentContent: {
+      type: "slot",
+      displayName: "Not Present Content",
+      description:
+        "Rendered when the field is absent on the current product. Leave empty to render nothing.",
+      hidePlaceholder: true,
+    },
+    previewState: {
+      type: "choice",
+      options: ["auto", "withData"],
+      defaultValue: "auto",
+      displayName: "Preview State",
+      description: "Force sample data for design-time editing.",
+      advanced: true,
+    },
+  },
+  providesData: true,
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPProductField",
+};
+
+export function EPProductField(props: EPProductFieldProps) {
+  const {
+    field = "name",
+    show = "value",
+    format = "auto",
+    locale,
+    children,
+    notPresentContent,
+    className,
+    previewState = "auto",
+  } = props;
+
+  const { resolved, inEditor } = useResolvedField({
+    kind: "topLevel",
+    leafId: field,
+    format,
+    locale,
+    forceMock: previewState === "withData",
+  });
+
+  return (
+    <FieldDisplay
+      resolved={resolved}
+      show={show}
+      children={children}
+      notPresentContent={notPresentContent}
+      className={className}
+      inEditor={inEditor}
+      dataAttr="data-ep-product-field"
+    />
+  );
+}
+
+export function registerEPProductField(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPProductFieldProps>,
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPProductField, customMeta ?? epProductFieldMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/field-catalog.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/field-catalog.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the address catalog and the dropdown option-builders. Pure
+ * data helpers — no React or @plasmicapp/host involved.
+ */
+import {
+  PRODUCT_FIELD_LEAVES,
+  buildFieldOptions,
+  buildLeafOptions,
+  buildTemplateOptions,
+  getProductFieldLeaf,
+} from "../field-catalog";
+import { normalizeExtensions } from "../format";
+
+describe("PRODUCT_FIELD_LEAVES", () => {
+  it("has unique leaf ids", () => {
+    const ids = PRODUCT_FIELD_LEAVES.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("maps the price leaf to a currency-formatted scalar with a currency path", () => {
+    const price = getProductFieldLeaf("price");
+    expect(price).toMatchObject({
+      path: ["price", "value"],
+      defaultFormat: "currency",
+      currencyPath: ["price", "currencyCode"],
+    });
+  });
+
+  it("exposes the first image as a flattened array-path leaf", () => {
+    expect(getProductFieldLeaf("firstImageUrl")?.path).toEqual([
+      "images",
+      0,
+      "url",
+    ]);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getProductFieldLeaf("nope")).toBeUndefined();
+  });
+});
+
+describe("buildLeafOptions", () => {
+  it("returns a { label, value } option per leaf, preserving order", () => {
+    const options = buildLeafOptions();
+    expect(options).toHaveLength(PRODUCT_FIELD_LEAVES.length);
+    expect(options[0]).toEqual({ label: "Name", value: "name" });
+    expect(options).toContainEqual({
+      label: "Price (formatted)",
+      value: "price",
+    });
+  });
+});
+
+describe("extension dropdown builders", () => {
+  const templates = normalizeExtensions({
+    "products(care-and-materials)": { material: "Cotton", care: "Wash cold" },
+    "products(metrics)": { rating: 4.7 },
+  });
+
+  it("builds template options as { humanized label, raw slug value }", () => {
+    expect(buildTemplateOptions(templates)).toEqual([
+      { label: "Care And Materials", value: "products(care-and-materials)" },
+      { label: "Metrics", value: "products(metrics)" },
+    ]);
+  });
+
+  it("returns an empty list for undefined templates", () => {
+    expect(buildTemplateOptions(undefined)).toEqual([]);
+  });
+
+  it("builds field options for the selected template", () => {
+    expect(
+      buildFieldOptions(templates, "products(care-and-materials)"),
+    ).toEqual([
+      { label: "Material", value: "material" },
+      { label: "Care", value: "care" },
+    ]);
+  });
+
+  it("returns an empty list for an unknown or unselected template", () => {
+    expect(buildFieldOptions(templates, "products(nope)")).toEqual([]);
+    expect(buildFieldOptions(templates, undefined)).toEqual([]);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format-value.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format-value.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the formatValue primitive and the isPresent presence helper.
+ * Pure functions — no React or @plasmicapp/host involved. Locale is passed
+ * explicitly so assertions are deterministic across machines.
+ */
+import {
+  DEFAULT_LOCALE,
+  extractRawExtensions,
+  formatValue,
+  isPresent,
+} from "../format";
+
+describe("extractRawExtensions", () => {
+  it("reads the EP wire path off a product's rawData", () => {
+    const extensions = { "products(x)": { a: 1 } };
+    expect(
+      extractRawExtensions({
+        rawData: { data: { attributes: { extensions } } },
+      }),
+    ).toBe(extensions);
+  });
+
+  it("is fail-soft for missing rawData / attributes / extensions", () => {
+    expect(extractRawExtensions(undefined)).toBeNull();
+    expect(extractRawExtensions({})).toBeNull();
+    expect(extractRawExtensions({ rawData: { data: {} } })).toBeNull();
+  });
+});
+
+describe("isPresent", () => {
+  it.each([
+    ["null", null, false],
+    ["undefined", undefined, false],
+    ["empty string", "", false],
+    ["whitespace-only string", "   ", false],
+    ["empty array", [], false],
+    ["empty object", {}, false],
+    ["non-empty string", "x", true],
+    ["zero", 0, true],
+    ["false", false, true],
+    ["non-empty array", [1], true],
+    ["non-empty object", { a: 1 }, true],
+  ])("treats %s as %s", (_label, value, expected) => {
+    expect(isPresent(value)).toBe(expected);
+  });
+});
+
+describe("formatValue", () => {
+  it("returns empty string for null/undefined regardless of format", () => {
+    expect(formatValue(null, "currency", "en-US", "USD")).toBe("");
+    expect(formatValue(undefined, "text")).toBe("");
+  });
+
+  describe("currency", () => {
+    it("formats a number with the supplied currency code", () => {
+      expect(formatValue(135, "currency", "en-US", "CHF")).toBe(
+        new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "CHF",
+        }).format(135),
+      );
+    });
+
+    it("is locale-deterministic", () => {
+      const value = formatValue(1234.5, "currency", "de-DE", "EUR");
+      expect(value).toBe(
+        new Intl.NumberFormat("de-DE", {
+          style: "currency",
+          currency: "EUR",
+        }).format(1234.5),
+      );
+    });
+
+    it("coerces a numeric string", () => {
+      expect(formatValue("99", "currency", "en-US", "USD")).toBe(
+        new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+        }).format(99),
+      );
+    });
+
+    it("falls back to a plain number when no currency code is given", () => {
+      expect(formatValue(135, "currency", "en-US")).toBe(
+        new Intl.NumberFormat("en-US").format(135),
+      );
+    });
+
+    it("falls back to humane text for a non-numeric value", () => {
+      expect(formatValue("free", "currency", "en-US", "USD")).toBe("free");
+    });
+  });
+
+  describe("number", () => {
+    it("groups via Intl for the locale", () => {
+      expect(formatValue(1234567, "number", "en-US")).toBe(
+        new Intl.NumberFormat("en-US").format(1234567),
+      );
+    });
+
+    it("coerces a numeric string", () => {
+      expect(formatValue("42", "number", "en-US")).toBe(
+        new Intl.NumberFormat("en-US").format(42),
+      );
+    });
+  });
+
+  describe("date", () => {
+    it("formats an ISO date string via Intl", () => {
+      const iso = "2026-06-02T00:00:00.000Z";
+      expect(formatValue(iso, "date", "en-US")).toBe(
+        new Intl.DateTimeFormat("en-US").format(new Date(iso)),
+      );
+    });
+
+    it("falls back to humane text for an unparseable value", () => {
+      expect(formatValue("not a date", "date", "en-US")).toBe("not a date");
+    });
+  });
+
+  describe("raw", () => {
+    it("returns strings unchanged", () => {
+      expect(formatValue("CHF 135", "raw")).toBe("CHF 135");
+    });
+
+    it("stringifies numbers and booleans without locale grouping", () => {
+      expect(formatValue(1234567, "raw")).toBe("1234567");
+      expect(formatValue(true, "raw")).toBe("true");
+    });
+
+    it("JSON-encodes arrays and objects", () => {
+      expect(formatValue([{ code: "x" }], "raw")).toBe('[{"code":"x"}]');
+    });
+  });
+
+  describe("text", () => {
+    it("uses the humane renderer (Yes/No, comma-joined arrays)", () => {
+      expect(formatValue(true, "text")).toBe("Yes");
+      expect(formatValue(["red", "green"], "text")).toBe("red, green");
+    });
+  });
+
+  describe("auto inference", () => {
+    it("renders booleans as Yes/No", () => {
+      expect(formatValue(true, "auto")).toBe("Yes");
+      expect(formatValue(false, "auto")).toBe("No");
+    });
+
+    it("groups numbers via Intl for the default locale", () => {
+      expect(formatValue(1299, "auto")).toBe(
+        new Intl.NumberFormat(DEFAULT_LOCALE).format(1299),
+      );
+    });
+
+    it("passes strings through and humanizes complex values", () => {
+      expect(formatValue("Organic cotton", "auto")).toBe("Organic cotton");
+      expect(formatValue(["a", "b"], "auto")).toBe("a, b");
+      expect(formatValue({ width_cm: 30 }, "auto")).toBe("Width Cm: 30");
+    });
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/resolve-field.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/resolve-field.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the field resolvers. Pure functions — given a product (or
+ * normalized templates) and an address, they return a ResolvedField. No React
+ * or @plasmicapp/host involved.
+ */
+import { MOCK_PRODUCT } from "../design-time-data";
+import { normalizeExtensions } from "../format";
+import {
+  resolveExtensionField,
+  resolveTopLevelField,
+} from "../resolve-field";
+import type { Product } from "../../../types/product";
+
+const product: Product = {
+  id: "p1",
+  name: "Acme Widget",
+  description: "A fine widget.",
+  sku: "AW-1",
+  slug: "acme-widget",
+  images: [{ url: "https://img/1.jpg", alt: "Widget" }],
+  variants: [],
+  price: { value: 135, currencyCode: "CHF" },
+  options: [],
+};
+
+describe("resolveTopLevelField", () => {
+  it("resolves a simple string leaf", () => {
+    const r = resolveTopLevelField(product, "name");
+    expect(r).toEqual({
+      value: "Acme Widget",
+      displayValue: "Acme Widget",
+      label: "Name",
+      key: "name",
+      type: "string",
+      hasValue: true,
+    });
+  });
+
+  it("formats price as currency by default using price.currencyCode", () => {
+    const r = resolveTopLevelField(product, "price", "auto", "en-US");
+    expect(r.value).toBe(135);
+    expect(r.type).toBe("number");
+    expect(r.hasValue).toBe(true);
+    expect(r.displayValue).toBe(
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "CHF",
+      }).format(135),
+    );
+  });
+
+  it("honours an explicit format override over the leaf default", () => {
+    const r = resolveTopLevelField(product, "price", "number", "en-US");
+    expect(r.displayValue).toBe(new Intl.NumberFormat("en-US").format(135));
+  });
+
+  it("walks an array path null-safely for the first image", () => {
+    expect(resolveTopLevelField(product, "firstImageUrl").value).toBe(
+      "https://img/1.jpg",
+    );
+  });
+
+  it("reports absence when an array leaf has no element", () => {
+    const noImages: Product = { ...product, images: [] };
+    const r = resolveTopLevelField(noImages, "firstImageUrl");
+    expect(r.hasValue).toBe(false);
+    expect(r.displayValue).toBe("");
+    expect(r.label).toBe("First image URL");
+  });
+
+  it("is fail-soft for a missing product", () => {
+    const r = resolveTopLevelField(undefined, "name");
+    expect(r.hasValue).toBe(false);
+    expect(r.label).toBe("Name");
+  });
+
+  it("is fail-soft for an unknown leaf id, humanizing the id as a label", () => {
+    const r = resolveTopLevelField(product, "totallyUnknown");
+    expect(r).toMatchObject({
+      hasValue: false,
+      label: "Totally Unknown",
+      key: "totallyUnknown",
+      type: "null",
+    });
+  });
+
+  it("resolves against the design-time mock product", () => {
+    expect(resolveTopLevelField(MOCK_PRODUCT, "name").value).toBe(
+      "Sample Product",
+    );
+  });
+});
+
+describe("resolveExtensionField", () => {
+  const templates = normalizeExtensions({
+    "products(care-and-materials)": {
+      material: "Organic cotton",
+      is_fair_trade: true,
+      notes: "",
+    },
+    "products(metrics)": { rating: 4.7 },
+  });
+
+  it("resolves a present field with its humanized label", () => {
+    const r = resolveExtensionField(
+      templates,
+      "products(care-and-materials)",
+      "material",
+    );
+    expect(r).toEqual({
+      value: "Organic cotton",
+      displayValue: "Organic cotton",
+      label: "Material",
+      key: "material",
+      type: "string",
+      hasValue: true,
+    });
+  });
+
+  it("renders a boolean via auto inference", () => {
+    const r = resolveExtensionField(
+      templates,
+      "products(care-and-materials)",
+      "is_fair_trade",
+    );
+    expect(r.displayValue).toBe("Yes");
+    expect(r.type).toBe("boolean");
+    expect(r.hasValue).toBe(true);
+  });
+
+  it("treats a present-but-blank string as absent", () => {
+    const r = resolveExtensionField(
+      templates,
+      "products(care-and-materials)",
+      "notes",
+    );
+    expect(r.hasValue).toBe(false);
+    expect(r.displayValue).toBe("");
+  });
+
+  it("is fail-soft for an unknown field key, humanizing it as a label", () => {
+    const r = resolveExtensionField(
+      templates,
+      "products(care-and-materials)",
+      "missing_key",
+    );
+    expect(r).toMatchObject({
+      hasValue: false,
+      label: "Missing Key",
+      key: "missing_key",
+      type: "null",
+    });
+  });
+
+  it("is fail-soft for an unknown template slug", () => {
+    expect(
+      resolveExtensionField(templates, "products(nope)", "material").hasValue,
+    ).toBe(false);
+  });
+
+  it("is fail-soft for undefined templates", () => {
+    expect(
+      resolveExtensionField(undefined, "products(x)", "y").hasValue,
+    ).toBe(false);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/design-time-data.ts
@@ -1,3 +1,4 @@
+import type { Product } from "../../types/product";
 import type { ExtensionTemplate, ExtensionsData } from "./types";
 import { normalizeExtensions } from "./format";
 
@@ -24,4 +25,31 @@ export const MOCK_EXTENSION_TEMPLATES: ExtensionTemplate[] =
 export const MOCK_EXTENSIONS_DATA: ExtensionsData = {
   templateCount: MOCK_EXTENSION_TEMPLATES.length,
   isEmpty: MOCK_EXTENSION_TEMPLATES.length === 0,
+};
+
+/** Mock product for the field components at design time; carries rawData.extensions for the dropdowns. */
+export const MOCK_PRODUCT: Product = {
+  id: "mock-product",
+  name: "Sample Product",
+  description:
+    "This is a placeholder product shown only at design time. Bind a real product (or productId) to fetch live data.",
+  descriptionHtml:
+    "<p>This is a placeholder product shown only at design time.</p>",
+  slug: "sample-product",
+  sku: "MOCK-SKU",
+  images: [
+    {
+      url: "https://picsum.photos/seed/ep-product-field/800/800",
+      alt: "Sample product",
+    },
+  ],
+  variants: [],
+  price: {
+    value: 135,
+    currencyCode: "CHF",
+  },
+  options: [],
+  rawData: {
+    data: { attributes: { extensions: MOCK_EXTENSIONS_RAW } },
+  } as Product["rawData"],
 };

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/field-catalog.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/field-catalog.ts
@@ -1,0 +1,104 @@
+import type { FormatSpec } from "./format";
+import type { ChoiceObject, ExtensionTemplate } from "./types";
+
+/** A curated, addressable leaf of the normalized product (path is walked null-safely). */
+export interface ProductFieldLeaf {
+  id: string;
+  label: string;
+  path: (string | number)[];
+  defaultFormat: FormatSpec;
+  /** Where to read the currency code for `currency` formatting; price leaves only. */
+  currencyPath?: (string | number)[];
+}
+
+/** The curated top-level leaf set; add a leaf here to surface a new field in the dropdown. */
+export const PRODUCT_FIELD_LEAVES: ProductFieldLeaf[] = [
+  { id: "name", label: "Name", path: ["name"], defaultFormat: "text" },
+  {
+    id: "description",
+    label: "Description",
+    path: ["description"],
+    defaultFormat: "text",
+  },
+  { id: "sku", label: "SKU", path: ["sku"], defaultFormat: "text" },
+  { id: "slug", label: "Slug", path: ["slug"], defaultFormat: "text" },
+  {
+    id: "price",
+    label: "Price (formatted)",
+    path: ["price", "value"],
+    defaultFormat: "currency",
+    currencyPath: ["price", "currencyCode"],
+  },
+  {
+    id: "priceValue",
+    label: "Price (raw number)",
+    path: ["price", "value"],
+    defaultFormat: "number",
+  },
+  {
+    id: "currencyCode",
+    label: "Currency code",
+    path: ["price", "currencyCode"],
+    defaultFormat: "text",
+  },
+  {
+    id: "firstImageUrl",
+    label: "First image URL",
+    path: ["images", 0, "url"],
+    defaultFormat: "raw",
+  },
+  {
+    id: "firstImageAlt",
+    label: "First image alt",
+    path: ["images", 0, "alt"],
+    defaultFormat: "text",
+  },
+];
+
+export function getProductFieldLeaf(id: string): ProductFieldLeaf | undefined {
+  return PRODUCT_FIELD_LEAVES.find((leaf) => leaf.id === id);
+}
+
+/** Shared `format` choice options for both field components — one source of truth. */
+export const FORMAT_CHOICE_OPTIONS: ChoiceObject[] = [
+  { label: "Auto", value: "auto" },
+  { label: "Text", value: "text" },
+  { label: "Currency", value: "currency" },
+  { label: "Date", value: "date" },
+  { label: "Number", value: "number" },
+  { label: "Raw (unformatted)", value: "raw" },
+];
+
+/** Shared `show` choice options for both field components. */
+export const SHOW_CHOICE_OPTIONS: ChoiceObject[] = [
+  { label: "Value", value: "value" },
+  { label: "Label (humanized)", value: "label" },
+];
+
+export function buildLeafOptions(): ChoiceObject[] {
+  return PRODUCT_FIELD_LEAVES.map((leaf) => ({
+    label: leaf.label,
+    value: leaf.id,
+  }));
+}
+
+export function buildTemplateOptions(
+  templates: ExtensionTemplate[] | undefined,
+): ChoiceObject[] {
+  return (templates ?? []).map((template) => ({
+    label: template.label,
+    value: template.slug,
+  }));
+}
+
+export function buildFieldOptions(
+  templates: ExtensionTemplate[] | undefined,
+  templateSlug: string | undefined,
+): ChoiceObject[] {
+  const template = (templates ?? []).find((t) => t.slug === templateSlug);
+  if (!template) return [];
+  return template.fields.map((field) => ({
+    label: field.label,
+    value: field.key,
+  }));
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/format.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/format.ts
@@ -96,12 +96,134 @@ export function formatDisplayValue(value: unknown): string {
   return String(value);
 }
 
+/** How a resolved value renders to a string; orthogonal to the field's address. */
+export type FormatSpec =
+  | "auto"
+  | "text"
+  | "currency"
+  | "date"
+  | "number"
+  | "raw";
+
+/** Fallback locale (hard-coded so SSR and CSR agree on Intl output). */
+export const DEFAULT_LOCALE = "en-US";
+
+/** Presence: null/undefined/blank/`[]`/`{}` are absent; `0` and `false` are present. */
+export function isPresent(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value as object).length > 0;
+  return true;
+}
+
+/** The single formatting primitive shared by both field components; every Intl path is guarded. */
+export function formatValue(
+  value: unknown,
+  format: FormatSpec = "auto",
+  locale: string = DEFAULT_LOCALE,
+  currency?: string,
+): string {
+  if (value === null || value === undefined) return "";
+  switch (format) {
+    case "raw":
+      return rawString(value);
+    case "text":
+      return formatDisplayValue(value);
+    case "number":
+      return formatNumber(value, locale);
+    case "currency":
+      return formatCurrency(value, locale, currency);
+    case "date":
+      return formatDate(value, locale);
+    case "auto":
+    default:
+      return formatAuto(value, locale);
+  }
+}
+
+function formatAuto(value: unknown, locale: string): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") return formatNumber(value, locale);
+  return formatDisplayValue(value);
+}
+
+function rawString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function formatNumber(value: unknown, locale: string): string {
+  const n = toFiniteNumber(value);
+  if (n === null) return formatDisplayValue(value);
+  try {
+    return new Intl.NumberFormat(locale).format(n);
+  } catch {
+    return String(n);
+  }
+}
+
+function formatCurrency(
+  value: unknown,
+  locale: string,
+  currency?: string,
+): string {
+  const n = toFiniteNumber(value);
+  if (n === null) return formatDisplayValue(value);
+  if (!currency) return formatNumber(value, locale);
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+    }).format(n);
+  } catch {
+    return formatNumber(value, locale);
+  }
+}
+
+function formatDate(value: unknown, locale: string): string {
+  if (value === null || value === undefined || value === "") return "";
+  const date = value instanceof Date ? value : new Date(value as string | number);
+  if (Number.isNaN(date.getTime())) return formatDisplayValue(value);
+  try {
+    return new Intl.DateTimeFormat(locale).format(date);
+  } catch {
+    return date.toISOString();
+  }
+}
+
 function formatDisplayValueShallow(value: unknown): string {
   if (value === null || value === undefined) return "";
   if (typeof value === "boolean") return value ? "Yes" : "No";
   if (typeof value === "number") return String(value);
   if (typeof value === "string") return value;
   return "";
+}
+
+/** The single place that knows the EP `attributes.extensions` wire path. */
+export function extractRawExtensions(
+  product: unknown,
+): Record<string, unknown> | null {
+  const rawData = (product as { rawData?: unknown } | undefined)?.rawData as
+    | { data?: { attributes?: { extensions?: Record<string, unknown> | null } } }
+    | undefined;
+  return rawData?.data?.attributes?.extensions ?? null;
 }
 
 /**

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/index.ts
@@ -25,11 +25,22 @@ export {
   registerEPProductExtensionField,
   epProductExtensionFieldMeta,
 } from "./EPProductExtensionField";
+export {
+  EPProductField,
+  registerEPProductField,
+  epProductFieldMeta,
+} from "./EPProductField";
+export {
+  EPProductExtensionValue,
+  registerEPProductExtensionValue,
+  epProductExtensionValueMeta,
+} from "./EPProductExtensionValue";
 export type {
   ExtensionField,
   ExtensionTemplate,
   ExtensionsData,
   ExtensionFieldType,
+  ChoiceObject,
 } from "./types";
 export {
   normalizeExtensions,
@@ -37,4 +48,27 @@ export {
   humanizeFieldKey,
   inferType,
   formatDisplayValue,
+  formatValue,
+  isPresent,
+  DEFAULT_LOCALE,
 } from "./format";
+export type { FormatSpec } from "./format";
+export {
+  PRODUCT_FIELD_LEAVES,
+  getProductFieldLeaf,
+  buildLeafOptions,
+  buildTemplateOptions,
+  buildFieldOptions,
+} from "./field-catalog";
+export type { ProductFieldLeaf } from "./field-catalog";
+export {
+  resolveTopLevelField,
+  resolveExtensionField,
+} from "./resolve-field";
+export type { ResolvedField } from "./resolve-field";
+export {
+  useResolvedField,
+  FieldContextProvider,
+  FieldDisplay,
+} from "./useResolvedField";
+export type { UseResolvedFieldResult } from "./useResolvedField";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
@@ -1,0 +1,96 @@
+import type { Product } from "../../types/product";
+import { getProductFieldLeaf } from "./field-catalog";
+import {
+  type FormatSpec,
+  formatValue,
+  humanizeFieldKey,
+  inferType,
+  isPresent,
+} from "./format";
+import type { ExtensionFieldType, ExtensionTemplate } from "./types";
+
+/** The normalized view of one product field — the only shape the UI depends on. */
+export interface ResolvedField {
+  value: unknown;
+  displayValue: string;
+  label: string;
+  key: string;
+  type: ExtensionFieldType;
+  hasValue: boolean;
+}
+
+function walkPath(obj: unknown, path: (string | number)[]): unknown {
+  let cur: unknown = obj;
+  for (const segment of path) {
+    if (cur === null || cur === undefined) return undefined;
+    cur = (cur as Record<string | number, unknown>)[segment];
+  }
+  return cur;
+}
+
+/** Resolve a curated top-level leaf; fail-soft. `auto` uses the leaf's default format. */
+export function resolveTopLevelField(
+  product: Product | undefined | null,
+  leafId: string,
+  format: FormatSpec = "auto",
+  locale?: string,
+): ResolvedField {
+  const leaf = getProductFieldLeaf(leafId);
+  if (!leaf) {
+    return {
+      value: undefined,
+      displayValue: "",
+      label: humanizeFieldKey(leafId),
+      key: leafId,
+      type: "null",
+      hasValue: false,
+    };
+  }
+  const value = product ? walkPath(product, leaf.path) : undefined;
+  const currency = leaf.currencyPath
+    ? (walkPath(product, leaf.currencyPath) as string | undefined)
+    : undefined;
+  const effectiveFormat = format === "auto" ? leaf.defaultFormat : format;
+  const hasValue = isPresent(value);
+  return {
+    value,
+    displayValue: hasValue
+      ? formatValue(value, effectiveFormat, locale, currency)
+      : "",
+    label: leaf.label,
+    key: leaf.id,
+    type: inferType(value),
+    hasValue,
+  };
+}
+
+/** Resolve one extension field by (templateSlug, fieldKey); fail-soft. */
+export function resolveExtensionField(
+  templates: ExtensionTemplate[] | undefined,
+  templateSlug: string,
+  fieldKey: string,
+  format: FormatSpec = "auto",
+  locale?: string,
+): ResolvedField {
+  const template = (templates ?? []).find((t) => t.slug === templateSlug);
+  const field = template?.fields.find((f) => f.key === fieldKey);
+  if (!field) {
+    return {
+      value: undefined,
+      displayValue: "",
+      label: humanizeFieldKey(fieldKey ?? ""),
+      key: fieldKey ?? "",
+      type: "null",
+      hasValue: false,
+    };
+  }
+  const hasValue = isPresent(field.value);
+  return {
+    value: field.value,
+    displayValue: hasValue ? formatValue(field.value, format, locale) : "",
+    label: field.label,
+    key: field.key,
+    type: field.type,
+    hasValue,
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/types.ts
@@ -25,3 +25,9 @@ export interface ExtensionsData {
   templateCount: number;
   isEmpty: boolean;
 }
+
+/** A `{ label, value }` option for a Plasmic `choice` prop. */
+export interface ChoiceObject {
+  label: string;
+  value: string;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
@@ -1,0 +1,157 @@
+import {
+  DataProvider,
+  usePlasmicCanvasContext,
+  useSelector,
+} from "@plasmicapp/host";
+import React, { useMemo } from "react";
+import { Product } from "../../types/product";
+import { MOCK_PRODUCT } from "./design-time-data";
+import {
+  DEFAULT_LOCALE,
+  extractRawExtensions,
+  type FormatSpec,
+  normalizeExtensions,
+} from "./format";
+import {
+  type ResolvedField,
+  resolveExtensionField,
+  resolveTopLevelField,
+} from "./resolve-field";
+import type { ExtensionTemplate } from "./types";
+
+type ResolveArgs =
+  | {
+      kind: "topLevel";
+      leafId: string;
+      format: FormatSpec;
+      locale?: string;
+      forceMock?: boolean;
+    }
+  | {
+      kind: "extension";
+      templateSlug: string;
+      fieldKey: string;
+      format: FormatSpec;
+      locale?: string;
+      forceMock?: boolean;
+    };
+
+export interface UseResolvedFieldResult {
+  resolved: ResolvedField;
+  templates: ExtensionTemplate[];
+  inEditor: boolean;
+}
+
+/** Shared host wiring for both field components: read the product, mock in the canvas, delegate to the pure resolvers. */
+export function useResolvedField(args: ResolveArgs): UseResolvedFieldResult {
+  const liveProduct = useSelector("currentProduct") as Product | undefined;
+  const inEditor = !!usePlasmicCanvasContext();
+  const useMock = args.forceMock || (!liveProduct && inEditor);
+  const product = useMock ? MOCK_PRODUCT : liveProduct;
+  const locale = args.locale || DEFAULT_LOCALE;
+
+  const templates = useMemo(
+    () =>
+      args.kind === "extension"
+        ? normalizeExtensions(extractRawExtensions(product))
+        : [],
+    [args.kind, product],
+  );
+
+  const resolved = useMemo(() => {
+    if (args.kind === "topLevel") {
+      return resolveTopLevelField(product, args.leafId, args.format, locale);
+    }
+    return resolveExtensionField(
+      templates,
+      args.templateSlug,
+      args.fieldKey,
+      args.format,
+      locale,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    args.kind,
+    product,
+    templates,
+    locale,
+    args.format,
+    args.kind === "topLevel" ? args.leafId : undefined,
+    args.kind === "extension" ? args.templateSlug : undefined,
+    args.kind === "extension" ? args.fieldKey : undefined,
+  ]);
+
+  return { resolved, templates, inEditor };
+}
+
+/** Inline scalar with no children; structural section gate with children. Canvas placeholder when unresolvable. */
+export function FieldDisplay(props: {
+  resolved: ResolvedField;
+  show: "value" | "label";
+  children?: React.ReactNode;
+  notPresentContent?: React.ReactNode;
+  className?: string;
+  inEditor: boolean;
+  dataAttr: string;
+}) {
+  const { resolved, show, children, notPresentContent, className, inEditor, dataAttr } =
+    props;
+  const hasChildren = React.Children.count(children) > 0;
+
+  if (hasChildren) {
+    if (!resolved.hasValue && !inEditor) {
+      return notPresentContent ? (
+        <div className={className}>{notPresentContent}</div>
+      ) : null;
+    }
+    return (
+      <FieldContextProvider field={resolved}>
+        <div className={className} {...{ [dataAttr]: "" }}>
+          {children}
+        </div>
+      </FieldContextProvider>
+    );
+  }
+
+  if (resolved.hasValue) {
+    return (
+      <span className={className} {...{ [dataAttr]: "" }}>
+        {show === "label" ? resolved.label : resolved.displayValue}
+      </span>
+    );
+  }
+  if (inEditor) {
+    return (
+      <span className={className} data-ep-field-placeholder="">
+        {resolved.label || "Pick a field"}
+      </span>
+    );
+  }
+  if (notPresentContent) {
+    return <span className={className}>{notPresentContent}</span>;
+  }
+  return null;
+}
+
+/** Publishes the resolved field as flat, directly bindable selectors (no optional chaining in bindings). */
+export function FieldContextProvider(props: {
+  field: ResolvedField;
+  children?: React.ReactNode;
+}) {
+  const { field, children } = props;
+  return (
+    <DataProvider name="currentFieldValue" data={field.value}>
+      <DataProvider name="currentFieldDisplayValue" data={field.displayValue}>
+        <DataProvider name="currentFieldLabel" data={field.label}>
+          <DataProvider name="currentFieldKey" data={field.key}>
+            <DataProvider name="currentFieldType" data={field.type}>
+              <DataProvider name="currentFieldHasValue" data={field.hasValue}>
+                {children}
+              </DataProvider>
+            </DataProvider>
+          </DataProvider>
+        </DataProvider>
+      </DataProvider>
+    </DataProvider>
+  );
+}


### PR DESCRIPTION
Closes #338.

Adds two sibling Plasmic code components that display a single named product field in a chosen spot, retiring the raw `$ctx.currentProduct.rawData.data.attributes.extensions[…]` chains (40 + 11 on the ISO PDP alone). Companion to #336/#337 (`EPVariationCase`); design recorded in iso-storefront `doc/adr/0006-product-field-display-components.md`.

## Components

- **`EPProductField`** — picks one top-level normalized field (name, price, first image, …) from a curated static dropdown.
- **`EPProductExtensionValue`** — picks one extension field by `(template, field)` from cascading dropdowns sourced from the bound product's extensions, with free-text overrides. The specific-spot counterpart to the iterating `EPProductExtensionField` (left untouched).

Both default-render the formatted scalar as text, expose the resolved value + presence to a slot for composition (`$ctx.currentFieldValue` / `currentFieldHasValue` / …), self-gate inline or structurally gate a section keyed on children, and add a canvas placeholder.

## Shared pure cores (the real logic; unit-tested)

- `formatValue(value, format, locale, currency)` — `Intl` currency/date/number + `auto` inference, on top of the existing boolean/array/object handling. `Intl` is safe here (compiled code, not a designer binding); explicit `locale` avoids SSR/CSR hydration mismatch.
- `resolveTopLevelField` / `resolveExtensionField` → `ResolvedField`, with presence semantics (null/`""`/`[]`/missing → `hasValue=false`).
- `PRODUCT_FIELD_LEAVES` catalog + option-builders for the dropdowns.
- `extractRawExtensions` — single shared knowledge of the EP wire path, now used by both the field components and `EPProductExtensionsProvider`.

## Notes

- Registered alongside the existing extension surface; the iteration components (`EPProductExtension{Template,Field}List`, `EPProductExtensionField`) are unchanged.
- Extension dropdowns are sourced from the product instance ∪ mock + free-text (the implicit token can't read flow field definitions); stored values are string keys resolved fail-soft. A schema-sourced dropdown is deferred to a future server-side client-credentials mechanism — no stored-value migration when it lands.
- The iso-storefront migration of the existing raw chains is a separate follow-up.

## Tests

102 passing in `product-extensions/composable` (54 new across `format-value`, `resolve-field`, `field-catalog`; no regressions in the existing suites). `jest` via the repo root config.