### PR TITLE
fix(plasmic-mcp): load renderer assets from renderer origin, not auth host

### DIFF
--- a/packages/plasmic-mcp/README.md
+++ b/packages/plasmic-mcp/README.md
@@ -9,13 +9,29 @@ MCP server for Plasmic Studio with an embedded editing engine. Create pages, edi
 - Node.js >= 18
 - A Plasmic project ID and API token
 
-### Environment Variables
+### Credentials
+
+The server resolves credentials in this order:
+
+1. **Environment variables** (below) — `PLASMIC_AUTH_USER` + `PLASMIC_AUTH_TOKEN` must be set together.
+2. **`.plasmic.auth` file** — looked up in the current working directory, then your home directory (`~/.plasmic.auth`).
 
 | Variable | Description |
 |----------|-------------|
 | `PLASMIC_AUTH_USER` | Your Plasmic account email |
 | `PLASMIC_AUTH_TOKEN` | Plasmic API token |
-| `PLASMIC_AUTH_HOST` | Plasmic Studio host URL (optional — defaults to production) |
+| `PLASMIC_AUTH_HOST` | Studio host URL — **required** when `PLASMIC_AUTH_USER`/`PLASMIC_AUTH_TOKEN` are set (e.g. `https://useast.storefront.elasticpath.com`) |
+| `PLASMIC_RENDERER_ORIGIN` | Origin serving Plasmic's renderer assets for live preview (optional — defaults to `https://host.plasmicdev.com`). Override only on self-hosted Studio. |
+
+### Authenticate via CLI
+
+Instead of env vars, run the interactive `auth` command. It prompts for your email and API token and writes them to `~/.plasmic.auth`:
+
+```bash
+npx @elasticpath/plasmic-mcp auth [--host <studio-url>]
+```
+
+`--host` defaults to the existing credentials' host, or US East if none. With a stored `.plasmic.auth`, the MCP entries below need no `env` block.
 
 ### Claude Code
 

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {

--- a/packages/plasmic-mcp/src/preview-server.ts
+++ b/packages/plasmic-mcp/src/preview-server.ts
@@ -228,6 +228,19 @@ function getStudioOrigin(): string {
   return auth.host.replace(/\/$/, "");
 }
 
+/**
+ * Origin that serves Plasmic's renderer assets — the lightweight renderer
+ * `host.html` and the `sub` / `react-web-bundle` / `live-frame` bundles. On
+ * plasmic.com SaaS this is the same as the Studio origin, but on a self-hosted
+ * Studio (e.g. Elastic Path's *.storefront.elasticpath.com) the auth host
+ * serves the full Studio SPA at /static/host.html — which has no renderer
+ * commit hash — so renderer assets must come from Plasmic's renderer CDN.
+ * Override via PLASMIC_RENDERER_ORIGIN.
+ */
+function getRendererOrigin(): string {
+  return (process.env.PLASMIC_RENDERER_ORIGIN || "https://host.plasmicdev.com").replace(/\/$/, "");
+}
+
 // ---------------------------------------------------------------------------
 // Host.html fetch
 // ---------------------------------------------------------------------------
@@ -243,8 +256,8 @@ function getStudioOrigin(): string {
  * into the iframe directly (browsers block cross-origin frame access).
  */
 async function fetchAndCacheHostHtml(): Promise<void> {
-  // Studio's host.html — used for the commit hash and as hostless fallback.
-  const studioHostUrl = `${getStudioOrigin()}/static/host.html`;
+  // Renderer host.html — used for the commit hash and as hostless fallback.
+  const studioHostUrl = `${getRendererOrigin()}/static/host.html`;
   try {
     const response = await fetch(studioHostUrl, { redirect: "follow" });
     if (!response.ok) {
@@ -1056,7 +1069,7 @@ async function handleStaticProxy(
   pathname: string,
   res: http.ServerResponse
 ): Promise<void> {
-  const targetUrl = `${getStudioOrigin()}${pathname}`;
+  const targetUrl = `${getRendererOrigin()}${pathname}`;
   try {
     const proxyRes = await fetch(targetUrl, { redirect: "follow" });
     if (!proxyRes.ok) {
@@ -1196,7 +1209,7 @@ async function handlePreview(
     ];
   }
 
-  const studioOrigin = getStudioOrigin();
+  const studioOrigin = getRendererOrigin();
 
   // Track the active app host origin so the catch-all proxy forwards
   // `/_next/*` etc. to the right upstream. The iframe loads the user's host


### PR DESCRIPTION
## Summary

The preview server in `packages/plasmic-mcp` fetched the renderer `host.html` (for the commit hash) and proxied the renderer bundles (`sub`, `react-web-bundle`, `live-frame`) from the **Studio auth host** (`getStudioOrigin()`). On a self-hosted Studio the auth host serves the full Studio SPA at `/static/host.html` — which carries **no renderer commit hash** — so hash extraction fails and the bundle URLs can't be loaded, breaking live preview.

This PR adds a dedicated `getRendererOrigin()` (default `https://host.plasmicdev.com`, overridable via the new `PLASMIC_RENDERER_ORIGIN` env var) and routes renderer `host.html`, `/static/*` proxying, and bundle injection through it. `getStudioOrigin()` is retained for auth-host concerns (startup log, health endpoint).

Because the commit hash now derives from the same renderer origin that serves the bundles, the two stay consistent on both SaaS and self-hosted setups (no SaaS regression).

## Changes
- `getRendererOrigin()` helper + `PLASMIC_RENDERER_ORIGIN` override.
- `fetchAndCacheHostHtml`, `handleStaticProxy`, and `handlePreview` use the renderer origin.
- Version bump `0.1.7` → `0.2.0` (new env var = backward-compatible feature).

## Testing
- [ ] Live preview on self-hosted Studio (`*.storefront.elasticpath.com`)
- [ ] Live preview on plasmic.com SaaS (no regression)

Closes #344