### PR TITLE
fix(ep-commerce): replace inline `type` import specifiers that break tsdx build

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
@@ -1,12 +1,12 @@
 import type { Product } from "../../types/product";
 import { getProductFieldLeaf } from "./field-catalog";
 import {
-  type FormatSpec,
   formatValue,
   humanizeFieldKey,
   inferType,
   isPresent,
 } from "./format";
+import type { FormatSpec } from "./format";
 import type { ExtensionFieldType, ExtensionTemplate } from "./types";
 
 /** The normalized view of one product field — the only shape the UI depends on. */

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
@@ -9,14 +9,14 @@ import { MOCK_PRODUCT } from "./design-time-data";
 import {
   DEFAULT_LOCALE,
   extractRawExtensions,
-  type FormatSpec,
   normalizeExtensions,
 } from "./format";
+import type { FormatSpec } from "./format";
 import {
-  type ResolvedField,
   resolveExtensionField,
   resolveTopLevelField,
 } from "./resolve-field";
+import type { ResolvedField } from "./resolve-field";
 import type { ExtensionTemplate } from "./types";
 
 type ResolveArgs =


### PR DESCRIPTION
Closes #342.

PR #339 shipped `import { type X, Y } from "..."` inline type-only specifiers in `useResolvedField.tsx` and `resolve-field.ts`. That's TS 4.5+ syntax; the package's build (`tsdx` → `rollup-plugin-typescript2`) bundles an older TypeScript that can't parse it, so `yarn build` fails:

```
useResolvedField.tsx(12,8): syntax error TS1005: ',' expected.
```

`tsc`/workspace typecheck pass (newer TS), so it slipped through. This splits the inline specifiers into separate `import type { ... }` statements (the existing package style). No behavior change.

Verified: with this change, `tsdx build && node build-server.mjs` completes (EXIT=0) and the dist includes both components + `server.js`. Follow-up suggestion (separate): run `yarn build` for this package in CI, not just `tsc`, to catch this class of error.