### PR TITLE
fix(plasmic-mcp): runtime deps (prompts, open) + optional playwright + --version fixes

### DIFF
--- a/packages/plasmic-mcp/build.mjs
+++ b/packages/plasmic-mcp/build.mjs
@@ -6,6 +6,11 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const wabSrc = path.resolve(__dirname, "../../platform/wab/src");
 
+// Single source of truth for the version reported by `--version`.
+const pkgVersion = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "package.json"), "utf-8")
+).version;
+
 /**
  * Resolve a path alias to an actual file, trying common extensions.
  */
@@ -116,6 +121,10 @@ const result = await esbuild.build({
 
   alias: {
     "mobx/dist/mobx.cjs.development.js": "mobx",
+  },
+
+  define: {
+    __MCP_VERSION__: JSON.stringify(pkgVersion),
   },
 
   plugins: [bundlePlugin],

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {
@@ -50,7 +50,9 @@
     "mobx-utils": "^6.0.0",
     "moment": "^2.29.0",
     "nanoid": "^3.3.0",
+    "open": "^8.0.9",
     "parse-data-url": "^2.0.0",
+    "prompts": "^2.4.2",
     "regex": "^4.0.0",
     "regexp.execall": "^1.0.0",
     "semver": "^6.3.0",
@@ -68,11 +70,13 @@
     "@types/lodash": "^4.17.0",
     "@types/node": "^20.0.0",
     "esbuild": "^0.20.0",
-    "playwright": "^1.58.2",
     "tsx": "^4.20.0",
     "typescript": "^5.2.0",
     "vitest": "3.2.4",
     "yaml": "^2.7.0"
+  },
+  "optionalDependencies": {
+    "playwright": "^1.58.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/plasmic-mcp/src/__tests__/cli.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/cli.test.ts
@@ -35,6 +35,16 @@ describe("parseArgs", () => {
     expect(result.command).toBe("version");
   });
 
+  it("parses -v flag", () => {
+    const result = parseArgs([...base, "-v"]);
+    expect(result.command).toBe("version");
+  });
+
+  it("parses bareword version command", () => {
+    const result = parseArgs([...base, "version"]);
+    expect(result.command).toBe("version");
+  });
+
   it("defaults to serve on unknown command", () => {
     const result = parseArgs([...base, "unknown-thing"]);
     expect(result.command).toBe("serve");

--- a/packages/plasmic-mcp/src/cli.ts
+++ b/packages/plasmic-mcp/src/cli.ts
@@ -23,7 +23,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     return { command: "serve", options: {} };
   }
 
-  if (args[0] === "--version" || args[0] === "-v") {
+  if (args[0] === "--version" || args[0] === "-v" || args[0] === "version") {
     return { command: "version", options: {} };
   }
 

--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -29,7 +29,11 @@ import { getAuth, writeAuth } from "./auth.js";
 import { acquireAuth } from "./auth-flow.js";
 import * as logger from "./logger.js";
 
-const VERSION = "0.1.4";
+// Injected at build time via esbuild `define` from package.json (see build.mjs).
+// Falls back to "dev" when run directly through tsx.
+declare const __MCP_VERSION__: string;
+const VERSION =
+  typeof __MCP_VERSION__ !== "undefined" ? __MCP_VERSION__ : "dev";
 
 const US_EAST_HOST = "https://useast.storefront.elasticpath.com";
 const EU_WEST_HOST = "https://euwest.storefront.elasticpath.com";
@@ -113,8 +117,9 @@ async function main() {
       await runAuth(options.host);
       break;
     case "version":
-      // Version goes to stdout (not stderr) since this is a user-facing command, not stdio transport
-      console.log(`@elasticpath/plasmic-mcp v${VERSION}`);
+      // Write straight to stdout: console.log is redirected to stderr at startup
+      // to protect the JSON-RPC transport, but this is a user-facing command.
+      process.stdout.write(`@elasticpath/plasmic-mcp v${VERSION}\n`);
       process.exit(0);
       break;
   }


### PR DESCRIPTION
## Summary

Two related fixes to the published CLI, bundled into the `0.2.1` release.

### 1. Missing runtime dependencies (the `auth` crash)
The published `auth` command crashed on a clean install/`npx`:

```
Cannot find package 'prompts' imported from .../dist/index.cjs
```

The bundle externalizes packages that are `import()`-ed at runtime, but `prompts`, `open`, and `playwright` weren't declared as installable deps.

- Add `prompts ^2.4.2` and `open ^8.0.9` to `dependencies` (auth manual + `--browser` flows).
- Move `playwright ^1.58.2` to `optionalDependencies` — `headless-canvas.ts` already try/catches the import and emits an actionable install message.

### 2. Broken `--version`
Three defects in the version command:
- `VERSION` was hardcoded to `"0.1.4"` and never tracked `package.json`.
- It used `console.log`, which is reassigned to `console.error` at startup to protect the JSON-RPC transport — so `--version` printed to **stderr**.
- The bareword `version` fell through to the serve default, silently starting the server.

Fix: inject the version at build time via esbuild `define` from `package.json` (falls back to `"dev"` under tsx), write to `process.stdout` directly, and accept `version` as well as `--version`/`-v`.

- Version bump `0.2.0` → `0.2.1`.

## Verification
- Packed the build, installed isolated, drove the real `auth` flow → `Credentials written… Authentication successful`; `.plasmic.auth` written correctly (`{host,user,token}`, perms `0600`). Before this change it died with `ERR_MODULE_NOT_FOUND`.
- `--version`, `version`, and `-v` all print `@elasticpath/plasmic-mcp v0.2.1` to stdout (survives `2>/dev/null`).
- `typecheck` + cli/entry-point unit tests pass (added coverage for `-v` and bareword `version`).

Closes #346