### PR TITLE
fix(mcp-registry): degrade function-options choice props to string instead of fataling ingestion

### DIFF
--- a/packages/plasmic-mcp-registry/src/__tests__/serialize.test.ts
+++ b/packages/plasmic-mcp-registry/src/__tests__/serialize.test.ts
@@ -108,6 +108,45 @@ describe("serializeComponentMeta", () => {
     expect(props.options).not.toHaveProperty("onSearch");
   });
 
+  it("degrades a choice prop with function options to a valid string control", () => {
+    const meta = {
+      name: "DynamicChoice",
+      props: {
+        template: {
+          type: "choice",
+          displayName: "Template",
+          description: "Pick a template",
+          advanced: false,
+          allowSearch: true,
+          options: (_props: unknown, _ctx: unknown) => [
+            { label: "Iso Standard", value: "products(iso-standard)" },
+          ],
+        },
+        kind: {
+          type: "choice",
+          options: ["a", "b"],
+          defaultValue: "a",
+        },
+      },
+    };
+
+    const result = serializeComponentMeta(meta);
+    const props = result.props as Record<string, Record<string, unknown>>;
+
+    // Function-options choice degrades to a string control (no invalid empty choice)
+    expect(props.template.type).toBe("string");
+    expect(props.template).not.toHaveProperty("options");
+    expect(props.template).not.toHaveProperty("allowSearch");
+    // Display metadata is preserved so the prop stays usable/labelled
+    expect(props.template.displayName).toBe("Template");
+    expect(props.template.description).toBe("Pick a template");
+
+    // Static (array) choice is untouched
+    expect(props.kind.type).toBe("choice");
+    expect(props.kind.options).toEqual(["a", "b"]);
+    expect(props.kind.defaultValue).toBe("a");
+  });
+
   it("handles meta with variants field preserved correctly", () => {
     const meta = {
       name: "VariantComp",

--- a/packages/plasmic-mcp-registry/src/serialize.ts
+++ b/packages/plasmic-mcp-registry/src/serialize.ts
@@ -17,6 +17,52 @@ const NON_SERIALIZABLE_TOP_LEVEL_FIELDS = new Set([
   "templates",
 ]);
 
+/** JSON-safe descriptor fields worth carrying over when degrading a prop. */
+const PRESERVED_PROP_FIELDS = [
+  "displayName",
+  "description",
+  "defaultValue",
+  "advanced",
+] as const;
+
+/**
+ * Degrade `choice` props whose `options` is a function to a plain `string`
+ * control.
+ *
+ * A Plasmic prop control function (dynamic, context-driven options fed via
+ * setControlContextData) cannot survive JSON transport: the JSON roundtrip
+ * drops the function, leaving a `choice` with no `options` — which is invalid
+ * and fatals downstream registration. Since a choice's stored value is a string
+ * key either way, a `string` control is the safe degraded form: MCP consumers
+ * can still read and write the value, and the live host meta (which keeps the
+ * function) still renders the dynamic dropdown in Studio. Static (array)
+ * options are left untouched.
+ */
+function degradeDynamicChoiceProps(props: unknown): unknown {
+  if (!props || typeof props !== "object") return props;
+  const result: Record<string, unknown> = {};
+  for (const [name, descriptor] of Object.entries(
+    props as Record<string, unknown>,
+  )) {
+    const d = descriptor as Record<string, unknown> | null;
+    if (
+      d &&
+      typeof d === "object" &&
+      d.type === "choice" &&
+      typeof d.options === "function"
+    ) {
+      const degraded: Record<string, unknown> = { type: "string" };
+      for (const key of PRESERVED_PROP_FIELDS) {
+        if (key in d && typeof d[key] !== "function") degraded[key] = d[key];
+      }
+      result[name] = degraded;
+    } else {
+      result[name] = descriptor;
+    }
+  }
+  return result;
+}
+
 /**
  * Strips non-serializable fields from a CodeComponentMeta.
  *
@@ -43,6 +89,12 @@ export function serializeComponentMeta(meta: unknown): SerializedComponentMeta {
     if (NON_SERIALIZABLE_TOP_LEVEL_FIELDS.has(key)) continue;
     if (typeof value === "function") continue;
     filtered[key] = value;
+  }
+
+  // Degrade dynamic (function-options) choice props before the roundtrip so
+  // they survive as valid `string` controls instead of invalid empty choices.
+  if (filtered.props) {
+    filtered.props = degradeDynamicChoiceProps(filtered.props);
   }
 
   // JSON roundtrip: strips remaining nested functions, Symbols, undefined.
@@ -85,6 +137,11 @@ export function serializeContextMeta(meta: unknown): SerializedContextMeta {
   for (const [key, value] of Object.entries(raw)) {
     if (typeof value === "function") continue;
     filtered[key] = value;
+  }
+
+  // Degrade dynamic (function-options) choice props to valid string controls.
+  if (filtered.props) {
+    filtered.props = degradeDynamicChoiceProps(filtered.props);
   }
 
   // JSON roundtrip: strips nested function callbacks in props and globalActions


### PR DESCRIPTION
Closes #340.

## Problem

`serializeComponentMeta` / `serializeContextMeta` strip functions via a `JSON.parse(JSON.stringify())` roundtrip. A `choice` prop whose `options` is a Plasmic prop control function (dynamic options fed via `setControlContextData`) loses the function and is left as a `choice` with `options: undefined` — an **invalid** descriptor. The MCP server then throws a fatal `SyncError` registering it, which aborts the **entire** dev-host ingestion batch (blocking unrelated, valid components too).

First surfaced ingesting the field-display components (`EPProductField`, `EPProductExtensionValue`) from #338 / #339. The dynamic dropdown itself is fine — it works in browser Studio, which executes the function client-side. The gap is only the headless MCP serialization boundary.

## Fix

Before the JSON roundtrip, degrade any `choice` prop whose `options` is a function to a plain `string` control (preserving `displayName`/`description`/`defaultValue`/`advanced`). Applied to both component and global-context prop maps. Static (array) options are untouched.

A choice's stored value is a string key either way, so:
- headless consumers (the MCP) can still read and write the value;
- the live host meta (which keeps the function) still renders the dynamic dropdown in Studio, with any MCP-written value shown selected.

This follows the standard fail-safe-serialization / declarative-only-schema pattern (Zapier dynamic dropdowns reference an operation by key; react-jsonschema-form keeps `uiSchema` function-free).

## Tests

- New unit test: a function-options `choice` degrades to `string` (no `options`/`allowSearch`, display fields preserved); a static array `choice` passes through untouched. All `serialize` tests green.

## Verification (end-to-end)

Against the ISO Storefront project: after the fix, dev-host ingestion no longer fatals; both field-display components ingest. The MCP set `template="products(iso-standard)"` / `field="reference"` (string keys) on the choice props, and browser Studio's live dropdowns showed **Template: Iso Standard / Field: Reference** — confirming the MCP-configured + Studio-dynamic round-trip on one shared string value.