### PR TITLE
fix(plasmic-mcp): derive renderer origin from Studio app-config

### DIFF
--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elasticpath/plasmic-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for Plasmic Studio with embedded editing engine",
   "type": "module",
   "bin": {

--- a/packages/plasmic-mcp/src/__tests__/renderer-origin.test.ts
+++ b/packages/plasmic-mcp/src/__tests__/renderer-origin.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for renderer-origin resolution.
+ */
+
+import { describe, it, expect } from "vitest";
+import { deriveRendererOrigin, RENDERER_ORIGIN_FALLBACK } from "../renderer-origin.js";
+
+describe("deriveRendererOrigin", () => {
+  it("uses the env override when set, stripping a trailing slash", () => {
+    expect(
+      deriveRendererOrigin("https://my.host.example.com/", undefined)
+    ).toBe("https://my.host.example.com");
+  });
+
+  it("derives the origin from the app-config defaultHostUrl", () => {
+    // Studio returns a full host.html URL; we want just the origin.
+    expect(
+      deriveRendererOrigin(
+        undefined,
+        "https://host.elasticpathdev.com/static/host.html"
+      )
+    ).toBe("https://host.elasticpathdev.com");
+  });
+
+  it("preserves an environment/region prefix from defaultHostUrl", () => {
+    expect(
+      deriveRendererOrigin(
+        undefined,
+        "https://useast.host.elasticpathdev.com/static/host.html"
+      )
+    ).toBe("https://useast.host.elasticpathdev.com");
+  });
+
+  it("prefers the env override over the app-config value", () => {
+    expect(
+      deriveRendererOrigin(
+        "https://override.example.com",
+        "https://useast.host.elasticpathdev.com/static/host.html"
+      )
+    ).toBe("https://override.example.com");
+  });
+
+  it("falls back when neither override nor app-config is available", () => {
+    expect(deriveRendererOrigin(undefined, undefined)).toBe(
+      RENDERER_ORIGIN_FALLBACK
+    );
+  });
+
+  it("falls back when the app-config URL is malformed", () => {
+    expect(deriveRendererOrigin(undefined, "not a url")).toBe(
+      RENDERER_ORIGIN_FALLBACK
+    );
+  });
+
+  it("honors a custom fallback", () => {
+    expect(
+      deriveRendererOrigin(undefined, undefined, "https://fallback.example.com/")
+    ).toBe("https://fallback.example.com");
+  });
+});

--- a/packages/plasmic-mcp/src/preview-server.ts
+++ b/packages/plasmic-mcp/src/preview-server.ts
@@ -17,6 +17,7 @@ import * as url from "node:url";
 import type { PlasmicApiClient } from "./api-client.js";
 import { getSession } from "./session.js";
 import { getAuth } from "./auth.js";
+import { deriveRendererOrigin } from "./renderer-origin.js";
 import {
   exportReactPresentational,
   exportProjectConfig,
@@ -81,6 +82,9 @@ let commitHash: string | null = null;
 
 /** Reference to the API client (kept for future use). */
 let apiClientRef: PlasmicApiClient | null = null;
+
+/** Renderer origin resolved at startup (see resolveRendererOrigin). */
+let cachedRendererOrigin: string | null = null;
 
 /** Cache of generated module content, keyed by filename. Served at /static/{filename}
  *  so SystemJS can fetch CSS/JS modules that the codegen output imports. */
@@ -150,9 +154,13 @@ export async function startPreviewServer(
 ): Promise<number> {
   await stopPreviewServer();
 
-  await fetchAndCacheHostHtml();
-
   apiClientRef = apiClient;
+
+  // Resolve the renderer origin before fetching host.html — fetchAndCacheHostHtml
+  // and the static proxy both read it.
+  await resolveRendererOrigin();
+
+  await fetchAndCacheHostHtml();
 
   return new Promise((resolve, reject) => {
     const srv = http.createServer(async (req, res) => {
@@ -202,6 +210,7 @@ export async function stopPreviewServer(): Promise<void> {
       activeAppHostOrigin = null;
       commitHash = null;
       apiClientRef = null;
+      cachedRendererOrigin = null;
       generatedModules.clear();
       resolve();
     });
@@ -213,6 +222,7 @@ export async function stopPreviewServer(): Promise<void> {
       activeAppHostOrigin = null;
       commitHash = null;
       apiClientRef = null;
+      cachedRendererOrigin = null;
       generatedModules.clear();
       resolve();
     }, 2000);
@@ -229,16 +239,42 @@ function getStudioOrigin(): string {
 }
 
 /**
+ * Resolve the renderer origin once and cache it. Priority: PLASMIC_RENDERER_ORIGIN
+ * env override → origin of the Studio `appConfig.defaultHostUrl` (the same value
+ * Studio's own getHostUrl() uses, so it tracks the deployment — including any
+ * environment/region prefix on a self-hosted host) → fallback.
+ */
+async function resolveRendererOrigin(): Promise<void> {
+  const envOverride = process.env.PLASMIC_RENDERER_ORIGIN;
+  let appConfigHostUrl: string | undefined;
+
+  if (!envOverride && apiClientRef) {
+    try {
+      const { config } = await apiClientRef.getAppConfig();
+      appConfigHostUrl = config?.defaultHostUrl as string | undefined;
+    } catch (err) {
+      console.error(
+        `[plasmic-mcp] Could not derive renderer origin from Studio app-config (${err}); ` +
+          `set PLASMIC_RENDERER_ORIGIN to override.`
+      );
+    }
+  }
+
+  cachedRendererOrigin = deriveRendererOrigin(envOverride, appConfigHostUrl);
+  console.error(`[plasmic-mcp] Renderer origin: ${cachedRendererOrigin}`);
+}
+
+/**
  * Origin that serves Plasmic's renderer assets — the lightweight renderer
- * `host.html` and the `sub` / `react-web-bundle` / `live-frame` bundles. On
- * plasmic.com SaaS this is the same as the Studio origin, but on a self-hosted
- * Studio (e.g. Elastic Path's *.storefront.elasticpath.com) the auth host
- * serves the full Studio SPA at /static/host.html — which has no renderer
- * commit hash — so renderer assets must come from Plasmic's renderer CDN.
- * Override via PLASMIC_RENDERER_ORIGIN.
+ * `host.html` and the `sub` / `react-web-bundle` / `live-frame` bundles.
+ * Populated by resolveRendererOrigin() at startup; before that resolves we
+ * fall back to the env override or default so the getter stays synchronous.
  */
 function getRendererOrigin(): string {
-  return (process.env.PLASMIC_RENDERER_ORIGIN || "https://host.plasmicdev.com").replace(/\/$/, "");
+  if (cachedRendererOrigin) {
+    return cachedRendererOrigin;
+  }
+  return deriveRendererOrigin(process.env.PLASMIC_RENDERER_ORIGIN, undefined);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plasmic-mcp/src/renderer-origin.ts
+++ b/packages/plasmic-mcp/src/renderer-origin.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolution of the "renderer origin" — the host that serves Plasmic's
+ * lightweight renderer assets (`/static/host.html` and the `sub` /
+ * `react-web-bundle` / `live-frame` bundles) for live preview.
+ *
+ * On plasmic.com SaaS this is `host.plasmicdev.com`. On a self-hosted Studio
+ * the Studio auth host serves the full SPA at `/static/host.html` (no renderer
+ * commit hash), so renderer assets must come from a separate origin — for
+ * Elastic Path, its own CloudFront `host` distribution. Rather than hardcode
+ * that (it carries an environment/region prefix), we derive it from the
+ * Studio's own `appConfig.defaultHostUrl` — the same value Studio's
+ * `getHostUrl()` uses — and fall back only when that can't be reached.
+ */
+
+/** Last-resort default, used only when no override and no app-config are available. */
+export const RENDERER_ORIGIN_FALLBACK = "https://host.plasmicdev.com";
+
+/**
+ * Pure resolution, in priority order:
+ *   1. `envOverride` — `PLASMIC_RENDERER_ORIGIN` (explicit operator override)
+ *   2. origin of `appConfigHostUrl` — the Studio `appConfig.defaultHostUrl`
+ *   3. `fallback`
+ *
+ * Trailing slashes are stripped. An unparseable `appConfigHostUrl` is ignored
+ * in favour of the fallback.
+ */
+export function deriveRendererOrigin(
+  envOverride: string | undefined,
+  appConfigHostUrl: string | undefined,
+  fallback: string = RENDERER_ORIGIN_FALLBACK
+): string {
+  if (envOverride) {
+    return envOverride.replace(/\/$/, "");
+  }
+  if (appConfigHostUrl) {
+    try {
+      return new URL(appConfigHostUrl).origin;
+    } catch {
+      // Malformed defaultHostUrl — fall through to the fallback.
+    }
+  }
+  return fallback.replace(/\/$/, "");
+}


### PR DESCRIPTION
## Summary

The renderer origin (`getRendererOrigin()` in `preview-server.ts`) defaulted to `https://host.plasmicdev.com` — Plasmic's public SaaS CDN, which **does not exist for self-hosted Studio**. Elastic Path serves its renderer/canvas-host assets from its own CloudFront host under `*.host.elasticpathdev.com`, which also carries an environment/region prefix, so hardcoding any single value is wrong.

This derives the origin the same way Studio's own `getHostUrl()` does — from `appConfig.defaultHostUrl` (the `/api/v1/app-config` endpoint, already exposed via `apiClient.getAppConfig()`).

## Resolution order
1. `PLASMIC_RENDERER_ORIGIN` env (explicit operator override)
2. origin of the Studio `appConfig.defaultHostUrl` (tracks the deployment, incl. any env/region prefix)
3. fallback (`host.plasmicdev.com`, only if app-config is unreachable and no override)

Resolved once at preview startup and cached so the hot-path getter stays synchronous. The startup order in `startPreviewServer` was adjusted so the API client is set and the origin resolved before `fetchAndCacheHostHtml()` (which reads it).

## Changes
- New `src/renderer-origin.ts` — pure `deriveRendererOrigin()` + `RENDERER_ORIGIN_FALLBACK`.
- `preview-server.ts` — `resolveRendererOrigin()` (async, calls `getAppConfig()`, caches), sync `getRendererOrigin()` reads the cache; cleared on stop.
- `src/__tests__/renderer-origin.test.ts` — 7 cases incl. env override precedence, deriving the origin (and preserving an env/region prefix), malformed-URL and fallback paths.
- Version `0.2.1` → `0.2.2`.

## Context
Follow-up to #345. The hardcoded default landed in `0.2.0`; this makes the default correct on both SaaS and self-hosted without requiring operators to set `PLASMIC_RENDERER_ORIGIN`.

Closes #348