### PR TITLE
feat(ep-commerce): catalog-search enhancements for faceted search pages

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -31,6 +31,8 @@ interface EPCatalogSearchProviderProps {
   className?: string;
   indexName?: string;
   queryBy?: string;
+  baseFilter?: string;
+  highlightFullFields?: string;
   hitsPerPage?: number;
   enableUrlSync?: boolean;
   currencyCode?: string;
@@ -92,6 +94,20 @@ export const epCatalogSearchProviderMeta: CodeComponentMeta<EPCatalogSearchProvi
         description: "Fields to search (comma-separated)",
         defaultValue: "name,description",
       },
+      baseFilter: {
+        type: "string",
+        displayName: "Base Filter",
+        description:
+          'Typesense filter_by expression applied to EVERY search, combined (&&) with any facet refinements — e.g. "meta.product_types:!=child" to exclude variation children from hits. Leave empty for no base filter.',
+        defaultValue: "",
+      },
+      highlightFullFields: {
+        type: "string",
+        displayName: "Highlight Full Fields",
+        description:
+          'Comma-separated fields highlighted in full instead of snippeted (Typesense highlight_full_fields) — e.g. "name". Long fields like description are snippeted by default.',
+        defaultValue: "",
+      },
       hitsPerPage: {
         type: "number",
         displayName: "Hits Per Page",
@@ -134,6 +150,8 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
     className,
     indexName = "search",
     queryBy = "name,description",
+    baseFilter = "",
+    highlightFullFields = "",
     hitsPerPage = 12,
     enableUrlSync = true,
     currencyCode = DEFAULT_CURRENCY_CODE,
@@ -194,6 +212,8 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
     <EPCatalogSearchProviderInner
       indexName={indexName}
       queryBy={queryBy}
+      baseFilter={baseFilter}
+      highlightFullFields={highlightFullFields}
       hitsPerPage={hitsPerPage}
       enableUrlSync={enableUrlSync}
       currencyCode={currencyCode}
@@ -210,6 +230,8 @@ function EPCatalogSearchProviderInner(props: {
   errorContent?: React.ReactNode;
   indexName: string;
   queryBy: string;
+  baseFilter?: string;
+  highlightFullFields?: string;
   hitsPerPage: number;
   enableUrlSync: boolean;
   currencyCode: string;
@@ -220,6 +242,8 @@ function EPCatalogSearchProviderInner(props: {
     errorContent,
     indexName,
     queryBy,
+    baseFilter,
+    highlightFullFields,
     hitsPerPage,
     enableUrlSync,
     currencyCode,
@@ -247,6 +271,11 @@ function EPCatalogSearchProviderInner(props: {
         client,
         additionalSearchParameters: {
           query_by: queryBy,
+          // Typesense snippets long fields by default; fields listed here are
+          // highlighted in full (`<mark>`-wrapped) instead.
+          ...(highlightFullFields
+            ? { highlight_full_fields: highlightFullFields }
+            : {}),
         },
         // Inline the product image record onto each hit. Adapter v0.1.0+
         // forwards this as `?include=main_image` on the catalog-search call
@@ -264,7 +293,7 @@ function EPCatalogSearchProviderInner(props: {
       );
       return null;
     }
-  }, [client, queryBy]);
+  }, [client, queryBy, highlightFullFields]);
 
   if (!searchClient) {
     return (
@@ -294,7 +323,15 @@ function EPCatalogSearchProviderInner(props: {
       indexName={indexName}
       routing={enableUrlSync}
     >
-      <Configure hitsPerPage={hitsPerPage} />
+      {/* `filters` rides through the adapter's _adaptFilters, which always
+          joins it (&&) with facet refinements — unlike the adapter-level
+          `additionalSearchParameters.filter_by`, which is silently DROPPED
+          whenever InstantSearch generates its own filters (i.e. as soon as
+          any facet is refined). Must be Typesense filter_by syntax. */}
+      <Configure
+        hitsPerPage={hitsPerPage}
+        {...(baseFilter ? { filters: baseFilter } : {})}
+      />
       <DataProvider name="catalogSearchData" data={catalogSearchData}>
         <div className={className} data-ep-catalog-search-provider="">
           {children}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPClearRefinements.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPClearRefinements.tsx
@@ -26,6 +26,7 @@ interface EPClearRefinementsProps {
   children?: React.ReactNode;
   includedAttributes?: string[];
   excludedAttributes?: string[];
+  alwaysRender?: boolean;
   className?: string;
   previewState?: PreviewState;
 }
@@ -61,6 +62,13 @@ export const epClearRefinementsMeta: CodeComponentMeta<EPClearRefinementsProps> 
       description:
         "Attributes to leave alone when clearing. Mutually exclusive with Included Attributes.",
     },
+    alwaysRender: {
+      type: "boolean",
+      displayName: "Always Render",
+      description:
+        "Keep rendering children when there is nothing to clear (default hides them). Use for always-visible controls like an \"All results\" scope pill — style the active state off $ctx.clearRefinementsData.canRefine (false = no refinements = \"all\" is selected).",
+      defaultValue: false,
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -89,6 +97,7 @@ export const EPClearRefinements = React.forwardRef<
     children,
     includedAttributes,
     excludedAttributes,
+    alwaysRender = false,
     className,
     previewState = "auto",
   } = props;
@@ -110,6 +119,7 @@ export const EPClearRefinements = React.forwardRef<
       ref={ref}
       includedAttributes={includedAttributes}
       excludedAttributes={excludedAttributes}
+      alwaysRender={alwaysRender}
       className={className}
     >
       {children}
@@ -147,10 +157,11 @@ const EPClearRefinementsInner = React.forwardRef<
     children?: React.ReactNode;
     includedAttributes?: string[];
     excludedAttributes?: string[];
+    alwaysRender?: boolean;
     className?: string;
   }
 >(function EPClearRefinementsInner(
-  { children, includedAttributes, excludedAttributes, className },
+  { children, includedAttributes, excludedAttributes, alwaysRender, className },
   ref
 ) {
   const { useClearRefinements } = require("react-instantsearch");
@@ -176,7 +187,9 @@ const EPClearRefinementsInner = React.forwardRef<
     if (canRefine) refine();
   }, [refine, canRefine]);
 
-  if (!canRefine) return null;
+  // Default behavior hides the control when there's nothing to clear;
+  // alwaysRender keeps it for always-visible "All results"-style pills.
+  if (!canRefine && !alwaysRender) return null;
 
   return (
     <DataProvider name="clearRefinementsData" data={data}>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
@@ -4,6 +4,11 @@
  * Wraps `useRefinementList()` from react-instantsearch. Headless — exposes
  * refinement items for designer to render with any Plasmic elements.
  * Supports toggleRefinement action via refActions.
+ *
+ * `singleSelect` switches the backing hook to `useMenu()` for radio-style
+ * facets (e.g. a single-choice "scope" filter): selecting a value REPLACES
+ * the current refinement instead of OR-combining, and re-selecting the
+ * refined value clears it (the "All" affordance).
  */
 
 import {
@@ -28,6 +33,8 @@ interface EPRefinementListProps {
   limit?: number;
   showMore?: boolean;
   searchable?: boolean;
+  singleSelect?: boolean;
+  itemGap?: string;
   className?: string;
   previewState?: PreviewState;
 }
@@ -83,6 +90,20 @@ export const epRefinementListMeta: CodeComponentMeta<EPRefinementListProps> = {
       description: "Allow searching within facet values",
       defaultValue: false,
     },
+    singleSelect: {
+      type: "boolean",
+      displayName: "Single Select",
+      description:
+        "Radio-style facet: selecting a value replaces the current refinement instead of combining (uses InstantSearch's menu widget). Re-selecting the refined value clears it. Searchable is ignored in this mode.",
+      defaultValue: false,
+    },
+    itemGap: {
+      type: "string",
+      displayName: "Item Gap",
+      description:
+        "Single-select mode lays items out as a wrapping flex ROW (pill style) with this gap. Ignored in multi-select mode (vertical list). Set inline because Plasmic strips layout styles from code-component instances.",
+      defaultValue: "9.5px",
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -114,6 +135,8 @@ export const EPRefinementList = React.forwardRef<
     limit = 10,
     showMore = false,
     searchable = false,
+    singleSelect = false,
+    itemGap = "9.5px",
     className,
     previewState = "auto",
   } = props;
@@ -124,9 +147,34 @@ export const EPRefinementList = React.forwardRef<
 
   if (useMock) {
     return (
-      <MockRefinementList ref={ref} className={className} label={label}>
+      <MockRefinementList
+        ref={ref}
+        className={className}
+        label={label}
+        singleSelect={singleSelect}
+        itemGap={itemGap}
+      >
         {children}
       </MockRefinementList>
+    );
+  }
+
+  // Separate inner components — the backing InstantSearch hook differs
+  // (useMenu vs useRefinementList) and hooks cannot be picked conditionally
+  // within one component.
+  if (singleSelect) {
+    return (
+      <EPMenuListInner
+        ref={ref}
+        attribute={attribute || "brand"}
+        label={label}
+        limit={limit}
+        showMore={showMore}
+        itemGap={itemGap}
+        className={className}
+      >
+        {children}
+      </EPMenuListInner>
     );
   }
 
@@ -147,15 +195,36 @@ export const EPRefinementList = React.forwardRef<
 
 const MockRefinementList = React.forwardRef<
   EPRefinementListActions,
-  { children?: React.ReactNode; className?: string; label?: string }
->(function MockRefinementList({ children, className, label }, ref) {
+  {
+    children?: React.ReactNode;
+    className?: string;
+    label?: string;
+    singleSelect?: boolean;
+    itemGap?: string;
+  }
+>(function MockRefinementList(
+  { children, className, label, singleSelect, itemGap },
+  ref
+) {
   useImperativeHandle(ref, () => ({
     toggleRefinement: () => {},
   }));
 
+  // Mirror the runtime singleSelect layout (EPMenuListInner) so the Studio
+  // canvas matches the browser: a wrapping flex pill-row instead of the
+  // default vertical block list.
+  const listStyle: React.CSSProperties | undefined = singleSelect
+    ? { display: "flex", flexWrap: "wrap", gap: itemGap }
+    : undefined;
+
   return (
-    <div className={className} data-ep-refinement-list="" aria-label={label}>
-      <div role="list">
+    <div
+      className={className}
+      data-ep-refinement-list=""
+      {...(singleSelect ? { "data-single-select": "" } : {})}
+      aria-label={label}
+    >
+      <div role="list" style={listStyle}>
         {MOCK_REFINEMENT_ITEMS.map((item, i) => (
           <div key={item.value} role="listitem">
             <DataProvider name="currentRefinement" data={item}>
@@ -219,6 +288,78 @@ const EPRefinementListInner = React.forwardRef<
   return (
     <div className={className} data-ep-refinement-list="" aria-label={label}>
       <div role="list">
+        {normalizedItems.map((item: any, i: number) => (
+          <div key={item.value} role="listitem">
+            <DataProvider name="currentRefinement" data={item}>
+              <DataProvider name="currentRefinementIndex" data={i}>
+                {repeatedElement(i, children)}
+              </DataProvider>
+            </DataProvider>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+const EPMenuListInner = React.forwardRef<
+  EPRefinementListActions,
+  {
+    children?: React.ReactNode;
+    attribute: string;
+    label?: string;
+    limit: number;
+    showMore: boolean;
+    itemGap?: string;
+    className?: string;
+  }
+>(function EPMenuListInner(
+  { children, attribute, label, limit, showMore, itemGap, className },
+  ref
+) {
+  const { useMenu } = require("react-instantsearch");
+  const { items, refine } = useMenu({
+    attribute,
+    limit,
+    showMore,
+    // Highest-count value first (e.g. the largest scope before smaller
+    // ones); name breaks ties deterministically.
+    sortBy: ["count:desc", "name:asc"],
+  });
+
+  useImperativeHandle(ref, () => ({
+    toggleRefinement: (value: string) => refine(value),
+  }));
+
+  // Same per-item shape as the multi-select path (value/label/count/
+  // isRefined/toggle) so designs can switch modes without rebinding.
+  const normalizedItems = useMemo(
+    () =>
+      (items || []).map((item: any) => ({
+        value: item.value,
+        label: item.label,
+        count: item.count,
+        isRefined: item.isRefined,
+        toggle: () => refine(item.value),
+      })),
+    [items, refine]
+  );
+
+  if (normalizedItems.length === 0) return null;
+
+  return (
+    <div
+      className={className}
+      data-ep-refinement-list=""
+      data-single-select=""
+      aria-label={label}
+    >
+      {/* Inline flex-row — Plasmic strips layout styles from code-component
+          instances, so the pill row is laid out here (gap via itemGap). */}
+      <div
+        role="list"
+        style={{ display: "flex", flexWrap: "wrap", gap: itemGap }}
+      >
         {normalizedItems.map((item: any, i: number) => (
           <div key={item.value} role="listitem">
             <DataProvider name="currentRefinement" data={item}>

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
@@ -296,13 +296,25 @@ const EPSearchAutocompleteInner = React.forwardRef<
     [hookOutput.setQuery, hookOutput.focus, hookOutput.clear]
   );
 
+  // clear/setQuery ride along in the data context (same pattern as
+  // EPRefinementList's per-item `toggle` and searchPaginationData.goTo) so
+  // designers can wire e.g. a clear-✕ via a customFunction interaction
+  // ($ctx.autocompleteData.clear()) without reaching the component ref.
   const publicData: AutocompleteData = useMemo(
     () => ({
       isOpen: !!hookOutput.state.isOpen,
       query: hookOutput.state.query ?? "",
       collections: hookOutput.collections,
+      clear: hookOutput.clear,
+      setQuery: hookOutput.setQuery,
     }),
-    [hookOutput.state.isOpen, hookOutput.state.query, hookOutput.collections]
+    [
+      hookOutput.state.isOpen,
+      hookOutput.state.query,
+      hookOutput.collections,
+      hookOutput.clear,
+      hookOutput.setQuery,
+    ]
   );
 
   return (

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -22,6 +22,7 @@ import React, { useMemo } from "react";
 import { Registerable } from "../registerable";
 import { formatCurrency } from "../utils/formatCurrency";
 import { MOCK_SEARCH_PRODUCTS } from "./design-time-data";
+import { MOCK_EXTENSIONS_RAW } from "../utils/extensions-mock";
 import type { Product } from "../types/product";
 
 type PreviewState = "auto" | "withData";
@@ -51,11 +52,14 @@ const DEFAULT_GRID_TEMPLATE_COLUMNS =
   "repeat(auto-fill, minmax(220px, 1fr))";
 const DEFAULT_GRID_GAP = "24px";
 
+const DEFAULT_PRODUCT_PATH_PREFIX = "/product";
+
 interface EPSearchHitsProps {
   children?: React.ReactNode;
   className?: string;
   gridTemplateColumns?: string;
   gridGap?: string;
+  productPathPrefix?: string;
   previewState?: PreviewState;
 }
 
@@ -66,7 +70,8 @@ interface EPSearchHitsProps {
  */
 function normalizeHitToCurrentProduct(
   hit: Record<string, any>,
-  currencyCode: string
+  currencyCode: string,
+  productPathPrefix: string = DEFAULT_PRODUCT_PATH_PREFIX
 ) {
   const name = hit.ep_name || hit.name || hit.attributes?.name || "";
   const slug =
@@ -127,8 +132,54 @@ function normalizeHitToCurrentProduct(
   const formatted =
     displayPrice?.formatted || formatCurrency(priceValue, priceCurrency);
 
-  // Highlight results from InstantSearch
+  // Highlight results from InstantSearch.
+  //
+  // The EP catalog-search backend keys highlights by the BARE query_by field
+  // names (`name`, `description`) while the document nests them under
+  // `attributes.…` — the adapter's document-driven highlight walk therefore
+  // drops them from `_highlightResult`/`_snippetResult`. Recover from the
+  // raw Typesense hit (`highlight.<field>.{value,snippet}`), keeping the
+  // adapter paths as fallbacks for backends where they do line up.
   const highlighted = hit._highlightResult || hit._highlight || {};
+  const snippeted = hit._snippetResult || {};
+  const rawHighlight = hit._rawTypesenseHit?.highlight || {};
+  const highlightedName =
+    rawHighlight.name?.value ||
+    rawHighlight.name?.snippet ||
+    highlighted.ep_name?.value ||
+    highlighted.name?.value ||
+    highlighted.attributes?.name?.value ||
+    undefined;
+  const highlightedDescription =
+    rawHighlight.description?.value ||
+    highlighted.ep_description?.value ||
+    highlighted.description?.value ||
+    highlighted.attributes?.description?.value ||
+    undefined;
+  // Snippet = the shortened, `<mark>`-highlighted excerpt Typesense builds
+  // for long fields (e.g. a description/abstract snippet on a hit card).
+  const snippetedDescription =
+    rawHighlight.description?.snippet ||
+    snippeted.description?.value ||
+    snippeted.attributes?.description?.value ||
+    undefined;
+
+  // Template extensions — the catalog-search document carries the same
+  // `attributes.extensions` block as the shopper product API. Expose it
+  //   1. resolved on `extensions` for direct bindings
+  //      (`currentProduct.extensions["products(…)"].field`), and
+  //   2. under `rawData.data` so the PDP field components
+  //      (EPProductField / EPProductExtensionValue, which read
+  //      `rawData.data.attributes.extensions`) work inside hit cards
+  //      unchanged.
+  const extensions: Record<string, unknown> =
+    hit.attributes?.extensions || hit.extensions || {};
+
+  // Strip the trailing slash so both "/product" and "/product/" work.
+  const pathPrefix = (productPathPrefix || DEFAULT_PRODUCT_PATH_PREFIX).replace(
+    /\/+$/,
+    ""
+  );
 
   return {
     id: hit.objectID || hit.id || "",
@@ -136,9 +187,10 @@ function normalizeHitToCurrentProduct(
     slug,
     sku,
     description,
-    // Match the EP ProductDetail page route (`/product/[slug]`).
-    // Falls back to id-based URL when the hit lacks a slug.
-    path: slug ? `/product/${slug}` : `/product/${hit.objectID || hit.id || ""}`,
+    // PDP route — configurable via the `productPathPrefix` prop so storefronts
+    // with a different route shape (e.g. `/products`, `/en/products`) link
+    // correctly. Falls back to an id-based URL when the hit lacks a slug.
+    path: `${pathPrefix}/${slug || hit.objectID || hit.id || ""}`,
     images: [
       {
         url: imageUrl || TRANSPARENT_PIXEL,
@@ -151,11 +203,15 @@ function normalizeHitToCurrentProduct(
       formatted,
     },
     options: [] as Array<{ displayName: string; values: Array<{ label: string }> }>,
-    _highlightedName: highlighted.ep_name?.value || highlighted.name?.value || undefined,
-    _highlightedDescription:
-      highlighted.ep_description?.value ||
-      highlighted.description?.value ||
-      undefined,
+    extensions,
+    // The search document has the shopper-product shape ({attributes, id,
+    // meta, …}), so wrapping it as `{ data: hit }` matches the PDP's
+    // `rawData` contract (see extractRawExtensions in
+    // product-extensions/composable/format.ts).
+    rawData: { data: hit },
+    _highlightedName: highlightedName,
+    _highlightedDescription: highlightedDescription,
+    _snippetedDescription: snippetedDescription,
     _score: hit._score ?? hit._rankingInfo?.relevance ?? undefined,
     rawHit: hit,
   };
@@ -164,9 +220,19 @@ function normalizeHitToCurrentProduct(
 /**
  * Build currentProduct from mock Product (design-time).
  */
-function buildMockCurrentProduct(product: Product) {
+function buildMockCurrentProduct(
+  product: Product,
+  productPathPrefix: string = DEFAULT_PRODUCT_PATH_PREFIX
+) {
   const currencyCode = product.price.currencyCode ?? "USD";
   const formatted = formatCurrency(product.price.value, currencyCode);
+  const pathPrefix = (productPathPrefix || DEFAULT_PRODUCT_PATH_PREFIX).replace(
+    /\/+$/,
+    ""
+  );
+  // Same mock extensions as the PDP field components, so the cascading
+  // template/field dropdowns populate when authoring hit cards in the canvas.
+  const extensions = MOCK_EXTENSIONS_RAW;
 
   return {
     id: product.id,
@@ -174,7 +240,7 @@ function buildMockCurrentProduct(product: Product) {
     slug: product.slug ?? "",
     sku: product.sku ?? "",
     description: product.description,
-    path: product.path ?? `/${product.slug ?? ""}`,
+    path: product.path ?? `${pathPrefix}/${product.slug ?? ""}`,
     images: product.images,
     price: {
       value: product.price.value,
@@ -185,8 +251,11 @@ function buildMockCurrentProduct(product: Product) {
       displayName: opt.displayName,
       values: opt.values.map((v) => ({ label: v.label })),
     })),
+    extensions,
+    rawData: { data: { attributes: { extensions } } },
     _highlightedName: undefined,
     _highlightedDescription: undefined,
+    _snippetedDescription: undefined,
     _score: undefined,
     rawHit: {},
   };
@@ -229,6 +298,13 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
       description: "CSS gap between hit cards.",
       defaultValue: DEFAULT_GRID_GAP,
     },
+    productPathPrefix: {
+      type: "string",
+      displayName: "Product Path Prefix",
+      description:
+        "Route prefix used to build each hit's currentProduct.path link (prefix + '/' + slug). Set this to match the storefront's PDP route, e.g. \"/products\".",
+      defaultValue: DEFAULT_PRODUCT_PATH_PREFIX,
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -249,6 +325,7 @@ export function EPSearchHits(props: EPSearchHitsProps) {
     className,
     gridTemplateColumns = DEFAULT_GRID_TEMPLATE_COLUMNS,
     gridGap = DEFAULT_GRID_GAP,
+    productPathPrefix = DEFAULT_PRODUCT_PATH_PREFIX,
     previewState = "auto",
   } = props;
 
@@ -260,14 +337,22 @@ export function EPSearchHits(props: EPSearchHitsProps) {
 
   if (useMock) {
     return (
-      <MockSearchHits className={className} gridStyle={gridStyle}>
+      <MockSearchHits
+        className={className}
+        gridStyle={gridStyle}
+        productPathPrefix={productPathPrefix}
+      >
         {children}
       </MockSearchHits>
     );
   }
 
   return (
-    <EPSearchHitsInner className={className} gridStyle={gridStyle}>
+    <EPSearchHitsInner
+      className={className}
+      gridStyle={gridStyle}
+      productPathPrefix={productPathPrefix}
+    >
       {children}
     </EPSearchHitsInner>
   );
@@ -277,12 +362,16 @@ function MockSearchHits(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
+  productPathPrefix?: string;
 }) {
-  const { children, className, gridStyle } = props;
+  const { children, className, gridStyle, productPathPrefix } = props;
 
   const products = useMemo(
-    () => MOCK_SEARCH_PRODUCTS.map(buildMockCurrentProduct),
-    []
+    () =>
+      MOCK_SEARCH_PRODUCTS.map((p) =>
+        buildMockCurrentProduct(p, productPathPrefix)
+      ),
+    [productPathPrefix]
   );
 
   if (products.length === 0) return null;
@@ -312,8 +401,9 @@ function EPSearchHitsInner(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
+  productPathPrefix?: string;
 }) {
-  const { children, className, gridStyle } = props;
+  const { children, className, gridStyle, productPathPrefix } = props;
 
   const { useHits, useInstantSearch } = require("react-instantsearch");
   const { hits } = useHits();
@@ -328,9 +418,9 @@ function EPSearchHitsInner(props: {
   const normalizedProducts = useMemo(
     () =>
       (hits || []).map((hit: Record<string, any>) =>
-        normalizeHitToCurrentProduct(hit, currencyCode)
+        normalizeHitToCurrentProduct(hit, currencyCode, productPathPrefix)
       ),
-    [hits, currencyCode]
+    [hits, currencyCode, productPathPrefix]
   );
 
   if (normalizedProducts.length === 0) return null;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
@@ -176,12 +176,19 @@ const EPSearchPaginationInner = React.forwardRef<
     prevPage: handlePrevPage,
   }));
 
+  // goTo/next/prev ride along in the data context (same pattern as
+  // EPRefinementList's per-item `toggle`) so designers can wire clicks via
+  // customFunction interactions ($ctx.searchPaginationData.goTo(page))
+  // without reaching the component ref.
   const paginationData: SearchPaginationData = {
     currentPage: currentRefinement,
     totalPages: nbPages,
     hasNext: !isLastPage,
     hasPrev: !isFirstPage,
     pages,
+    goTo: handleGoToPage,
+    next: handleNextPage,
+    prev: handlePrevPage,
   };
 
   return (

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
@@ -45,6 +45,11 @@ const mockUseRefinementList = jest.fn().mockReturnValue({
   refine: jest.fn(),
 });
 
+const mockUseMenu = jest.fn().mockReturnValue({
+  items: [],
+  refine: jest.fn(),
+});
+
 const mockUseHierarchicalMenu = jest.fn().mockReturnValue({
   items: [],
   refine: jest.fn(),
@@ -147,6 +152,7 @@ jest.mock("react-instantsearch", () => ({
   useHits: (...a: unknown[]) => mockUseHits(...a),
   useInstantSearch: (...a: unknown[]) => mockUseInstantSearch(...a),
   useRefinementList: (...a: unknown[]) => mockUseRefinementList(...a),
+  useMenu: (...a: unknown[]) => mockUseMenu(...a),
   useHierarchicalMenu: (...a: unknown[]) => mockUseHierarchicalMenu(...a),
   useRange: (...a: unknown[]) => mockUseRange(...a),
   usePagination: (...a: unknown[]) => mockUsePagination(...a),
@@ -157,7 +163,11 @@ jest.mock("react-instantsearch", () => ({
   InstantSearch: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="instantsearch">{children}</div>
   ),
-  Configure: () => null,
+  // Render props so tests can assert what the provider configures
+  // (hitsPerPage, the base `filters`, …).
+  Configure: (props: Record<string, unknown>) => (
+    <div data-testid="configure" data-configure={JSON.stringify(props)} />
+  ),
 }));
 
 jest.mock("@elasticpath/catalog-search-instantsearch-adapter", () => ({
@@ -427,6 +437,79 @@ describe("EPCatalogSearchProvider", () => {
     );
     expect(data.isSearchActive).toBe(false);
     expect(data.query).toBe("");
+  });
+
+  function getConfigureProps(container: HTMLElement) {
+    const el = container.querySelector('[data-testid="configure"]');
+    expect(el).not.toBeNull();
+    return JSON.parse(el!.getAttribute("data-configure") || "{}");
+  }
+
+  it("passes baseFilter to Configure as `filters` at runtime", () => {
+    // `filters` rides through the adapter's _adaptFilters, which always joins
+    // it with facet refinements — adapter-level filter_by would be dropped as
+    // soon as a facet is refined.
+    const { container } = render(
+      <EPCatalogSearchProvider baseFilter="meta.product_types:!=child">
+        <div>children</div>
+      </EPCatalogSearchProvider>
+    );
+
+    const props = getConfigureProps(container);
+    expect(props.filters).toBe("meta.product_types:!=child");
+    expect(props.hitsPerPage).toBe(12);
+  });
+
+  it("omits `filters` from Configure when baseFilter is empty", () => {
+    const { container } = render(
+      <EPCatalogSearchProvider>
+        <div>children</div>
+      </EPCatalogSearchProvider>
+    );
+
+    const props = getConfigureProps(container);
+    expect(props).not.toHaveProperty("filters");
+  });
+
+  it("forwards highlightFullFields to the adapter's search parameters", () => {
+    const AdapterMock = (
+      require("@elasticpath/catalog-search-instantsearch-adapter") as {
+        default: jest.Mock;
+      }
+    ).default;
+
+    render(
+      <EPCatalogSearchProvider highlightFullFields="name,description">
+        <div>children</div>
+      </EPCatalogSearchProvider>
+    );
+
+    expect(AdapterMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        additionalSearchParameters: expect.objectContaining({
+          highlight_full_fields: "name,description",
+        }),
+      })
+    );
+  });
+
+  it("does not send highlight_full_fields when unset", () => {
+    const AdapterMock = (
+      require("@elasticpath/catalog-search-instantsearch-adapter") as {
+        default: jest.Mock;
+      }
+    ).default;
+
+    render(
+      <EPCatalogSearchProvider>
+        <div>children</div>
+      </EPCatalogSearchProvider>
+    );
+
+    const args = AdapterMock.mock.calls[0][0];
+    expect(args.additionalSearchParameters).not.toHaveProperty(
+      "highlight_full_fields"
+    );
   });
 });
 
@@ -780,6 +863,106 @@ describe("EPSearchHits", () => {
     expect(data.name).toBe("British Product");
   });
 
+  /** Render one EP catalog-search shaped hit and return the normalized currentProduct. */
+  function renderHitAndGetCurrentProduct(
+    hit: Record<string, unknown>,
+    props: { productPathPrefix?: string } = {}
+  ) {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    mockUseSelector.mockReturnValue(undefined);
+    mockUseHits.mockReturnValue({ hits: [hit] });
+
+    const { container } = render(
+      <EPSearchHits {...props}>
+        <div>child</div>
+      </EPSearchHits>
+    );
+    const providerEl = container.querySelector(
+      '[data-testid="data-provider-currentProduct"]'
+    );
+    expect(providerEl).not.toBeNull();
+    return JSON.parse(providerEl!.getAttribute("data-provider-data") || "{}");
+  }
+
+  // The adapter spreads the EP search document onto the hit, so attributes
+  // (incl. extensions) live under hit.attributes.
+  const EP_HIT = {
+    objectID: "ep-hit-1",
+    attributes: {
+      name: "Sample Product",
+      slug: "sample-product",
+      sku: "sample-sku-001",
+      description: "A sample product description for testing.",
+      extensions: {
+        "products(specs)": {
+          reference: "SP-001",
+          product_kind: "standard",
+          lifecycle_status: "Published",
+        },
+      },
+    },
+  };
+
+  it("exposes template extensions resolved and under the PDP rawData contract", () => {
+    const data = renderHitAndGetCurrentProduct(EP_HIT);
+
+    // 1. direct binding: currentProduct.extensions["products(…)"].field
+    expect(
+      data.extensions["products(specs)"].lifecycle_status
+    ).toBe("Published");
+    // 2. PDP field components read rawData.data.attributes.extensions
+    //    (see extractRawExtensions in product-extensions/composable/format.ts)
+    expect(
+      data.rawData.data.attributes.extensions["products(specs)"]
+        .product_kind
+    ).toBe("standard");
+  });
+
+  it("defaults extensions to {} when the hit has none", () => {
+    const data = renderHitAndGetCurrentProduct({
+      objectID: "no-ext",
+      attributes: { name: "Plain", slug: "plain" },
+    });
+    expect(data.extensions).toEqual({});
+  });
+
+  it("builds path from productPathPrefix (trailing slash tolerated)", () => {
+    const withPrefix = renderHitAndGetCurrentProduct(EP_HIT, {
+      productPathPrefix: "/products/",
+    });
+    expect(withPrefix.path).toBe("/products/sample-product");
+
+    const withDefault = renderHitAndGetCurrentProduct(EP_HIT);
+    expect(withDefault.path).toBe("/product/sample-product");
+  });
+
+  it("recovers bare-keyed EP highlights from the raw Typesense hit", () => {
+    // EP keys highlights by the bare query_by names while the document nests
+    // fields under attributes — the adapter's document-driven walk drops
+    // them, so the normalizer reads _rawTypesenseHit.highlight directly.
+    const data = renderHitAndGetCurrentProduct({
+      ...EP_HIT,
+      _highlightResult: {
+        attributes: {
+          name: { value: "Sample Product", matchLevel: "none" },
+        },
+      },
+      _rawTypesenseHit: {
+        highlight: {
+          name: { value: "Sample <mark>Product</mark>" },
+          description: {
+            snippet: "a <mark>sample</mark> description",
+          },
+        },
+      },
+    });
+
+    expect(data._highlightedName).toBe("Sample <mark>Product</mark>");
+    expect(data._snippetedDescription).toBe(
+      "a <mark>sample</mark> description"
+    );
+  });
+
   it("should fall back to USD when catalogSearchData has no currencyCode", () => {
     mockUsePlasmicCanvasContext.mockReturnValue(null);
     mockUseSelector.mockReturnValue(undefined);
@@ -854,6 +1037,47 @@ describe("EPRefinementList", () => {
     expect(data.label).toBeTruthy();
     expect(typeof data.count).toBe("number");
     expect(typeof data.isRefined).toBe("boolean");
+  });
+
+  it("uses useMenu (replace semantics) when singleSelect — radio-style facets", () => {
+    mockUseMenu.mockReturnValue({
+      items: [
+        { value: "type-a", label: "type-a", count: 39, isRefined: true },
+        { value: "type-b", label: "type-b", count: 1, isRefined: false },
+      ],
+      refine: jest.fn(),
+    });
+
+    const { container } = render(
+      <EPRefinementList
+        attribute="extensions.products(specs).product_kind"
+        singleSelect
+      >
+        <div>child</div>
+      </EPRefinementList>
+    );
+
+    expect(mockUseMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attribute: "extensions.products(specs).product_kind",
+      })
+    );
+    expect(mockUseRefinementList).not.toHaveBeenCalled();
+
+    // Same per-item shape as the multi-select path
+    const providerEl = container.querySelector(
+      '[data-testid="data-provider-currentRefinement"]'
+    );
+    const data = JSON.parse(
+      providerEl!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("type-a");
+    expect(data.count).toBe(39);
+    expect(data.isRefined).toBe(true);
+
+    expect(
+      container.querySelector("[data-single-select]")
+    ).not.toBeNull();
   });
 
   it("should expose currentRefinementIndex in editor", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
@@ -296,6 +296,10 @@ export interface SearchPaginationData {
   hasNext: boolean;
   hasPrev: boolean;
   pages: number[];
+  /** Wire clicks via customFunction interactions, e.g. $ctx.searchPaginationData.goTo(page). */
+  goTo?: (page: number) => void;
+  next?: () => void;
+  prev?: () => void;
 }
 
 export const MOCK_SEARCH_PAGINATION_DATA: SearchPaginationData = {
@@ -437,6 +441,9 @@ export interface AutocompleteData {
   query: string;
   /** Per-source item collections — each source renders its own list. */
   collections: AutocompleteCollection[];
+  /** Wire via customFunction interactions, e.g. $ctx.autocompleteData.clear(). */
+  clear?: () => void;
+  setQuery?: (value: string) => void;
 }
 
 export const MOCK_AUTOCOMPLETE_DATA: AutocompleteData = {


### PR DESCRIPTION
Closes #351.

Reusable additions to the EP catalog-search components for building faceted, deep-linked search result pages. All handlers ride the `$ctx` data context so Plasmic designers wire interactions without component refs.

## Changes

| Component | Addition |
|-----------|----------|
| `EPCatalogSearchProvider` | `baseFilter` prop — injected via InstantSearch `<Configure filters>` so it persists across facet refinement (adapter-level `filter_by` does not). `highlightFullFields` prop → Typesense `highlight_full_fields`. |
| `EPSearchHits` | Exposes resolved `extensions` **and** `rawData` on `currentProduct` so the PDP field components work inside hit cards unchanged. Configurable `productPathPrefix` for the hit link. Recovers EP's bare-keyed highlights from the raw Typesense hit and exposes `_snippetedDescription`. |
| `EPRefinementList` | `singleSelect` (radio-style via `useMenu`, count-desc ordering) + `itemGap` for the pill row. The design-time canvas mock mirrors the `singleSelect` flex pill-row so the visual builder matches runtime. |
| `EPClearRefinements` | `alwaysRender` for always-visible "all"-style affordances (style off `clearRefinementsData.canRefine`). |
| `EPSearchPagination` | `goTo` / `next` / `prev` exposed on `searchPaginationData`. |
| `EPSearchAutocomplete` | `clear` / `setQuery` exposed on `autocompleteData`. |

## Why the base filter goes through `<Configure filters>`

The adapter joins `Configure`'s `filters` with generated facet filters (`&&`), but **drops** `additionalSearchParameters.filter_by` as soon as InstantSearch generates its own filters (i.e. on any facet refinement). Routing the base filter through `filters` is the only way it survives a facet selection — verified live (selecting a scope facet no longer re-admits filtered-out documents, e.g. variation children).

## Testing

- All package tests pass (`catalog-search-components.test.tsx` extended: base-filter/highlight provider config, hit extensions + `rawData` + `productPathPrefix` + highlight recovery, `singleSelect` menu semantics + canvas mock layout).
- Verified end-to-end against a live storefront search page (Playwright, 1440px + 390px): live search-as-you-type + URL sync + back/forward, autocomplete, single-select scope facet with live counts + clear-all, query-term highlighting in title and snippet, numbered pagination with page indicator, reference links to the PDP, empty state, header-search hand-off.

## Notes

- No production build artifacts are committed (source only).
- Single commit on `master`.