### PR TITLE
feat(ep-commerce): tiered designer data surface for catalog-search (ADR-0011)

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCatalogSearchProvider.tsx
@@ -25,6 +25,17 @@ import { useHeadlessStyling } from "./headless-styling";
 
 type PreviewState = "auto" | "withData" | "loading" | "empty" | "error";
 
+/**
+ * Typesense filter excluding PXM variation children from hits. AND'd with the
+ * caller's baseFilter when excludeVariationChildren is on (the default).
+ */
+const EXCLUDE_VARIATION_CHILDREN_FILTER = "meta.product_types:!=child";
+
+/** AND-join non-empty Typesense filter_by clauses. */
+function combineFilters(...clauses: Array<string | undefined>): string {
+  return clauses.map((c) => (c || "").trim()).filter(Boolean).join(" && ");
+}
+
 interface EPCatalogSearchProviderProps {
   children?: React.ReactNode;
   errorContent?: React.ReactNode;
@@ -32,6 +43,7 @@ interface EPCatalogSearchProviderProps {
   indexName?: string;
   queryBy?: string;
   baseFilter?: string;
+  excludeVariationChildren?: boolean;
   highlightFullFields?: string;
   hitsPerPage?: number;
   enableUrlSync?: boolean;
@@ -43,27 +55,40 @@ export const epCatalogSearchProviderMeta: CodeComponentMeta<EPCatalogSearchProvi
   {
     name: "plasmic-commerce-ep-catalog-search-provider",
     displayName: "EP Catalog Search Provider",
+    section: "EP Catalog Search",
     description:
       "Root provider for Elastic Path Catalog Search. Wraps InstantSearch with the EP adapter. Place search components (EP Search Box, EP Search Hits, etc.) as children.",
     props: {
       children: {
         type: "slot",
+        // Batteries-included but unstyled scaffold (D8): a complete, working
+        // search built from the Tier-0 components — search box, scope facet,
+        // hits (with its own default field-component card), empty state, and
+        // pagination. Renders against mock data in the canvas, so a designer
+        // styles up from a correct structure instead of assembling from
+        // scratch. Generic (no ISO knowledge): set the scope facet's Attribute
+        // to your store's single-choice facet.
         defaultValue: [
           {
             type: "vbox",
+            styles: { gap: "16px" },
             children: [
               {
                 type: "component",
                 name: "plasmic-commerce-ep-search-box",
               },
               {
-                type: "hbox",
-                children: [
-                  {
-                    type: "component",
-                    name: "plasmic-commerce-ep-search-hits",
-                  },
-                ],
+                type: "component",
+                name: "plasmic-commerce-ep-single-select-facet",
+                props: { includeAllOption: true },
+              },
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-search-hits",
+              },
+              {
+                type: "component",
+                name: "plasmic-commerce-ep-search-empty",
               },
               {
                 type: "component",
@@ -98,8 +123,15 @@ export const epCatalogSearchProviderMeta: CodeComponentMeta<EPCatalogSearchProvi
         type: "string",
         displayName: "Base Filter",
         description:
-          'Typesense filter_by expression applied to EVERY search, combined (&&) with any facet refinements — e.g. "meta.product_types:!=child" to exclude variation children from hits. Leave empty for no base filter.',
+          'Typesense filter_by expression applied to EVERY search, combined (&&) with any facet refinements and the Exclude Variation Children filter — e.g. "lifecycle_status:=published". Leave empty for no base filter.',
         defaultValue: "",
+      },
+      excludeVariationChildren: {
+        type: "boolean",
+        displayName: "Exclude Variation Children",
+        description:
+          "Hide PXM variation children from results (emits meta.product_types:!=child, AND'd with Base Filter). On by default — children almost never belong in hits. Turn off to include them.",
+        defaultValue: true,
       },
       highlightFullFields: {
         type: "string",
@@ -151,6 +183,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
     indexName = "search",
     queryBy = "name,description",
     baseFilter = "",
+    excludeVariationChildren = true,
     highlightFullFields = "",
     hitsPerPage = 12,
     enableUrlSync = true,
@@ -213,6 +246,7 @@ export function EPCatalogSearchProvider(props: EPCatalogSearchProviderProps) {
       indexName={indexName}
       queryBy={queryBy}
       baseFilter={baseFilter}
+      excludeVariationChildren={excludeVariationChildren}
       highlightFullFields={highlightFullFields}
       hitsPerPage={hitsPerPage}
       enableUrlSync={enableUrlSync}
@@ -231,6 +265,7 @@ function EPCatalogSearchProviderInner(props: {
   indexName: string;
   queryBy: string;
   baseFilter?: string;
+  excludeVariationChildren?: boolean;
   highlightFullFields?: string;
   hitsPerPage: number;
   enableUrlSync: boolean;
@@ -243,6 +278,7 @@ function EPCatalogSearchProviderInner(props: {
     indexName,
     queryBy,
     baseFilter,
+    excludeVariationChildren,
     highlightFullFields,
     hitsPerPage,
     enableUrlSync,
@@ -311,6 +347,14 @@ function EPCatalogSearchProviderInner(props: {
   // Dynamic require to avoid hard dependency
   const { InstantSearch, Configure } = require("react-instantsearch");
 
+  // Exclude PXM variation children by default (D3), AND'd with the caller's
+  // baseFilter. Both ride through the adapter's _adaptFilters as InstantSearch
+  // `filters`, which is always joined (&&) with facet refinements.
+  const effectiveFilter = combineFilters(
+    excludeVariationChildren ? EXCLUDE_VARIATION_CHILDREN_FILTER : "",
+    baseFilter
+  );
+
   const catalogSearchData: CatalogSearchData = {
     isSearchActive: true,
     query: "",
@@ -330,7 +374,7 @@ function EPCatalogSearchProviderInner(props: {
           any facet is refined). Must be Typesense filter_by syntax. */}
       <Configure
         hitsPerPage={hitsPerPage}
-        {...(baseFilter ? { filters: baseFilter } : {})}
+        {...(effectiveFilter ? { filters: effectiveFilter } : {})}
       />
       <DataProvider name="catalogSearchData" data={catalogSearchData}>
         <div className={className} data-ep-catalog-search-provider="">

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPClearRefinements.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPClearRefinements.tsx
@@ -38,6 +38,7 @@ interface EPClearRefinementsActions {
 export const epClearRefinementsMeta: CodeComponentMeta<EPClearRefinementsProps> = {
   name: "plasmic-commerce-ep-clear-refinements",
   displayName: "EP Clear Refinements",
+  section: "EP Catalog Search",
   description:
     "Drops a single button that clears all active filters in one click. Click + disabled state are wired automatically. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCurrentRefinements.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPCurrentRefinements.tsx
@@ -41,6 +41,7 @@ interface EPCurrentRefinementsProps {
 export const epCurrentRefinementsMeta: CodeComponentMeta<EPCurrentRefinementsProps> = {
   name: "plasmic-commerce-ep-current-refinements",
   displayName: "EP Current Refinements",
+  section: "EP Catalog Search",
   description:
     "Chip row showing each active filter. Repeats children per refinement; click dismisses that refinement automatically. Hides itself when no filters are active. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPHierarchicalMenu.tsx
@@ -34,6 +34,7 @@ interface EPHierarchicalMenuActions {
 export const epHierarchicalMenuMeta: CodeComponentMeta<EPHierarchicalMenuProps> = {
   name: "plasmic-commerce-ep-hierarchical-menu",
   displayName: "EP Hierarchical Menu",
+  section: "EP Catalog Search",
   description:
     "Category tree navigation for hierarchical facets. Repeats children per category item with refineCategory action. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRangeFilter.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRangeFilter.tsx
@@ -31,6 +31,7 @@ interface EPRangeFilterActions {
 export const epRangeFilterMeta: CodeComponentMeta<EPRangeFilterProps> = {
   name: "plasmic-commerce-ep-range-filter",
   displayName: "EP Range Filter",
+  section: "EP Catalog Search",
   description:
     "Numeric range filter (price, rating, etc.). Exposes rangeData with min/max for binding. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPRefinementList.tsx
@@ -1,14 +1,19 @@
 /**
- * EPRefinementList — facet filter list for catalog search.
+ * EPRefinementList — multi-select facet filter list for catalog search.
  *
- * Wraps `useRefinementList()` from react-instantsearch. Headless — exposes
- * refinement items for designer to render with any Plasmic elements.
- * Supports toggleRefinement action via refActions.
+ * Wraps `useRefinementList()` from react-instantsearch. Headless — exposes one
+ * refinement item per value to the slot; the designer styles the row. Selecting
+ * a value OR-combines it with the others (a multi-select facet, e.g. Brand,
+ * Color, Material).
  *
- * `singleSelect` switches the backing hook to `useMenu()` for radio-style
- * facets (e.g. a single-choice "scope" filter): selecting a value REPLACES
- * the current refinement instead of OR-combining, and re-selecting the
- * refined value clears it (the "All" affordance).
+ * Auto-wiring (D2, default on) makes each slotted row a toggle button: click +
+ * Enter/Space refine, `aria-pressed`/`[data-active]` reflect the refined state,
+ * all without a `customFunction`. Turn it off (`autoWire={false}`) for
+ * byte-for-byte the prior behaviour — the per-item `toggle` stays on context.
+ *
+ * For radio-style "pick one" facets (a single-choice scope filter), use
+ * EPSingleSelectFacet instead — the per-item context is identical, so slot
+ * content ports across the two.
  */
 
 import {
@@ -21,10 +26,19 @@ import registerComponent, {
 } from "@plasmicapp/host/registerComponent";
 import React, { useImperativeHandle, useMemo } from "react";
 import { Registerable } from "../registerable";
+import { autoWireItem } from "./auto-wire";
 import { MOCK_REFINEMENT_ITEMS } from "./design-time-data";
-import type { RefinementItem } from "./design-time-data";
 
 type PreviewState = "auto" | "withData";
+
+/** Per-item context published to the slot (shared with EPSingleSelectFacet). */
+export interface NormalizedRefinementItem {
+  value: string;
+  label: string;
+  count: number;
+  isRefined: boolean;
+  toggle: () => void;
+}
 
 interface EPRefinementListProps {
   children?: React.ReactNode;
@@ -33,8 +47,7 @@ interface EPRefinementListProps {
   limit?: number;
   showMore?: boolean;
   searchable?: boolean;
-  singleSelect?: boolean;
-  itemGap?: string;
+  autoWire?: boolean;
   className?: string;
   previewState?: PreviewState;
 }
@@ -46,8 +59,9 @@ interface EPRefinementListActions {
 export const epRefinementListMeta: CodeComponentMeta<EPRefinementListProps> = {
   name: "plasmic-commerce-ep-refinement-list",
   displayName: "EP Refinement List",
+  section: "EP Catalog Search",
   description:
-    "Facet filter list (e.g., Brand, Color, Material). Repeats children for each refinement value with toggle action. Must be inside EP Catalog Search Provider.",
+    "Multi-select facet filter (e.g., Brand, Color, Material). Repeats children for each value; clicking a row toggles it (auto-wired by default). For a single-choice scope filter use EP Single Select Facet. Must be inside EP Catalog Search Provider.",
   props: {
     children: {
       type: "slot",
@@ -90,19 +104,12 @@ export const epRefinementListMeta: CodeComponentMeta<EPRefinementListProps> = {
       description: "Allow searching within facet values",
       defaultValue: false,
     },
-    singleSelect: {
+    autoWire: {
       type: "boolean",
-      displayName: "Single Select",
+      displayName: "Auto-wire clicks",
       description:
-        "Radio-style facet: selecting a value replaces the current refinement instead of combining (uses InstantSearch's menu widget). Re-selecting the refined value clears it. Searchable is ignored in this mode.",
-      defaultValue: false,
-    },
-    itemGap: {
-      type: "string",
-      displayName: "Item Gap",
-      description:
-        "Single-select mode lays items out as a wrapping flex ROW (pill style) with this gap. Ignored in multi-select mode (vertical list). Set inline because Plasmic strips layout styles from code-component instances.",
-      defaultValue: "9.5px",
+        "Make each row a toggle button — click/Enter/Space refine, aria-pressed + [data-active] reflect the refined state, no customFunction needed. Turn off to wire $ctx.currentRefinement.toggle() yourself (prior behaviour).",
+      defaultValue: true,
     },
     previewState: {
       type: "choice",
@@ -135,8 +142,7 @@ export const EPRefinementList = React.forwardRef<
     limit = 10,
     showMore = false,
     searchable = false,
-    singleSelect = false,
-    itemGap = "9.5px",
+    autoWire = true,
     className,
     previewState = "auto",
   } = props;
@@ -151,30 +157,10 @@ export const EPRefinementList = React.forwardRef<
         ref={ref}
         className={className}
         label={label}
-        singleSelect={singleSelect}
-        itemGap={itemGap}
+        autoWire={autoWire}
       >
         {children}
       </MockRefinementList>
-    );
-  }
-
-  // Separate inner components — the backing InstantSearch hook differs
-  // (useMenu vs useRefinementList) and hooks cannot be picked conditionally
-  // within one component.
-  if (singleSelect) {
-    return (
-      <EPMenuListInner
-        ref={ref}
-        attribute={attribute || "brand"}
-        label={label}
-        limit={limit}
-        showMore={showMore}
-        itemGap={itemGap}
-        className={className}
-      >
-        {children}
-      </EPMenuListInner>
     );
   }
 
@@ -186,6 +172,7 @@ export const EPRefinementList = React.forwardRef<
       limit={limit}
       showMore={showMore}
       searchable={searchable}
+      autoWire={autoWire}
       className={className}
     >
       {children}
@@ -193,49 +180,76 @@ export const EPRefinementList = React.forwardRef<
   );
 });
 
+/**
+ * Pure presentational render shared by the mock and runtime wrappers (#305
+ * contract, D9): one render path, so the canvas DOM tree matches the browser.
+ */
+function RefinementItems(props: {
+  items: NormalizedRefinementItem[];
+  children?: React.ReactNode;
+  className?: string;
+  label?: string;
+  autoWire: boolean;
+}) {
+  const { items, children, className, label, autoWire } = props;
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className={className} data-ep-refinement-list="" aria-label={label}>
+      <div role="list">
+        {items.map((item, i) => {
+          const content = repeatedElement(i, children);
+          const wired = autoWire
+            ? autoWireItem(content, {
+                onActivate: item.toggle,
+                role: "button",
+                selected: item.isRefined,
+                selectionAttr: "aria-pressed",
+              })
+            : content;
+          return (
+            <div key={item.value} role="listitem">
+              <DataProvider name="currentRefinement" data={item}>
+                <DataProvider name="currentRefinementIndex" data={i}>
+                  {wired}
+                </DataProvider>
+              </DataProvider>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 const MockRefinementList = React.forwardRef<
   EPRefinementListActions,
   {
     children?: React.ReactNode;
     className?: string;
     label?: string;
-    singleSelect?: boolean;
-    itemGap?: string;
+    autoWire: boolean;
   }
->(function MockRefinementList(
-  { children, className, label, singleSelect, itemGap },
-  ref
-) {
+>(function MockRefinementList({ children, className, label, autoWire }, ref) {
   useImperativeHandle(ref, () => ({
     toggleRefinement: () => {},
   }));
 
-  // Mirror the runtime singleSelect layout (EPMenuListInner) so the Studio
-  // canvas matches the browser: a wrapping flex pill-row instead of the
-  // default vertical block list.
-  const listStyle: React.CSSProperties | undefined = singleSelect
-    ? { display: "flex", flexWrap: "wrap", gap: itemGap }
-    : undefined;
+  const items = useMemo<NormalizedRefinementItem[]>(
+    () => MOCK_REFINEMENT_ITEMS.map((item) => ({ ...item, toggle: () => {} })),
+    []
+  );
 
   return (
-    <div
+    <RefinementItems
+      items={items}
       className={className}
-      data-ep-refinement-list=""
-      {...(singleSelect ? { "data-single-select": "" } : {})}
-      aria-label={label}
+      label={label}
+      autoWire={autoWire}
     >
-      <div role="list" style={listStyle}>
-        {MOCK_REFINEMENT_ITEMS.map((item, i) => (
-          <div key={item.value} role="listitem">
-            <DataProvider name="currentRefinement" data={item}>
-              <DataProvider name="currentRefinementIndex" data={i}>
-                {repeatedElement(i, children)}
-              </DataProvider>
-            </DataProvider>
-          </div>
-        ))}
-      </div>
-    </div>
+      {children}
+    </RefinementItems>
   );
 });
 
@@ -248,10 +262,11 @@ const EPRefinementListInner = React.forwardRef<
     limit: number;
     showMore: boolean;
     searchable: boolean;
+    autoWire: boolean;
     className?: string;
   }
 >(function EPRefinementListInner(
-  { children, attribute, label, limit, showMore, searchable, className },
+  { children, attribute, label, limit, showMore, searchable, autoWire, className },
   ref
 ) {
   const { useRefinementList } = require("react-instantsearch");
@@ -266,12 +281,9 @@ const EPRefinementListInner = React.forwardRef<
     toggleRefinement: (value: string) => refine(value),
   }));
 
-  // Expose `toggle` as part of the per-item context so designers can wire
-  // a click in Studio (interaction → customFunction `$ctx.currentRefinement.toggle()`)
-  // without the component pre-rendering a button or <a>. Functions in
-  // DataProvider data are passed through React context untouched, so this
-  // costs nothing for designers who don't use it.
-  const normalizedItems = useMemo(
+  // `toggle` rides along on the per-item context so a designer can wire a click
+  // via customFunction when auto-wiring is off — the Tier-1 escape.
+  const normalizedItems = useMemo<NormalizedRefinementItem[]>(
     () =>
       (items || []).map((item: any) => ({
         value: item.value,
@@ -283,94 +295,15 @@ const EPRefinementListInner = React.forwardRef<
     [items, refine]
   );
 
-  if (normalizedItems.length === 0) return null;
-
   return (
-    <div className={className} data-ep-refinement-list="" aria-label={label}>
-      <div role="list">
-        {normalizedItems.map((item: any, i: number) => (
-          <div key={item.value} role="listitem">
-            <DataProvider name="currentRefinement" data={item}>
-              <DataProvider name="currentRefinementIndex" data={i}>
-                {repeatedElement(i, children)}
-              </DataProvider>
-            </DataProvider>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-});
-
-const EPMenuListInner = React.forwardRef<
-  EPRefinementListActions,
-  {
-    children?: React.ReactNode;
-    attribute: string;
-    label?: string;
-    limit: number;
-    showMore: boolean;
-    itemGap?: string;
-    className?: string;
-  }
->(function EPMenuListInner(
-  { children, attribute, label, limit, showMore, itemGap, className },
-  ref
-) {
-  const { useMenu } = require("react-instantsearch");
-  const { items, refine } = useMenu({
-    attribute,
-    limit,
-    showMore,
-    // Highest-count value first (e.g. the largest scope before smaller
-    // ones); name breaks ties deterministically.
-    sortBy: ["count:desc", "name:asc"],
-  });
-
-  useImperativeHandle(ref, () => ({
-    toggleRefinement: (value: string) => refine(value),
-  }));
-
-  // Same per-item shape as the multi-select path (value/label/count/
-  // isRefined/toggle) so designs can switch modes without rebinding.
-  const normalizedItems = useMemo(
-    () =>
-      (items || []).map((item: any) => ({
-        value: item.value,
-        label: item.label,
-        count: item.count,
-        isRefined: item.isRefined,
-        toggle: () => refine(item.value),
-      })),
-    [items, refine]
-  );
-
-  if (normalizedItems.length === 0) return null;
-
-  return (
-    <div
+    <RefinementItems
+      items={normalizedItems}
       className={className}
-      data-ep-refinement-list=""
-      data-single-select=""
-      aria-label={label}
+      label={label}
+      autoWire={autoWire}
     >
-      {/* Inline flex-row — Plasmic strips layout styles from code-component
-          instances, so the pill row is laid out here (gap via itemGap). */}
-      <div
-        role="list"
-        style={{ display: "flex", flexWrap: "wrap", gap: itemGap }}
-      >
-        {normalizedItems.map((item: any, i: number) => (
-          <div key={item.value} role="listitem">
-            <DataProvider name="currentRefinement" data={item}>
-              <DataProvider name="currentRefinementIndex" data={i}>
-                {repeatedElement(i, children)}
-              </DataProvider>
-            </DataProvider>
-          </div>
-        ))}
-      </div>
-    </div>
+      {children}
+    </RefinementItems>
   );
 });
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocomplete.tsx
@@ -64,6 +64,7 @@ export const epSearchAutocompleteMeta: CodeComponentMeta<EPSearchAutocompletePro
   {
     name: "plasmic-commerce-ep-search-autocomplete",
     displayName: "EP Search Autocomplete",
+    section: "EP Catalog Search",
     description:
       "Provider for query-suggestion autocomplete, sourced from EP catalog-search's autocomplete endpoint. Compose with EP Search Autocomplete Input, Panel, and List children. Must be inside EP Catalog Search Provider.",
     props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteInput.tsx
@@ -42,6 +42,7 @@ export const epSearchAutocompleteInputMeta: CodeComponentMeta<EPSearchAutocomple
   {
     name: "plasmic-commerce-ep-search-autocomplete-input",
     displayName: "EP Search Autocomplete Input",
+    section: "EP Catalog Search",
     description:
       "Input bridge for EP Search Autocomplete. Drop a Plasmic <input> into the slot and this component spreads value + onChange + keyboard handlers automatically. Must be inside EP Search Autocomplete.",
     props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompleteList.tsx
@@ -42,6 +42,7 @@ export const epSearchAutocompleteListMeta: CodeComponentMeta<EPSearchAutocomplet
   {
     name: "plasmic-commerce-ep-search-autocomplete-list",
     displayName: "EP Search Autocomplete List",
+    section: "EP Catalog Search",
     description:
       "Repeats children once per autocomplete suggestion item. Click handlers and ARIA semantics are wired automatically. Use `sourceId` to scope the list to a single named source. Per-iteration $ctx.currentSuggestion exposes the item, isHighlighted, and source. Must be inside EP Search Autocomplete.",
     props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchAutocompletePanel.tsx
@@ -55,6 +55,7 @@ export const epSearchAutocompletePanelMeta: CodeComponentMeta<EPSearchAutocomple
   {
     name: "plasmic-commerce-ep-search-autocomplete-panel",
     displayName: "EP Search Autocomplete Panel",
+    section: "EP Catalog Search",
     description:
       "Panel wrapper for the autocomplete dropdown. In Studio, opens when selected; closed otherwise so it doesn't cover surrounding page content. Hosts the mobile close button (hidden on desktop via media query). Must be inside EP Search Autocomplete.",
     props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchBox.tsx
@@ -53,6 +53,7 @@ interface EPSearchBoxActions {
 export const epSearchBoxMeta: CodeComponentMeta<EPSearchBoxProps> = {
   name: "plasmic-commerce-ep-search-box",
   displayName: "EP Search Box",
+  section: "EP Catalog Search",
   description:
     "Search field provider. Drops a Plasmic input and clear button into the slot, bind them to $ctx.searchFieldData (value, displayValue, isEmpty) and the setValue/clear ref-actions. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchEmpty.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchEmpty.tsx
@@ -45,6 +45,7 @@ interface EPSearchEmptyProps {
 export const epSearchEmptyMeta: CodeComponentMeta<EPSearchEmptyProps> = {
   name: "plasmic-commerce-ep-search-empty",
   displayName: "EP Search Empty",
+  section: "EP Catalog Search",
   description:
     "Shown when a search returns zero results. Stays hidden during the initial load and during error states; only renders after a real response with no hits. Wire `dataCond: $ctx.searchStatsData.nbHits > 0` on EP Search Stats / Pagination if you want them hidden alongside it. Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchHits.tsx
@@ -1,12 +1,26 @@
 /**
  * EPSearchHits — repeater for catalog search results.
  *
- * Wraps `useHits()` from react-instantsearch and normalizes each hit to
- * the unified `currentProduct` shape used by EPProductGrid (per D2/D4).
- * Designers can reuse the same card layouts across listing and search.
+ * Wraps `useHits()` from react-instantsearch and normalizes each hit through
+ * the shared `normalizeSearchHit` (ADR-0011 D7) to the unified `currentProduct`
+ * shape used across the PDP and EPProductGrid. Designers reuse the same card
+ * layouts and the same field components across listing and search.
  *
- * Search-specific extras (_highlightedName, _highlightedDescription, _score,
- * rawHit) are also available for advanced use.
+ * Per hit it publishes the tiered, progressively-disclosed data surface:
+ *   - Tier 0 — drop an `EPProductField` and pick a field from the dropdown
+ *     (resolves here via the `currentProduct.rawData` bridge).
+ *   - Tier 1 — `$ctx.currentProduct.fields.<key>`, the slug-free flattening of
+ *     the configured `primaryExtensionTemplate` (discoverable, null-safe).
+ *   - Tier 2 — `$ctx.productExtensions["<slug>"].field`, the ADR-0007 slug-keyed
+ *     Proxy map, scoped per hit.
+ *   - Tier 3 — raw `currentProduct.extensions` / `currentProduct.rawData`.
+ *
+ * Search-specific extras (`_highlightedName`, `_snippetedDescription`, `_score`,
+ * `rawHit`) ride along on `currentProduct` for advanced use.
+ *
+ * The mock (canvas) and runtime paths share one presentational render
+ * (`HitsList`) fed `NormalizedHit[]` — the data wrapper above owns the
+ * InstantSearch hook, the inner is pure (#305 headless styling contract, D9).
  */
 
 import {
@@ -20,9 +34,13 @@ import registerComponent, {
 } from "@plasmicapp/host/registerComponent";
 import React, { useMemo } from "react";
 import { Registerable } from "../registerable";
-import { formatCurrency } from "../utils/formatCurrency";
 import { MOCK_SEARCH_PRODUCTS } from "./design-time-data";
 import { MOCK_EXTENSIONS_RAW } from "../utils/extensions-mock";
+import {
+  DEFAULT_PRODUCT_PATH_PREFIX,
+  normalizeSearchHit,
+} from "../utils/normalize-hit";
+import type { NormalizedHit } from "../utils/normalize-hit";
 import type { Product } from "../types/product";
 
 type PreviewState = "auto" | "withData";
@@ -48,11 +66,8 @@ function buildHitsGridStyle(
   };
 }
 
-const DEFAULT_GRID_TEMPLATE_COLUMNS =
-  "repeat(auto-fill, minmax(220px, 1fr))";
+const DEFAULT_GRID_TEMPLATE_COLUMNS = "repeat(auto-fill, minmax(220px, 1fr))";
 const DEFAULT_GRID_GAP = "24px";
-
-const DEFAULT_PRODUCT_PATH_PREFIX = "/product";
 
 interface EPSearchHitsProps {
   children?: React.ReactNode;
@@ -60,226 +75,70 @@ interface EPSearchHitsProps {
   gridTemplateColumns?: string;
   gridGap?: string;
   productPathPrefix?: string;
+  primaryExtensionTemplate?: string;
   previewState?: PreviewState;
 }
 
 /**
- * Normalize an InstantSearch hit to the unified currentProduct shape.
- * The EP catalog search adapter surfaces various field name conventions;
- * this function tries multiple patterns.
+ * Build a search-hit-shaped record from a design-time mock Product so the
+ * canvas runs through the *same* `normalizeSearchHit` as runtime (mock == runtime
+ * shape, D9). Carries the shared mock extensions so the Tier-1 `fields` and the
+ * Tier-2 map populate when authoring hit cards in the canvas.
  */
-function normalizeHitToCurrentProduct(
-  hit: Record<string, any>,
-  currencyCode: string,
-  productPathPrefix: string = DEFAULT_PRODUCT_PATH_PREFIX
-) {
-  const name = hit.ep_name || hit.name || hit.attributes?.name || "";
-  const slug =
-    hit.ep_slug || hit.slug || hit.attributes?.slug || "";
-  const sku = hit.ep_sku || hit.sku || hit.attributes?.sku || "";
-  const description =
-    hit.ep_description ||
-    hit.description ||
-    hit.attributes?.description ||
-    "";
-
-  // Image: prefer the inlined `main_image` record that EPCatalogSearchProvider
-  // requests via `include: ["main_image"]` (adapter v0.1.0+ resolves the
-  // included block against each hit's relationship reference). Fallbacks
-  // cover catalogs that already denormalize a URL onto the hit root.
-  const imageUrl =
-    hit.main_image?.link?.href ||
-    hit.ep_main_image?.link?.href ||
-    hit.ep_main_image_url ||
-    hit.main_image_url ||
-    "";
-
-  // 1x1 transparent gif — keeps the <img src> attribute non-empty so the
-  // browser doesn't issue a self-referential request (and React's
-  // empty-string warning stays silent) while letting the surrounding
-  // styles render the visual placeholder.
-  const TRANSPARENT_PIXEL =
-    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-
-  // Price resolution — EP catalog search exposes prices in two shapes
-  // depending on catalog config:
-  //   1. `meta.display_price.without_tax`  → preferred; pre-formatted, currency-aware
-  //   2. `attributes.price[CURRENCY].amount` (in cents) → raw fallback
-  // We also keep the older `ep_price` / `price` paths for back-compat with
-  // search backends that flatten the price object onto the hit root.
-  const displayPrice =
-    hit.meta?.display_price?.without_tax ||
-    hit.meta?.display_price?.with_tax ||
-    null;
-  const attrPriceObj =
-    hit.attributes?.price?.[currencyCode] ||
-    hit.attributes?.price?.USD ||
-    null;
-  const flatPriceObj =
-    hit.ep_price?.[currencyCode] ||
-    hit.price?.[currencyCode] ||
-    hit.ep_price?.USD ||
-    hit.price?.USD ||
-    null;
-  const priceValue =
-    displayPrice?.float_price ??
-    flatPriceObj?.float_price ??
-    flatPriceObj?.amount ??
-    (attrPriceObj?.amount != null ? attrPriceObj.amount / 100 : undefined) ??
-    hit.price?.value ??
-    0;
-  const priceCurrency = displayPrice?.currency || currencyCode || "USD";
-  const formatted =
-    displayPrice?.formatted || formatCurrency(priceValue, priceCurrency);
-
-  // Highlight results from InstantSearch.
-  //
-  // The EP catalog-search backend keys highlights by the BARE query_by field
-  // names (`name`, `description`) while the document nests them under
-  // `attributes.…` — the adapter's document-driven highlight walk therefore
-  // drops them from `_highlightResult`/`_snippetResult`. Recover from the
-  // raw Typesense hit (`highlight.<field>.{value,snippet}`), keeping the
-  // adapter paths as fallbacks for backends where they do line up.
-  const highlighted = hit._highlightResult || hit._highlight || {};
-  const snippeted = hit._snippetResult || {};
-  const rawHighlight = hit._rawTypesenseHit?.highlight || {};
-  const highlightedName =
-    rawHighlight.name?.value ||
-    rawHighlight.name?.snippet ||
-    highlighted.ep_name?.value ||
-    highlighted.name?.value ||
-    highlighted.attributes?.name?.value ||
-    undefined;
-  const highlightedDescription =
-    rawHighlight.description?.value ||
-    highlighted.ep_description?.value ||
-    highlighted.description?.value ||
-    highlighted.attributes?.description?.value ||
-    undefined;
-  // Snippet = the shortened, `<mark>`-highlighted excerpt Typesense builds
-  // for long fields (e.g. a description/abstract snippet on a hit card).
-  const snippetedDescription =
-    rawHighlight.description?.snippet ||
-    snippeted.description?.value ||
-    snippeted.attributes?.description?.value ||
-    undefined;
-
-  // Template extensions — the catalog-search document carries the same
-  // `attributes.extensions` block as the shopper product API. Expose it
-  //   1. resolved on `extensions` for direct bindings
-  //      (`currentProduct.extensions["products(…)"].field`), and
-  //   2. under `rawData.data` so the PDP field components
-  //      (EPProductField / EPProductExtensionValue, which read
-  //      `rawData.data.attributes.extensions`) work inside hit cards
-  //      unchanged.
-  const extensions: Record<string, unknown> =
-    hit.attributes?.extensions || hit.extensions || {};
-
-  // Strip the trailing slash so both "/product" and "/product/" work.
-  const pathPrefix = (productPathPrefix || DEFAULT_PRODUCT_PATH_PREFIX).replace(
-    /\/+$/,
-    ""
-  );
-
+function mockProductToHit(product: Product): Record<string, any> {
   return {
-    id: hit.objectID || hit.id || "",
-    name,
-    slug,
-    sku,
-    description,
-    // PDP route — configurable via the `productPathPrefix` prop so storefronts
-    // with a different route shape (e.g. `/products`, `/en/products`) link
-    // correctly. Falls back to an id-based URL when the hit lacks a slug.
-    path: `${pathPrefix}/${slug || hit.objectID || hit.id || ""}`,
-    images: [
-      {
-        url: imageUrl || TRANSPARENT_PIXEL,
-        alt: name,
+    objectID: product.id,
+    attributes: {
+      name: product.name,
+      slug: product.slug ?? "",
+      sku: product.sku ?? "",
+      description: product.description,
+      extensions: MOCK_EXTENSIONS_RAW,
+    },
+    main_image: { link: { href: product.images[0]?.url } },
+    meta: {
+      display_price: {
+        without_tax: {
+          float_price: product.price.value,
+          currency: product.price.currencyCode ?? "USD",
+        },
       },
-    ],
-    price: {
-      value: priceValue,
-      currencyCode: priceCurrency,
-      formatted,
     },
-    options: [] as Array<{ displayName: string; values: Array<{ label: string }> }>,
-    extensions,
-    // The search document has the shopper-product shape ({attributes, id,
-    // meta, …}), so wrapping it as `{ data: hit }` matches the PDP's
-    // `rawData` contract (see extractRawExtensions in
-    // product-extensions/composable/format.ts).
-    rawData: { data: hit },
-    _highlightedName: highlightedName,
-    _highlightedDescription: highlightedDescription,
-    _snippetedDescription: snippetedDescription,
-    _score: hit._score ?? hit._rankingInfo?.relevance ?? undefined,
-    rawHit: hit,
-  };
-}
-
-/**
- * Build currentProduct from mock Product (design-time).
- */
-function buildMockCurrentProduct(
-  product: Product,
-  productPathPrefix: string = DEFAULT_PRODUCT_PATH_PREFIX
-) {
-  const currencyCode = product.price.currencyCode ?? "USD";
-  const formatted = formatCurrency(product.price.value, currencyCode);
-  const pathPrefix = (productPathPrefix || DEFAULT_PRODUCT_PATH_PREFIX).replace(
-    /\/+$/,
-    ""
-  );
-  // Same mock extensions as the PDP field components, so the cascading
-  // template/field dropdowns populate when authoring hit cards in the canvas.
-  const extensions = MOCK_EXTENSIONS_RAW;
-
-  return {
-    id: product.id,
-    name: product.name,
-    slug: product.slug ?? "",
-    sku: product.sku ?? "",
-    description: product.description,
-    path: product.path ?? `${pathPrefix}/${product.slug ?? ""}`,
-    images: product.images,
-    price: {
-      value: product.price.value,
-      currencyCode,
-      formatted,
-    },
-    options: product.options.map((opt) => ({
-      displayName: opt.displayName,
-      values: opt.values.map((v) => ({ label: v.label })),
-    })),
-    extensions,
-    rawData: { data: { attributes: { extensions } } },
-    _highlightedName: undefined,
-    _highlightedDescription: undefined,
-    _snippetedDescription: undefined,
-    _score: undefined,
-    rawHit: {},
   };
 }
 
 export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
   name: "plasmic-commerce-ep-search-hits",
   displayName: "EP Search Hits",
+  section: "EP Catalog Search",
   description:
-    "Repeats children for each search result. Exposes currentProduct (same shape as EP Product Grid) plus search-specific extras. Must be inside EP Catalog Search Provider.",
+    "Repeats children for each search result. Exposes currentProduct (same shape as the PDP) — drop EP Product Field, bind currentProduct.fields.<key>, or use $ctx.productExtensions — plus search extras. Must be inside EP Catalog Search Provider.",
   props: {
     children: {
       type: "slot",
+      // Batteries-included but unstyled (D8): a working card built from the
+      // Tier-0 field components. Renders against mock data with zero bindings,
+      // so a designer styles up from a correct structure. `highlight: auto`
+      // shows the <mark>-matched name/abstract in a real search hit.
       defaultValue: [
         {
           type: "vbox",
+          styles: { alignItems: "flex-start", gap: "4px" },
           children: [
             {
-              type: "text",
-              value: "Product Name",
+              type: "component",
+              name: "plasmic-commerce-ep-product-field",
+              props: { field: "name", highlight: "auto" },
             },
             {
-              type: "text",
-              value: "$0.00",
+              type: "component",
+              name: "plasmic-commerce-ep-product-field",
+              props: { field: "description", highlight: "auto" },
+            },
+            {
+              type: "component",
+              name: "plasmic-commerce-ep-product-field",
+              props: { field: "price" },
             },
           ],
         },
@@ -305,6 +164,13 @@ export const epSearchHitsMeta: CodeComponentMeta<EPSearchHitsProps> = {
         "Route prefix used to build each hit's currentProduct.path link (prefix + '/' + slug). Set this to match the storefront's PDP route, e.g. \"/products\".",
       defaultValue: DEFAULT_PRODUCT_PATH_PREFIX,
     },
+    primaryExtensionTemplate: {
+      type: "string",
+      displayName: "Primary Extension Template",
+      description:
+        'Raw template slug (e.g. "products(iso-standard)") whose fields flatten onto the discoverable, slug-free $ctx.currentProduct.fields.<key> namespace. Leave empty to skip — the slug-keyed $ctx.productExtensions map and raw extensions are always available.',
+      defaultValue: "",
+    },
     previewState: {
       type: "choice",
       options: ["auto", "withData"],
@@ -326,6 +192,7 @@ export function EPSearchHits(props: EPSearchHitsProps) {
     gridTemplateColumns = DEFAULT_GRID_TEMPLATE_COLUMNS,
     gridGap = DEFAULT_GRID_GAP,
     productPathPrefix = DEFAULT_PRODUCT_PATH_PREFIX,
+    primaryExtensionTemplate = "",
     previewState = "auto",
   } = props;
 
@@ -341,6 +208,7 @@ export function EPSearchHits(props: EPSearchHitsProps) {
         className={className}
         gridStyle={gridStyle}
         productPathPrefix={productPathPrefix}
+        primaryExtensionTemplate={primaryExtensionTemplate}
       >
         {children}
       </MockSearchHits>
@@ -352,29 +220,23 @@ export function EPSearchHits(props: EPSearchHitsProps) {
       className={className}
       gridStyle={gridStyle}
       productPathPrefix={productPathPrefix}
+      primaryExtensionTemplate={primaryExtensionTemplate}
     >
       {children}
     </EPSearchHitsInner>
   );
 }
 
-function MockSearchHits(props: {
+/** Pure presentational render shared by the mock and runtime data wrappers. */
+function HitsList(props: {
+  items: NormalizedHit[];
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
-  productPathPrefix?: string;
 }) {
-  const { children, className, gridStyle, productPathPrefix } = props;
+  const { items, children, className, gridStyle } = props;
 
-  const products = useMemo(
-    () =>
-      MOCK_SEARCH_PRODUCTS.map((p) =>
-        buildMockCurrentProduct(p, productPathPrefix)
-      ),
-    [productPathPrefix]
-  );
-
-  if (products.length === 0) return null;
+  if (items.length === 0) return null;
 
   return (
     <div
@@ -384,11 +246,13 @@ function MockSearchHits(props: {
       data-ep-search-hits=""
       style={gridStyle}
     >
-      {products.map((product, i) => (
-        <div key={product.id} role="listitem">
+      {items.map(({ product, extensionsMap }, i) => (
+        <div key={product.id || i} role="listitem">
           <DataProvider name="currentProduct" data={product}>
-            <DataProvider name="currentProductIndex" data={i}>
-              {repeatedElement(i, children)}
+            <DataProvider name="productExtensions" data={extensionsMap}>
+              <DataProvider name="currentProductIndex" data={i}>
+                {repeatedElement(i, children)}
+              </DataProvider>
             </DataProvider>
           </DataProvider>
         </div>
@@ -397,17 +261,57 @@ function MockSearchHits(props: {
   );
 }
 
+function MockSearchHits(props: {
+  children?: React.ReactNode;
+  className?: string;
+  gridStyle: React.CSSProperties;
+  productPathPrefix: string;
+  primaryExtensionTemplate: string;
+}) {
+  const {
+    children,
+    className,
+    gridStyle,
+    productPathPrefix,
+    primaryExtensionTemplate,
+  } = props;
+
+  const items = useMemo(
+    () =>
+      MOCK_SEARCH_PRODUCTS.map((p) =>
+        normalizeSearchHit(
+          mockProductToHit(p),
+          p.price.currencyCode ?? "USD",
+          { productPathPrefix, primaryExtensionTemplate }
+        )
+      ),
+    [productPathPrefix, primaryExtensionTemplate]
+  );
+
+  return (
+    <HitsList items={items} className={className} gridStyle={gridStyle}>
+      {children}
+    </HitsList>
+  );
+}
+
 function EPSearchHitsInner(props: {
   children?: React.ReactNode;
   className?: string;
   gridStyle: React.CSSProperties;
-  productPathPrefix?: string;
+  productPathPrefix: string;
+  primaryExtensionTemplate: string;
 }) {
-  const { children, className, gridStyle, productPathPrefix } = props;
+  const {
+    children,
+    className,
+    gridStyle,
+    productPathPrefix,
+    primaryExtensionTemplate,
+  } = props;
 
-  const { useHits, useInstantSearch } = require("react-instantsearch");
+  const { useHits } = require("react-instantsearch");
   const { hits } = useHits();
-  const { indexUiState } = useInstantSearch();
 
   // Read currencyCode from parent EPCatalogSearchProvider's DataProvider context
   const catalogSearchData = useSelector("catalogSearchData") as
@@ -415,36 +319,21 @@ function EPSearchHitsInner(props: {
     | undefined;
   const currencyCode = catalogSearchData?.currencyCode || "USD";
 
-  const normalizedProducts = useMemo(
+  const items = useMemo(
     () =>
       (hits || []).map((hit: Record<string, any>) =>
-        normalizeHitToCurrentProduct(hit, currencyCode, productPathPrefix)
+        normalizeSearchHit(hit, currencyCode, {
+          productPathPrefix,
+          primaryExtensionTemplate,
+        })
       ),
-    [hits, currencyCode, productPathPrefix]
+    [hits, currencyCode, productPathPrefix, primaryExtensionTemplate]
   );
 
-  if (normalizedProducts.length === 0) return null;
-
   return (
-    <div
-      className={className}
-      role="list"
-      aria-label="Search results"
-      data-ep-search-hits=""
-      style={gridStyle}
-    >
-      {normalizedProducts.map(
-        (product: ReturnType<typeof normalizeHitToCurrentProduct>, i: number) => (
-          <div key={product.id || i} role="listitem">
-            <DataProvider name="currentProduct" data={product}>
-              <DataProvider name="currentProductIndex" data={i}>
-                {repeatedElement(i, children)}
-              </DataProvider>
-            </DataProvider>
-          </div>
-        )
-      )}
-    </div>
+    <HitsList items={items} className={className} gridStyle={gridStyle}>
+      {children}
+    </HitsList>
   );
 }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchPagination.tsx
@@ -13,12 +13,16 @@ import React, { useCallback, useImperativeHandle } from "react";
 import { Registerable } from "../registerable";
 import { MOCK_SEARCH_PAGINATION_DATA } from "./design-time-data";
 import type { SearchPaginationData } from "./design-time-data";
+import { buildPageItems } from "./pagination-window";
 
 type PreviewState = "auto" | "withData";
+
+const DEFAULT_WINDOW_SIZE = 7;
 
 interface EPSearchPaginationProps {
   children?: React.ReactNode;
   className?: string;
+  windowSize?: number;
   previewState?: PreviewState;
 }
 
@@ -31,8 +35,9 @@ interface EPSearchPaginationActions {
 export const epSearchPaginationMeta: CodeComponentMeta<EPSearchPaginationProps> = {
   name: "plasmic-commerce-ep-search-pagination",
   displayName: "EP Search Pagination",
+  section: "EP Catalog Search",
   description:
-    "Pagination provider. Drops a Prev button, page-indicator text, and Next button into the slot. Bind text to $ctx.searchPaginationData (currentPage, totalPages, hasNext, hasPrev) and wire button onClick to the prevPage/nextPage ref-actions; hide buttons when !hasPrev / !hasNext. Must be inside EP Catalog Search Provider.",
+    "Pagination provider. Drops a Prev button, page-indicator text, and Next button into the slot. Bind text to $ctx.searchPaginationData (currentPage, totalPages, hasNext, hasPrev) and wire button onClick to the prevPage/nextPage ref-actions; hide buttons when !hasPrev / !hasNext. For a numbered pager, dataRep over $ctx.searchPaginationData.pageItems (windowed, with ellipsis + each item's bound goTo). Must be inside EP Catalog Search Provider.",
   props: {
     children: {
       type: "slot",
@@ -60,6 +65,13 @@ export const epSearchPaginationMeta: CodeComponentMeta<EPSearchPaginationProps> 
           ],
         },
       ],
+    },
+    windowSize: {
+      type: "number",
+      displayName: "Window Size",
+      description:
+        "How many numbered page links to show around the current page in pageItems (first/last pages are always anchored, with ellipsis sentinels for the gaps).",
+      defaultValue: DEFAULT_WINDOW_SIZE,
     },
     previewState: {
       type: "choice",
@@ -93,7 +105,12 @@ export const EPSearchPagination = React.forwardRef<
   EPSearchPaginationActions,
   EPSearchPaginationProps
 >(function EPSearchPagination(props, ref) {
-  const { children, className, previewState = "auto" } = props;
+  const {
+    children,
+    className,
+    windowSize = DEFAULT_WINDOW_SIZE,
+    previewState = "auto",
+  } = props;
 
   const inEditor = !!usePlasmicCanvasContext();
   const useMock =
@@ -108,7 +125,11 @@ export const EPSearchPagination = React.forwardRef<
   }
 
   return (
-    <EPSearchPaginationInner ref={ref} className={className}>
+    <EPSearchPaginationInner
+      ref={ref}
+      className={className}
+      windowSize={windowSize}
+    >
       {children}
     </EPSearchPaginationInner>
   );
@@ -138,8 +159,8 @@ const MockSearchPagination = React.forwardRef<
 
 const EPSearchPaginationInner = React.forwardRef<
   EPSearchPaginationActions,
-  { children?: React.ReactNode; className?: string }
->(function EPSearchPaginationInner({ children, className }, ref) {
+  { children?: React.ReactNode; className?: string; windowSize: number }
+>(function EPSearchPaginationInner({ children, className, windowSize }, ref) {
   const { usePagination } = require("react-instantsearch");
   const {
     currentRefinement,
@@ -148,7 +169,7 @@ const EPSearchPaginationInner = React.forwardRef<
     refine,
     isFirstPage,
     isLastPage,
-  } = usePagination();
+  } = usePagination({ padding: Math.max(0, Math.floor((windowSize - 1) / 2)) });
 
   const handleGoToPage = useCallback(
     (page: number) => {
@@ -186,6 +207,8 @@ const EPSearchPaginationInner = React.forwardRef<
     hasNext: !isLastPage,
     hasPrev: !isFirstPage,
     pages,
+    // Windowed page-item model (D4) — each item carries its own bound goTo.
+    pageItems: buildPageItems(pages, nbPages, currentRefinement, handleGoToPage),
     goTo: handleGoToPage,
     next: handleNextPage,
     prev: handlePrevPage,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchSortBy.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchSortBy.tsx
@@ -60,6 +60,7 @@ interface EPSearchSortByActions {
 export const epSearchSortByMeta: CodeComponentMeta<EPSearchSortByProps> = {
   name: "plasmic-commerce-ep-search-sort-by",
   displayName: "EP Search Sort By",
+  section: "EP Catalog Search",
   description:
     "Sort order selector for catalog search. Must be inside EP Catalog Search Provider. Bind a <select> in the slot to $ctx.sortByData and wire onChange to the setSort ref-action.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchStats.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSearchStats.tsx
@@ -25,6 +25,7 @@ interface EPSearchStatsProps {
 export const epSearchStatsMeta: CodeComponentMeta<EPSearchStatsProps> = {
   name: "plasmic-commerce-ep-search-stats",
   displayName: "EP Search Stats",
+  section: "EP Catalog Search",
   description:
     "Exposes search statistics (result count, query, processing time). Must be inside EP Catalog Search Provider.",
   props: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSingleSelectFacet.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/EPSingleSelectFacet.tsx
@@ -1,0 +1,421 @@
+/**
+ * EPSingleSelectFacet — radio-style "pick one" facet for catalog search
+ * (ADR-0011 D5).
+ *
+ * Wraps `useMenu()` from react-instantsearch: selecting a value REPLACES the
+ * current refinement (single choice) instead of OR-combining, and re-selecting
+ * the refined value clears it. This is the split-out of EPRefinementList's old
+ * `singleSelect` flag — a dedicated component (radiogroup a11y, replace
+ * semantics, the accreting All-option concern) rather than a flag where half
+ * the sibling props no-op (the SwiftUI "compose, don't enumerate" anti-pattern,
+ * and the house precedent of ADR-0005's EPVariationOptionList split).
+ *
+ * The per-item context is identical to EPRefinementList's
+ * (`value`/`label`/`count`/`isRefined`/`toggle`), so slot content ports across
+ * a mode change — plus `isAllOption` to style the "All" affordance.
+ *
+ * Auto-wiring (D2, default on) makes each row a radio: click/Enter/Space
+ * select, `aria-checked`/`[data-active]` reflect the state. Off → wire
+ * `$ctx.currentRefinement.toggle()` yourself.
+ *
+ * `includeAllOption` (D6, default off) prepends an "All" pseudo-item that is
+ * refined when nothing is refined and clears the facet when chosen — so a
+ * scope bar needs neither a second `EPClearRefinements` component nor an
+ * `isRefined` ternary.
+ */
+
+import {
+  DataProvider,
+  repeatedElement,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useImperativeHandle, useMemo } from "react";
+import { Registerable } from "../registerable";
+import { autoWireItem } from "./auto-wire";
+import { MOCK_REFINEMENT_ITEMS } from "./design-time-data";
+
+type PreviewState = "auto" | "withData";
+
+/** Per-item context — the EPRefinementList shape plus the All-option flag. */
+export interface SingleSelectFacetItem {
+  value: string;
+  label: string;
+  count?: number;
+  isRefined: boolean;
+  toggle: () => void;
+  /** True for the synthetic "All" pseudo-item (D6). */
+  isAllOption: boolean;
+}
+
+interface EPSingleSelectFacetProps {
+  children?: React.ReactNode;
+  attribute?: string;
+  label?: string;
+  limit?: number;
+  showMore?: boolean;
+  includeAllOption?: boolean;
+  allOptionLabel?: string;
+  autoWire?: boolean;
+  itemGap?: string;
+  className?: string;
+  previewState?: PreviewState;
+}
+
+interface EPSingleSelectFacetActions {
+  /** Select a value (replace semantics). */
+  select(value: string): void;
+  /** Clear the facet (the "All" affordance). */
+  clear(): void;
+}
+
+export const epSingleSelectFacetMeta: CodeComponentMeta<EPSingleSelectFacetProps> =
+  {
+    name: "plasmic-commerce-ep-single-select-facet",
+    displayName: "EP Single Select Facet",
+    section: "EP Catalog Search",
+    description:
+      "Radio-style 'pick one' facet (e.g. a scope filter). Selecting a value replaces the current choice; re-selecting clears it. Repeats children per value with auto-wired radio semantics. Enable Include All Option for a built-in 'All' pill. Must be inside EP Catalog Search Provider.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          {
+            type: "hbox",
+            children: [
+              { type: "text", value: "Option" },
+              { type: "text", value: "(0)" },
+            ],
+          },
+        ],
+      },
+      attribute: {
+        type: "string",
+        displayName: "Attribute",
+        description: "Facet attribute name to pick one value from.",
+        defaultValue: "brand",
+      },
+      label: {
+        type: "string",
+        displayName: "Label",
+        description: "Accessible label for the radio group.",
+      },
+      limit: {
+        type: "number",
+        displayName: "Limit",
+        description: "Maximum number of values to show.",
+        defaultValue: 10,
+      },
+      showMore: {
+        type: "boolean",
+        displayName: "Show More",
+        description: "Allow expanding beyond limit.",
+        defaultValue: false,
+      },
+      includeAllOption: {
+        type: "boolean",
+        displayName: "Include All Option",
+        description:
+          'Prepend an "All" pseudo-item: refined when nothing is refined, clears the facet when chosen. Style it via $ctx.currentRefinement.isAllOption. Off keeps the values-only list.',
+        defaultValue: false,
+      },
+      allOptionLabel: {
+        type: "string",
+        displayName: "All Option Label",
+        description: 'Label for the All pseudo-item.',
+        defaultValue: "All",
+      },
+      autoWire: {
+        type: "boolean",
+        displayName: "Auto-wire clicks",
+        description:
+          "Make each row a radio — click/Enter/Space select, aria-checked + [data-active] reflect the state, no customFunction. Off → wire $ctx.currentRefinement.toggle() yourself.",
+        defaultValue: true,
+      },
+      itemGap: {
+        type: "string",
+        displayName: "Item Gap",
+        description:
+          "Items lay out as a wrapping flex ROW (pill style) with this gap. Set inline because Plasmic strips layout styles from code-component instances.",
+        defaultValue: "9.5px",
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "withData"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        advanced: true,
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPSingleSelectFacet",
+    parentComponentName: "plasmic-commerce-ep-catalog-search-provider",
+    providesData: true,
+    refActions: {
+      select: {
+        description: "Select a value (replace semantics)",
+        argTypes: [{ name: "value", type: "string" }],
+      },
+      clear: {
+        description: "Clear the facet (the All affordance)",
+        argTypes: [],
+      },
+    },
+  };
+
+export const EPSingleSelectFacet = React.forwardRef<
+  EPSingleSelectFacetActions,
+  EPSingleSelectFacetProps
+>(function EPSingleSelectFacet(props, ref) {
+  const {
+    children,
+    attribute,
+    label,
+    limit = 10,
+    showMore = false,
+    includeAllOption = false,
+    allOptionLabel = "All",
+    autoWire = true,
+    itemGap = "9.5px",
+    className,
+    previewState = "auto",
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const useMock =
+    previewState === "withData" || (previewState === "auto" && inEditor);
+
+  if (useMock) {
+    return (
+      <MockSingleSelectFacet
+        ref={ref}
+        className={className}
+        label={label}
+        includeAllOption={includeAllOption}
+        allOptionLabel={allOptionLabel}
+        autoWire={autoWire}
+        itemGap={itemGap}
+      >
+        {children}
+      </MockSingleSelectFacet>
+    );
+  }
+
+  return (
+    <EPSingleSelectFacetInner
+      ref={ref}
+      attribute={attribute || "brand"}
+      label={label}
+      limit={limit}
+      showMore={showMore}
+      includeAllOption={includeAllOption}
+      allOptionLabel={allOptionLabel}
+      autoWire={autoWire}
+      itemGap={itemGap}
+      className={className}
+    >
+      {children}
+    </EPSingleSelectFacetInner>
+  );
+});
+
+/** Prepend the synthetic "All" pseudo-item (D6) when requested. */
+function withAllOption(
+  items: SingleSelectFacetItem[],
+  includeAllOption: boolean,
+  allOptionLabel: string,
+  clear: () => void
+): SingleSelectFacetItem[] {
+  if (!includeAllOption) return items;
+  const allItem: SingleSelectFacetItem = {
+    value: "",
+    label: allOptionLabel,
+    count: undefined,
+    // "All" is selected exactly when no concrete value is refined.
+    isRefined: !items.some((i) => i.isRefined),
+    toggle: clear,
+    isAllOption: true,
+  };
+  return [allItem, ...items];
+}
+
+/** Pure presentational render shared by the mock and runtime wrappers (D9). */
+function SingleSelectItems(props: {
+  items: SingleSelectFacetItem[];
+  children?: React.ReactNode;
+  className?: string;
+  label?: string;
+  autoWire: boolean;
+  itemGap: string;
+}) {
+  const { items, children, className, label, autoWire, itemGap } = props;
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className={className}
+      data-ep-single-select-facet=""
+      data-single-select=""
+      role="radiogroup"
+      aria-label={label}
+    >
+      {/* Inline flex-row — Plasmic strips layout styles from code-component
+          instances, so the pill row is laid out here (gap via itemGap). */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: itemGap }}>
+        {items.map((item, i) => {
+          const content = repeatedElement(i, children);
+          const wired = autoWire
+            ? autoWireItem(content, {
+                onActivate: item.toggle,
+                role: "radio",
+                selected: item.isRefined,
+                selectionAttr: "aria-checked",
+              })
+            : content;
+          return (
+            <div key={item.isAllOption ? "__all__" : item.value}>
+              <DataProvider name="currentRefinement" data={item}>
+                <DataProvider name="currentRefinementIndex" data={i}>
+                  {wired}
+                </DataProvider>
+              </DataProvider>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const MockSingleSelectFacet = React.forwardRef<
+  EPSingleSelectFacetActions,
+  {
+    children?: React.ReactNode;
+    className?: string;
+    label?: string;
+    includeAllOption: boolean;
+    allOptionLabel: string;
+    autoWire: boolean;
+    itemGap: string;
+  }
+>(function MockSingleSelectFacet(
+  { children, className, label, includeAllOption, allOptionLabel, autoWire, itemGap },
+  ref
+) {
+  useImperativeHandle(ref, () => ({
+    select: () => {},
+    clear: () => {},
+  }));
+
+  const items = useMemo<SingleSelectFacetItem[]>(() => {
+    const base: SingleSelectFacetItem[] = MOCK_REFINEMENT_ITEMS.map((item) => ({
+      ...item,
+      toggle: () => {},
+      isAllOption: false,
+    }));
+    return withAllOption(base, includeAllOption, allOptionLabel, () => {});
+  }, [includeAllOption, allOptionLabel]);
+
+  return (
+    <SingleSelectItems
+      items={items}
+      className={className}
+      label={label}
+      autoWire={autoWire}
+      itemGap={itemGap}
+    >
+      {children}
+    </SingleSelectItems>
+  );
+});
+
+const EPSingleSelectFacetInner = React.forwardRef<
+  EPSingleSelectFacetActions,
+  {
+    children?: React.ReactNode;
+    attribute: string;
+    label?: string;
+    limit: number;
+    showMore: boolean;
+    includeAllOption: boolean;
+    allOptionLabel: string;
+    autoWire: boolean;
+    itemGap: string;
+    className?: string;
+  }
+>(function EPSingleSelectFacetInner(
+  {
+    children,
+    attribute,
+    label,
+    limit,
+    showMore,
+    includeAllOption,
+    allOptionLabel,
+    autoWire,
+    itemGap,
+    className,
+  },
+  ref
+) {
+  const { useMenu } = require("react-instantsearch");
+  const { items, refine } = useMenu({
+    attribute,
+    limit,
+    showMore,
+    // Highest-count value first (e.g. the largest scope before smaller ones);
+    // name breaks ties deterministically.
+    sortBy: ["count:desc", "name:asc"],
+  });
+
+  // Clearing the facet = re-selecting the currently-refined value (useMenu's
+  // replace semantics toggle the refined value off, leaving nothing refined).
+  const clear = React.useCallback(() => {
+    const refined = (items || []).find((i: any) => i.isRefined);
+    if (refined) refine(refined.value);
+  }, [items, refine]);
+
+  useImperativeHandle(ref, () => ({
+    select: (value: string) => refine(value),
+    clear,
+  }));
+
+  const normalizedItems = useMemo<SingleSelectFacetItem[]>(() => {
+    const base: SingleSelectFacetItem[] = (items || []).map((item: any) => ({
+      value: item.value,
+      label: item.label,
+      count: item.count,
+      isRefined: item.isRefined,
+      toggle: () => refine(item.value),
+      isAllOption: false,
+    }));
+    return withAllOption(base, includeAllOption, allOptionLabel, clear);
+  }, [items, refine, includeAllOption, allOptionLabel, clear]);
+
+  return (
+    <SingleSelectItems
+      items={normalizedItems}
+      className={className}
+      label={label}
+      autoWire={autoWire}
+      itemGap={itemGap}
+    >
+      {children}
+    </SingleSelectItems>
+  );
+});
+
+export function registerEPSingleSelectFacet(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSingleSelectFacetProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPSingleSelectFacet,
+    customMeta ?? epSingleSelectFacetMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/catalog-search-components.test.tsx
@@ -216,6 +216,12 @@ const { EPRefinementList, epRefinementListMeta, registerEPRefinementList } =
   require("../EPRefinementList") as typeof import("../EPRefinementList");
 
 const {
+  EPSingleSelectFacet,
+  epSingleSelectFacetMeta,
+  registerEPSingleSelectFacet,
+} = require("../EPSingleSelectFacet") as typeof import("../EPSingleSelectFacet");
+
+const {
   EPHierarchicalMenu,
   epHierarchicalMenuMeta,
   registerEPHierarchicalMenu,
@@ -445,24 +451,38 @@ describe("EPCatalogSearchProvider", () => {
     return JSON.parse(el!.getAttribute("data-configure") || "{}");
   }
 
-  it("passes baseFilter to Configure as `filters` at runtime", () => {
+  it("passes baseFilter to Configure as `filters`, AND'd with the child exclusion", () => {
     // `filters` rides through the adapter's _adaptFilters, which always joins
     // it with facet refinements — adapter-level filter_by would be dropped as
-    // soon as a facet is refined.
+    // soon as a facet is refined. excludeVariationChildren defaults on, so the
+    // baseFilter is AND'd after the child exclusion (D3).
     const { container } = render(
-      <EPCatalogSearchProvider baseFilter="meta.product_types:!=child">
+      <EPCatalogSearchProvider baseFilter="lifecycle_status:=published">
+        <div>children</div>
+      </EPCatalogSearchProvider>
+    );
+
+    const props = getConfigureProps(container);
+    expect(props.filters).toBe(
+      "meta.product_types:!=child && lifecycle_status:=published"
+    );
+    expect(props.hitsPerPage).toBe(12);
+  });
+
+  it("excludeVariationChildren defaults on — emits the child filter even with no baseFilter (D3)", () => {
+    const { container } = render(
+      <EPCatalogSearchProvider>
         <div>children</div>
       </EPCatalogSearchProvider>
     );
 
     const props = getConfigureProps(container);
     expect(props.filters).toBe("meta.product_types:!=child");
-    expect(props.hitsPerPage).toBe(12);
   });
 
-  it("omits `filters` from Configure when baseFilter is empty", () => {
+  it("omits `filters` entirely when excludeVariationChildren is off and no baseFilter", () => {
     const { container } = render(
-      <EPCatalogSearchProvider>
+      <EPCatalogSearchProvider excludeVariationChildren={false}>
         <div>children</div>
       </EPCatalogSearchProvider>
     );
@@ -863,6 +883,53 @@ describe("EPSearchHits", () => {
     expect(data.name).toBe("British Product");
   });
 
+  it("publishes the tiered surface per hit: currentProduct.fields + productExtensions map (D1)", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    mockUseSelector.mockImplementation((name: string) =>
+      name === "catalogSearchData" ? { currencyCode: "USD" } : undefined
+    );
+    mockUseHits.mockReturnValue({
+      hits: [
+        {
+          objectID: "hit-1",
+          attributes: {
+            name: "Standard 9001",
+            extensions: {
+              "products(iso-standard)": {
+                title: "Quality management",
+                product_kind: "publication",
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const { container } = render(
+      <EPSearchHits primaryExtensionTemplate="products(iso-standard)">
+        <div>child</div>
+      </EPSearchHits>
+    );
+
+    // Tier 1 — fields flattened onto currentProduct, no slug bracket
+    const productEl = container.querySelector(
+      '[data-testid="data-provider-currentProduct"]'
+    );
+    const product = JSON.parse(
+      productEl!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(product.fields.title).toBe("Quality management");
+    expect(product.fields.product_kind).toBe("publication");
+
+    // Tier 2 — per-hit slug-keyed productExtensions map is published
+    const extEl = container.querySelector(
+      '[data-testid="data-provider-productExtensions"]'
+    );
+    expect(extEl).not.toBeNull();
+    const ext = JSON.parse(extEl!.getAttribute("data-provider-data") || "{}");
+    expect(ext["products(iso-standard)"].title).toBe("Quality management");
+  });
+
   /** Render one EP catalog-search shaped hit and return the normalized currentProduct. */
   function renderHitAndGetCurrentProduct(
     hit: Record<string, unknown>,
@@ -1039,45 +1106,49 @@ describe("EPRefinementList", () => {
     expect(typeof data.isRefined).toBe("boolean");
   });
 
-  it("uses useMenu (replace semantics) when singleSelect — radio-style facets", () => {
-    mockUseMenu.mockReturnValue({
+  it("auto-wires each row as a toggle button (onClick refines, aria-pressed reflects state)", () => {
+    const refine = jest.fn();
+    mockUseRefinementList.mockReturnValue({
       items: [
-        { value: "type-a", label: "type-a", count: 39, isRefined: true },
-        { value: "type-b", label: "type-b", count: 1, isRefined: false },
+        { value: "acme", label: "Acme", count: 3, isRefined: true },
       ],
-      refine: jest.fn(),
+      refine,
     });
 
     const { container } = render(
-      <EPRefinementList
-        attribute="extensions.products(specs).product_kind"
-        singleSelect
-      >
-        <div>child</div>
+      <EPRefinementList attribute="brand">
+        <button type="button">row</button>
       </EPRefinementList>
     );
 
-    expect(mockUseMenu).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attribute: "extensions.products(specs).product_kind",
-      })
-    );
-    expect(mockUseRefinementList).not.toHaveBeenCalled();
+    const row = container.querySelector('[role="button"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.getAttribute("aria-pressed")).toBe("true");
+    row.click();
+    expect(refine).toHaveBeenCalledWith("acme");
+  });
 
-    // Same per-item shape as the multi-select path
+  it("autoWire=false injects nothing — prior behaviour (toggle on context only)", () => {
+    const refine = jest.fn();
+    mockUseRefinementList.mockReturnValue({
+      items: [{ value: "acme", label: "Acme", count: 3, isRefined: false }],
+      refine,
+    });
+
+    const { container } = render(
+      <EPRefinementList attribute="brand" autoWire={false}>
+        <button type="button">row</button>
+      </EPRefinementList>
+    );
+
+    // no injected role; the slot button keeps its own semantics
+    const wrapper = container.querySelector('[role="listitem"]')!;
+    expect(wrapper.querySelector('[role="button"][aria-pressed]')).toBeNull();
+    // toggle still rides on the per-item context as the escape hatch
     const providerEl = container.querySelector(
       '[data-testid="data-provider-currentRefinement"]'
     );
-    const data = JSON.parse(
-      providerEl!.getAttribute("data-provider-data") || "{}"
-    );
-    expect(data.value).toBe("type-a");
-    expect(data.count).toBe(39);
-    expect(data.isRefined).toBe(true);
-
-    expect(
-      container.querySelector("[data-single-select]")
-    ).not.toBeNull();
+    expect(providerEl).not.toBeNull();
   });
 
   it("should expose currentRefinementIndex in editor", () => {
@@ -1093,6 +1164,142 @@ describe("EPRefinementList", () => {
       '[data-testid="data-provider-currentRefinementIndex"]'
     );
     expect(indexProviders.length).toBe(MOCK_REFINEMENT_ITEMS.length);
+  });
+});
+
+/* ================================================================
+ * EPSingleSelectFacet tests (ADR-0011 D5/D6)
+ * ================================================================ */
+describe("EPSingleSelectFacet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+  });
+
+  it("uses useMenu (replace semantics), not useRefinementList", () => {
+    mockUseMenu.mockReturnValue({
+      items: [
+        { value: "type-a", label: "type-a", count: 39, isRefined: true },
+        { value: "type-b", label: "type-b", count: 1, isRefined: false },
+      ],
+      refine: jest.fn(),
+    });
+
+    const { container } = render(
+      <EPSingleSelectFacet attribute="extensions.products(specs).product_kind">
+        <div>child</div>
+      </EPSingleSelectFacet>
+    );
+
+    expect(mockUseMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attribute: "extensions.products(specs).product_kind",
+      })
+    );
+    expect(mockUseRefinementList).not.toHaveBeenCalled();
+
+    // per-item shape identical to EPRefinementList so slot content ports
+    const providerEl = container.querySelector(
+      '[data-testid="data-provider-currentRefinement"]'
+    );
+    const data = JSON.parse(
+      providerEl!.getAttribute("data-provider-data") || "{}"
+    );
+    expect(data.value).toBe("type-a");
+    expect(data.count).toBe(39);
+    expect(data.isRefined).toBe(true);
+    expect(data.isAllOption).toBe(false);
+
+    expect(container.querySelector('[role="radiogroup"]')).not.toBeNull();
+  });
+
+  it("auto-wires each row as a radio (aria-checked + click selects)", () => {
+    const refine = jest.fn();
+    mockUseMenu.mockReturnValue({
+      items: [
+        { value: "type-a", label: "type-a", count: 39, isRefined: true },
+      ],
+      refine,
+    });
+
+    const { container } = render(
+      <EPSingleSelectFacet attribute="kind">
+        <button type="button">opt</button>
+      </EPSingleSelectFacet>
+    );
+
+    const radio = container.querySelector('[role="radio"]') as HTMLElement;
+    expect(radio).not.toBeNull();
+    expect(radio.getAttribute("aria-checked")).toBe("true");
+    radio.click();
+    expect(refine).toHaveBeenCalledWith("type-a");
+  });
+
+  it("includeAllOption prepends an All pseudo-item: refined when nothing is, clears on toggle (D6)", () => {
+    const refine = jest.fn();
+    mockUseMenu.mockReturnValue({
+      items: [
+        { value: "type-a", label: "type-a", count: 39, isRefined: false },
+        { value: "type-b", label: "type-b", count: 1, isRefined: false },
+      ],
+      refine,
+    });
+
+    const { container } = render(
+      <EPSingleSelectFacet attribute="kind" includeAllOption allOptionLabel="All">
+        <div>opt</div>
+      </EPSingleSelectFacet>
+    );
+
+    const first = container.querySelector(
+      '[data-testid="data-provider-currentRefinement"]'
+    );
+    const allData = JSON.parse(first!.getAttribute("data-provider-data") || "{}");
+    expect(allData.isAllOption).toBe(true);
+    expect(allData.label).toBe("All");
+    // nothing refined → "All" is the active selection
+    expect(allData.isRefined).toBe(true);
+  });
+
+  it("the All option clears by re-selecting the refined value", () => {
+    const refine = jest.fn();
+    mockUseMenu.mockReturnValue({
+      items: [
+        { value: "type-a", label: "type-a", count: 39, isRefined: true },
+      ],
+      refine,
+    });
+
+    const { container } = render(
+      <EPSingleSelectFacet attribute="kind" includeAllOption>
+        <button type="button">opt</button>
+      </EPSingleSelectFacet>
+    );
+
+    // first radio is the All option — clicking it clears the current refinement
+    const allRadio = container.querySelector('[role="radio"]') as HTMLElement;
+    allRadio.click();
+    expect(refine).toHaveBeenCalledWith("type-a");
+  });
+
+  it("renders mock items in the editor", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue({});
+    const { container } = render(
+      <EPSingleSelectFacet attribute="kind">
+        <div>opt</div>
+      </EPSingleSelectFacet>
+    );
+    const providers = container.querySelectorAll(
+      '[data-testid="data-provider-currentRefinement"]'
+    );
+    expect(providers.length).toBe(MOCK_REFINEMENT_ITEMS.length);
+  });
+
+  it("meta exposes select/clear refActions, providesData, and the section", () => {
+    expect(epSingleSelectFacetMeta.section).toBe("EP Catalog Search");
+    expect(epSingleSelectFacetMeta.providesData).toBe(true);
+    expect(epSingleSelectFacetMeta.refActions).toHaveProperty("select");
+    expect(epSingleSelectFacetMeta.refActions).toHaveProperty("clear");
   });
 });
 
@@ -1207,6 +1414,47 @@ describe("EPSearchPagination", () => {
     expect(data.hasNext).toBe(true);
     expect(data.hasPrev).toBe(false);
     expect(data.pages).toEqual([0, 1, 2, 3]);
+    // windowed page-item model present in the mock too (D4)
+    expect(Array.isArray(data.pageItems)).toBe(true);
+    expect(data.pageItems.map((i: any) => i.label)).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+    ]);
+  });
+
+  it("exposes a windowed pageItems model at runtime (raw pages retained) (D4)", () => {
+    mockUsePlasmicCanvasContext.mockReturnValue(null);
+    mockUsePagination.mockReturnValue({
+      currentRefinement: 6,
+      nbPages: 20,
+      pages: [5, 6, 7],
+      refine: jest.fn(),
+      isFirstPage: false,
+      isLastPage: false,
+    });
+
+    const { container } = render(
+      <EPSearchPagination>
+        <div>Pagination UI</div>
+      </EPSearchPagination>
+    );
+
+    const data = JSON.parse(
+      container
+        .querySelector('[data-testid="data-provider-searchPaginationData"]')!
+        .getAttribute("data-provider-data") || "{}"
+    );
+    // raw pages retained alongside the model
+    expect(data.pages).toEqual([5, 6, 7]);
+    // first/last anchors + ellipsis sentinels
+    expect(data.pageItems[0]).toMatchObject({ label: "1", isFirst: true });
+    expect(data.pageItems[1].type).toBe("ellipsis");
+    expect(data.pageItems[data.pageItems.length - 1]).toMatchObject({
+      label: "20",
+      isLast: true,
+    });
   });
 });
 
@@ -2067,6 +2315,28 @@ describeHeadlessStylingContract({
       <EPRefinementList attribute="brand" className={className}>
         <div>row</div>
       </EPRefinementList>
+    );
+  },
+});
+
+describeHeadlessStylingContract({
+  componentName: "EPSingleSelectFacet",
+  leafSelector: "[data-ep-single-select-facet]",
+  setEditorMode,
+  renderInEditor: ({ className }) => (
+    <EPSingleSelectFacet attribute="brand" className={className}>
+      <div>opt</div>
+    </EPSingleSelectFacet>
+  ),
+  renderAtRuntime: ({ className }) => {
+    mockUseMenu.mockReturnValue({
+      items: [{ value: "acme", label: "Acme", count: 3, isRefined: false }],
+      refine: jest.fn(),
+    });
+    return (
+      <EPSingleSelectFacet attribute="brand" className={className}>
+        <div>opt</div>
+      </EPSingleSelectFacet>
     );
   },
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/pagination-window.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/__tests__/pagination-window.test.ts
@@ -1,0 +1,53 @@
+/**
+ * buildPageItems — windowed page-item model (ADR-0011 D4).
+ */
+
+import { buildPageItems } from "../pagination-window";
+
+describe("buildPageItems", () => {
+  const noop = () => {};
+
+  it("returns [] when there are no pages", () => {
+    expect(buildPageItems([], 0, 0, noop)).toEqual([]);
+  });
+
+  it("emits one page item per page with first/last/current flags", () => {
+    const items = buildPageItems([0, 1, 2, 3], 4, 1, noop);
+    expect(items.map((i) => i.label)).toEqual(["1", "2", "3", "4"]);
+    expect(items[0].isFirst).toBe(true);
+    expect(items[3].isLast).toBe(true);
+    expect(items[1].isCurrent).toBe(true);
+    expect(items.every((i) => i.type === "page")).toBe(true);
+  });
+
+  it("inserts a leading anchor + ellipsis when the window starts past page 1", () => {
+    // window [5,6,7] of 20 pages, current 6
+    const items = buildPageItems([5, 6, 7], 20, 6, noop);
+    expect(items[0]).toMatchObject({ type: "page", label: "1", isFirst: true });
+    expect(items[1].type).toBe("ellipsis");
+    expect(items[1].label).toBe("…");
+    // window pages follow
+    expect(items.slice(2, 5).map((i) => i.label)).toEqual(["6", "7", "8"]);
+  });
+
+  it("inserts a trailing ellipsis + last-page anchor when the window ends early", () => {
+    const items = buildPageItems([5, 6, 7], 20, 6, noop);
+    const last = items[items.length - 1];
+    expect(last).toMatchObject({ type: "page", label: "20", isLast: true });
+    expect(items[items.length - 2].type).toBe("ellipsis");
+  });
+
+  it("does not insert an ellipsis when the window is adjacent to the anchor", () => {
+    // window [1,2,3] of 5: page 0 anchor is adjacent to page 1 → no gap
+    const items = buildPageItems([1, 2, 3], 5, 2, noop);
+    expect(items.map((i) => i.label)).toEqual(["1", "2", "3", "4", "5"]);
+    expect(items.some((i) => i.type === "ellipsis")).toBe(false);
+  });
+
+  it("binds each page item's goTo to its own 0-indexed page", () => {
+    const goTo = jest.fn();
+    const items = buildPageItems([0, 1, 2], 3, 0, goTo);
+    items[2].goTo!();
+    expect(goTo).toHaveBeenCalledWith(2);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/auto-wire.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/auto-wire.ts
@@ -1,0 +1,71 @@
+/**
+ * auto-wire — the prop-getter pattern for repeated interactive items
+ * (ADR-0011 D2).
+ *
+ * The autocomplete list already delivers zero-wiring interaction by spreading
+ * `getItemProps()` (onClick + role + aria-*) onto each slotted `<li>`. This
+ * generalises that idea to refinement and single-select facet items: the
+ * component owns the click, the active/selected state, and the keyboard a11y;
+ * the designer only styles the slot.
+ *
+ * Auto-wiring is a defaulted-on, disableable prop. With it OFF the components
+ * inject nothing — byte-for-byte today's behaviour (the per-item `toggle`
+ * stays on context as the Tier-1 escape for custom, multi-step interactions).
+ *
+ * Injection reuses `cloneWithInjectedHandlers` (Pattern C): it clones the
+ * designer's slot element, composing any onClick/onKeyDown they set. Non-element
+ * / multi-element slots fail open (returned unchanged) — `toggle` is the escape.
+ */
+
+import React from "react";
+import { cloneWithInjectedHandlers } from "./cloneWithInjectedHandlers";
+
+export interface ItemInteraction {
+  /** Run on click / Enter / Space. */
+  onActivate: () => void;
+  /** ARIA role for the interactive slot element. */
+  role: "button" | "radio";
+  /** Selected/active state → drives the selection ARIA attribute + data-active. */
+  selected?: boolean;
+  /** Which ARIA selection attribute reflects `selected`. */
+  selectionAttr?: "aria-pressed" | "aria-checked";
+}
+
+/** The behavioural props spread onto an interactive item. */
+export function buildItemInteractionProps(
+  opts: ItemInteraction
+): Record<string, unknown> {
+  const { onActivate, role, selected, selectionAttr } = opts;
+  const props: Record<string, unknown> = {
+    onClick: () => onActivate(),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onActivate();
+      }
+    },
+    role,
+    tabIndex: 0,
+  };
+  if (selectionAttr) props[selectionAttr] = !!selected;
+  // Styling hook for the active state — designers target [data-active] in CSS
+  // instead of branching the binding on isRefined.
+  if (selected) props["data-active"] = "";
+  return props;
+}
+
+/**
+ * Clone a repeated slot item and inject the interaction props, composing the
+ * designer's onClick/onKeyDown. Fail-open for non-element / multi-element
+ * slots: the content is returned unchanged and the per-item `toggle` on context
+ * remains the escape hatch.
+ */
+export function autoWireItem(
+  content: React.ReactNode,
+  opts: ItemInteraction
+): React.ReactNode {
+  return cloneWithInjectedHandlers(content, {
+    injected: buildItemInteractionProps(opts),
+    compose: ["onClick", "onKeyDown"],
+  });
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/design-time-data.ts
@@ -7,6 +7,8 @@
  */
 
 import type { Product } from "../types/product";
+import { buildPageItems } from "./pagination-window";
+import type { SearchPageItem } from "./pagination-window";
 
 // ---------------------------------------------------------------------------
 // Search hit products — 6 sample products matching a "leather" query
@@ -295,7 +297,14 @@ export interface SearchPaginationData {
   totalPages: number;
   hasNext: boolean;
   hasPrev: boolean;
+  /** Raw windowed page numbers (0-indexed). Retained alongside pageItems. */
   pages: number[];
+  /**
+   * Windowed page-item model (ADR-0011 D4): ellipsis sentinels + first/last/
+   * current flags + a pre-bound per-item goTo. dataRep over this for a numbered
+   * pager without windowing math or a customFunction.
+   */
+  pageItems: SearchPageItem[];
   /** Wire clicks via customFunction interactions, e.g. $ctx.searchPaginationData.goTo(page). */
   goTo?: (page: number) => void;
   next?: () => void;
@@ -308,6 +317,7 @@ export const MOCK_SEARCH_PAGINATION_DATA: SearchPaginationData = {
   hasNext: true,
   hasPrev: false,
   pages: [0, 1, 2, 3],
+  pageItems: buildPageItems([0, 1, 2, 3], 4, 0, () => {}),
 };
 
 // ---------------------------------------------------------------------------

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/index.ts
@@ -9,6 +9,10 @@ export {
   registerEPRefinementList,
 } from "./EPRefinementList";
 export {
+  EPSingleSelectFacet,
+  registerEPSingleSelectFacet,
+} from "./EPSingleSelectFacet";
+export {
   EPHierarchicalMenu,
   registerEPHierarchicalMenu,
 } from "./EPHierarchicalMenu";
@@ -61,3 +65,6 @@ export type {
   AutocompleteSuggestionItem,
   CurrentSuggestion,
 } from "./design-time-data";
+export type { SearchPageItem } from "./pagination-window";
+export type { NormalizedRefinementItem } from "./EPRefinementList";
+export type { SingleSelectFacetItem } from "./EPSingleSelectFacet";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/pagination-window.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/catalog-search/pagination-window.ts
@@ -1,0 +1,81 @@
+/**
+ * pagination-window — the windowing math a designer can't express in a binding
+ * (ADR-0011 D4). Turns InstantSearch's windowed `pages` array into a render-ready
+ * list of page items with ellipsis sentinels and first/last/current flags, so a
+ * numbered pager is a plain `dataRep` over `pageItems` instead of hand-assembled
+ * conditional spans plus windowing arithmetic.
+ *
+ * Pure and side-effect free — exercised directly in tests. The raw
+ * `pages: number[]` and `goTo` stay alongside it (additive).
+ */
+
+export interface SearchPageItem {
+  /** A concrete page link, or an elided gap. */
+  type: "page" | "ellipsis";
+  /** 0-indexed page number (page items only). */
+  page?: number;
+  /** Display label — the 1-indexed page number, or "…" for an ellipsis. */
+  label: string;
+  isCurrent: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  /** Navigate to this page (page items only); pre-bound, no argument. */
+  goTo?: () => void;
+}
+
+/**
+ * Build the windowed page-item list.
+ *
+ * @param pages   InstantSearch's windowed page array (already padded around the
+ *                current page); falls back to `[currentPage]` when empty.
+ * @param nbPages total page count.
+ * @param currentPage 0-indexed current page.
+ * @param goTo    navigation callback (0-indexed); each page item binds its own.
+ */
+export function buildPageItems(
+  pages: number[],
+  nbPages: number,
+  currentPage: number,
+  goTo: (page: number) => void
+): SearchPageItem[] {
+  if (nbPages <= 0) return [];
+
+  const windowed = pages && pages.length > 0 ? pages : [currentPage];
+  const items: SearchPageItem[] = [];
+
+  const pageItem = (page: number): SearchPageItem => ({
+    type: "page",
+    page,
+    label: String(page + 1),
+    isCurrent: page === currentPage,
+    isFirst: page === 0,
+    isLast: page === nbPages - 1,
+    goTo: () => goTo(page),
+  });
+  const ellipsis = (): SearchPageItem => ({
+    type: "ellipsis",
+    label: "…",
+    isCurrent: false,
+    isFirst: false,
+    isLast: false,
+  });
+
+  const first = windowed[0];
+  const last = windowed[windowed.length - 1];
+
+  // Leading anchor to page 1 + a gap sentinel when the window doesn't reach it.
+  if (first > 0) {
+    items.push(pageItem(0));
+    if (first > 1) items.push(ellipsis());
+  }
+
+  windowed.forEach((p) => items.push(pageItem(p)));
+
+  // Trailing gap sentinel + anchor to the last page.
+  if (last < nbPages - 1) {
+    if (last < nbPages - 2) items.push(ellipsis());
+    items.push(pageItem(nbPages - 1));
+  }
+
+  return items;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -58,6 +58,7 @@ import { registerEPProductExtensionValue } from "./product-extensions/composable
 import { registerEPSearchBox } from "./catalog-search/EPSearchBox";
 import { registerEPSearchHits } from "./catalog-search/EPSearchHits";
 import { registerEPRefinementList } from "./catalog-search/EPRefinementList";
+import { registerEPSingleSelectFacet } from "./catalog-search/EPSingleSelectFacet";
 import { registerEPHierarchicalMenu } from "./catalog-search/EPHierarchicalMenu";
 import { registerEPRangeFilter } from "./catalog-search/EPRangeFilter";
 import { registerEPSearchPagination } from "./catalog-search/EPSearchPagination";
@@ -188,6 +189,7 @@ export function registerAll(loader?: Registerable) {
   registerEPSearchSortBy(loader);
   registerEPSearchHits(loader);
   registerEPRefinementList(loader);
+  registerEPSingleSelectFacet(loader);
   registerEPHierarchicalMenu(loader);
   registerEPRangeFilter(loader);
   registerEPSearchPagination(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/EPProductField.tsx
@@ -8,7 +8,7 @@ import {
   SHOW_CHOICE_OPTIONS,
   buildLeafOptions,
 } from "./field-catalog";
-import type { FormatSpec } from "../../utils/field-format";
+import type { FormatSpec, HighlightMode } from "../../utils/field-format";
 import { FieldDisplay, useResolvedField } from "./useResolvedField";
 
 type ShowFacet = "value" | "label";
@@ -18,6 +18,7 @@ interface EPProductFieldProps {
   field?: string;
   show?: ShowFacet;
   format?: FormatSpec;
+  highlight?: HighlightMode;
   locale?: string;
   children?: React.ReactNode;
   notPresentContent?: React.ReactNode;
@@ -53,7 +54,20 @@ export const epProductFieldMeta: CodeComponentMeta<EPProductFieldProps> = {
       defaultValue: "auto",
       displayName: "Format",
       description:
-        "How to format the value. Auto uses the field's natural format (e.g. price → currency).",
+        "How to format the value. Auto uses the field's natural format (e.g. price → currency). Title case humanizes enum values (e.g. \"in_force\" → \"In Force\").",
+    },
+    highlight: {
+      type: "choice",
+      options: [
+        { label: "Off", value: "off" },
+        { label: "Auto (search hits)", value: "auto" },
+        { label: "On (always)", value: "on" },
+      ],
+      defaultValue: "off",
+      displayName: "Search highlight",
+      description:
+        "For Name/Description inside a search hit: render the <mark>-highlighted match when one exists (plain value otherwise — inert on a PDP). Only the backend's highlight markup is rendered as HTML, never the raw value. Other fields ignore this.",
+      advanced: true,
     },
     locale: {
       type: "string",
@@ -95,6 +109,7 @@ export function EPProductField(props: EPProductFieldProps) {
     field = "name",
     show = "value",
     format = "auto",
+    highlight = "off",
     locale,
     children,
     notPresentContent,
@@ -102,10 +117,11 @@ export function EPProductField(props: EPProductFieldProps) {
     previewState = "auto",
   } = props;
 
-  const { resolved, inEditor } = useResolvedField({
+  const { resolved, inEditor, highlightHtml } = useResolvedField({
     kind: "topLevel",
     leafId: field,
     format,
+    highlight,
     locale,
     forceMock: previewState === "withData",
   });
@@ -119,6 +135,7 @@ export function EPProductField(props: EPProductFieldProps) {
       className={className}
       inEditor={inEditor}
       dataAttr="data-ep-product-field"
+      highlightHtml={highlightHtml}
     />
   );
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format-value.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/format-value.test.ts
@@ -140,6 +140,21 @@ describe("formatValue", () => {
     });
   });
 
+  describe("titlecase", () => {
+    it("humanizes single-token enum values without a ternary (D3)", () => {
+      expect(formatValue("publication", "titlecase")).toBe("Publication");
+      expect(formatValue("in_force", "titlecase")).toBe("In Force");
+      expect(formatValue("lifecycle-status", "titlecase")).toBe(
+        "Lifecycle Status",
+      );
+    });
+
+    it("falls back to the plain display value for non-strings", () => {
+      expect(formatValue(42, "titlecase")).toBe("42");
+      expect(formatValue(true, "titlecase")).toBe("Yes");
+    });
+  });
+
   describe("auto inference", () => {
     it("renders booleans as Yes/No", () => {
       expect(formatValue(true, "auto")).toBe("Yes");

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/product-field-highlight.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/__tests__/product-field-highlight.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ *
+ * EPProductField search-highlight rendering (ADR-0011 D3). The component reads
+ * the current product via useSelector; the SearchHitProduct extras
+ * (_highlightedName / _snippetedDescription) drive the <mark> markup.
+ */
+
+jest.mock("@plasmicapp/host", () => {
+  const React = require("react");
+  return {
+    DataProvider: ({ children }: any) =>
+      React.createElement(React.Fragment, null, children),
+    useSelector: jest.fn(),
+    usePlasmicCanvasContext: jest.fn().mockReturnValue(null),
+    repeatedElement: jest.fn((_i: number, children: any) => children),
+  };
+});
+
+jest.mock("@plasmicapp/host/registerComponent", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import React from "react";
+import { render } from "@testing-library/react";
+
+const {
+  useSelector: mockUseSelector,
+  usePlasmicCanvasContext: mockUsePlasmicCanvasContext,
+} = require("@plasmicapp/host");
+const { EPProductField } = require("../EPProductField");
+
+function setProduct(product: Record<string, any> | undefined) {
+  (mockUseSelector as jest.Mock).mockImplementation((key: string) =>
+    key === "currentProduct" ? product : undefined,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (mockUsePlasmicCanvasContext as jest.Mock).mockReturnValue(null);
+});
+
+const hitProduct = {
+  id: "p1",
+  name: "Leather Bag",
+  description: "A full-grain leather bag.",
+  price: { value: 10, currencyCode: "USD" },
+  images: [],
+  options: [],
+  variants: [],
+  _highlightedName: "<mark>Leather</mark> Bag",
+  _snippetedDescription: "a full-grain <mark>leather</mark> bag",
+};
+
+describe("EPProductField highlight (D3)", () => {
+  it("highlight=auto renders the <mark> name markup in a hit", () => {
+    setProduct(hitProduct);
+    const { container } = render(
+      <EPProductField field="name" highlight="auto" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.innerHTML).toBe("<mark>Leather</mark> Bag");
+  });
+
+  it("highlight=auto renders the snippeted abstract for description", () => {
+    setProduct(hitProduct);
+    const { container } = render(
+      <EPProductField field="description" highlight="auto" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.innerHTML).toBe("a full-grain <mark>leather</mark> bag");
+  });
+
+  it("highlight=auto is inert on a PDP product (no _highlighted*) — plain text", () => {
+    setProduct({
+      id: "p2",
+      name: "Plain Bag",
+      price: { value: 10, currencyCode: "USD" },
+      images: [],
+      options: [],
+      variants: [],
+    });
+    const { container } = render(
+      <EPProductField field="name" highlight="auto" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.textContent).toBe("Plain Bag");
+    expect(leaf.querySelector("mark")).toBeNull();
+  });
+
+  it("highlight=off (default) never renders markup even on a hit", () => {
+    setProduct(hitProduct);
+    const { container } = render(<EPProductField field="name" />);
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.textContent).toBe("Leather Bag");
+    expect(leaf.querySelector("mark")).toBeNull();
+  });
+
+  it("highlight=on renders the variant markup but NEVER injects the raw value as HTML", () => {
+    // A hit-less product whose name contains HTML metacharacters: `on` must
+    // fall back to plain text, not render the value via dangerouslySetInnerHTML
+    // (the html:true footgun ADR-0011 D3 exists to remove).
+    setProduct({
+      id: "p3",
+      name: "Foo & Bar <script>alert(1)</script>",
+      price: { value: 10, currencyCode: "USD" },
+      images: [],
+      options: [],
+      variants: [],
+    });
+    const { container } = render(
+      <EPProductField field="name" highlight="on" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    // rendered as text — no <script> element materialized
+    expect(leaf.querySelector("script")).toBeNull();
+    expect(leaf.textContent).toBe("Foo & Bar <script>alert(1)</script>");
+  });
+
+  it("highlight=on renders the <mark> variant as HTML when the hit has one", () => {
+    setProduct(hitProduct);
+    const { container } = render(
+      <EPProductField field="name" highlight="on" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.innerHTML).toBe("<mark>Leather</mark> Bag");
+  });
+
+  it("highlight only applies to query_by fields — other leaves ignore it", () => {
+    setProduct({ ...hitProduct, sku: "SKU-1" });
+    const { container } = render(
+      <EPProductField field="sku" highlight="auto" />,
+    );
+    const leaf = container.querySelector("[data-ep-product-field]")!;
+    expect(leaf.textContent).toBe("SKU-1");
+    expect(leaf.querySelector("mark")).toBeNull();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/field-catalog.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/field-catalog.ts
@@ -66,6 +66,7 @@ export const FORMAT_CHOICE_OPTIONS: ChoiceObject[] = [
   { label: "Currency", value: "currency" },
   { label: "Date", value: "date" },
   { label: "Number", value: "number" },
+  { label: "Title case", value: "titlecase" },
   { label: "Raw (unformatted)", value: "raw" },
 ];
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/resolve-field.ts
@@ -6,7 +6,6 @@ import {
   inferType,
   isPresent,
 } from "../../utils/field-format";
-import type { FormatSpec } from "./format";
 import type { FormatSpec } from "../../utils/field-format";
 import type { ExtensionFieldType, ExtensionTemplate } from "../../types/extensions";
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/product-extensions/composable/useResolvedField.tsx
@@ -10,9 +10,9 @@ import {
   DEFAULT_LOCALE,
   extractRawExtensions,
   normalizeExtensions,
+  resolveHighlightHtml,
 } from "../../utils/field-format";
-import type { FormatSpec } from "./format";
-import type { FormatSpec } from "../../utils/field-format";
+import type { FormatSpec, HighlightMode } from "../../utils/field-format";
 import {
   resolveExtensionField,
   resolveTopLevelField,
@@ -27,6 +27,8 @@ type ResolveArgs =
       format: FormatSpec;
       locale?: string;
       forceMock?: boolean;
+      /** Search-highlight rendering for `name`/`description`; default "off". */
+      highlight?: HighlightMode;
     }
   | {
       kind: "extension";
@@ -41,6 +43,12 @@ export interface UseResolvedFieldResult {
   resolved: ResolvedField;
   templates: ExtensionTemplate[];
   inEditor: boolean;
+  /**
+   * `<mark>`-wrapped highlight markup to render as HTML instead of the plain
+   * value, or `undefined` to render plainly. Only set for top-level
+   * `name`/`description` when `highlight` is on/auto and a variant exists.
+   */
+  highlightHtml?: string;
 }
 
 /** Shared host wiring for both field components: read the product, mock in the canvas, delegate to the pure resolvers. */
@@ -82,7 +90,20 @@ export function useResolvedField(args: ResolveArgs): UseResolvedFieldResult {
     args.kind === "extension" ? args.fieldKey : undefined,
   ]);
 
-  return { resolved, templates, inEditor };
+  const highlightHtml = useMemo(() => {
+    if (args.kind !== "topLevel" || !args.highlight || args.highlight === "off") {
+      return undefined;
+    }
+    return resolveHighlightHtml(product, args.leafId, args.highlight);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    args.kind,
+    args.kind === "topLevel" ? args.leafId : undefined,
+    args.kind === "topLevel" ? args.highlight : undefined,
+    product,
+  ]);
+
+  return { resolved, templates, inEditor, highlightHtml };
 }
 
 /** Inline scalar with no children; structural section gate with children. Canvas placeholder when unresolvable. */
@@ -94,9 +115,19 @@ export function FieldDisplay(props: {
   className?: string;
   inEditor: boolean;
   dataAttr: string;
+  /** When set, render this `<mark>` markup as HTML instead of the plain value. */
+  highlightHtml?: string;
 }) {
-  const { resolved, show, children, notPresentContent, className, inEditor, dataAttr } =
-    props;
+  const {
+    resolved,
+    show,
+    children,
+    notPresentContent,
+    className,
+    inEditor,
+    dataAttr,
+    highlightHtml,
+  } = props;
   const hasChildren = React.Children.count(children) > 0;
 
   if (hasChildren) {
@@ -115,6 +146,20 @@ export function FieldDisplay(props: {
   }
 
   if (resolved.hasValue) {
+    // Highlight markup (search hits) renders the value's `<mark>`-wrapped HTML
+    // in place of the plain text. Only `show === "value"` highlights — the
+    // humanized label is always plain. The markup comes from Typesense (the
+    // search backend), never designer input, so dangerouslySetInnerHTML is
+    // contained here rather than handed to designers as an `html:true` footgun.
+    if (highlightHtml != null && show !== "label") {
+      return (
+        <span
+          className={className}
+          {...{ [dataAttr]: "" }}
+          dangerouslySetInnerHTML={{ __html: highlightHtml }}
+        />
+      );
+    }
     return (
       <span className={className} {...{ [dataAttr]: "" }}>
         {show === "label" ? resolved.label : resolved.displayValue}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/normalize-hit.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/normalize-hit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * normalizeSearchHit — shared base Product contract + tiered surface (ADR-0011).
+ */
+
+import {
+  normalizeSearchHit,
+  DEFAULT_PRODUCT_PATH_PREFIX,
+} from "../normalize-hit";
+
+describe("normalizeSearchHit — base Product contract (D7)", () => {
+  it("produces the shared base Product fields from EP field-name conventions", () => {
+    const { product } = normalizeSearchHit(
+      {
+        objectID: "p1",
+        attributes: {
+          name: "Leather Bag",
+          slug: "leather-bag",
+          sku: "LB-1",
+          description: "A bag.",
+        },
+        main_image: { link: { href: "https://img/x.png" } },
+        meta: {
+          display_price: {
+            without_tax: { float_price: 12.5, currency: "USD" },
+          },
+        },
+      },
+      "USD"
+    );
+
+    expect(product.id).toBe("p1");
+    expect(product.name).toBe("Leather Bag");
+    expect(product.slug).toBe("leather-bag");
+    expect(product.sku).toBe("LB-1");
+    expect(product.description).toBe("A bag.");
+    expect(product.path).toBe(`${DEFAULT_PRODUCT_PATH_PREFIX}/leather-bag`);
+    expect(product.images[0].url).toBe("https://img/x.png");
+    expect(product.price.value).toBe(12.5);
+    expect(product.price.currencyCode).toBe("USD");
+    // base contract shape parity with the PDP normalizer
+    expect(product.variants).toEqual([]);
+    expect(product.options).toEqual([]);
+  });
+
+  it("a base field absent from a hit reads as absent (presence false), never throws", () => {
+    const { product } = normalizeSearchHit({ objectID: "p2" }, "USD");
+    // empty strings are the honest base-contract value; isPresent() reads them
+    // as absent, so a presence-gated field component renders nothing.
+    expect(product.name).toBe("");
+    expect(product.description).toBe("");
+    expect(product.slug).toBe("");
+    // never throws building the path even with no slug
+    expect(product.path).toBe(`${DEFAULT_PRODUCT_PATH_PREFIX}/p2`);
+  });
+
+  it("typed search superset rides along on the product", () => {
+    const { product } = normalizeSearchHit(
+      {
+        objectID: "p3",
+        _rawTypesenseHit: {
+          highlight: {
+            name: { value: "<mark>Leather</mark> Bag" },
+            description: { snippet: "a <mark>leather</mark> tote" },
+          },
+        },
+        _score: 0.92,
+      },
+      "USD"
+    );
+    expect(product._highlightedName).toBe("<mark>Leather</mark> Bag");
+    expect(product._snippetedDescription).toBe("a <mark>leather</mark> tote");
+    expect(product._score).toBe(0.92);
+    expect(product._rawTypesenseHit).toBeTruthy();
+    expect(product.rawHit.objectID).toBe("p3");
+  });
+});
+
+describe("normalizeSearchHit — tiered extension surface (D1)", () => {
+  const hit = {
+    objectID: "p4",
+    attributes: {
+      name: "Standard 9001",
+      extensions: {
+        "products(iso-standard)": {
+          title: "Quality management",
+          product_kind: "publication",
+        },
+      },
+    },
+  };
+
+  it("Tier 2: publishes a null-safe slug-keyed extensions map (absent slug → {})", () => {
+    const { extensionsMap } = normalizeSearchHit(hit, "USD");
+    expect(extensionsMap["products(iso-standard)"].title).toBe(
+      "Quality management"
+    );
+    // absent slug never throws (the buildExtensionsMap Proxy)
+    expect(extensionsMap["products(nope)"].whatever).toBeUndefined();
+  });
+
+  it("Tier 1: flattens the primaryExtensionTemplate onto currentProduct.fields", () => {
+    const { product } = normalizeSearchHit(hit, "USD", {
+      primaryExtensionTemplate: "products(iso-standard)",
+    });
+    expect(product.fields.title).toBe("Quality management");
+    expect(product.fields.product_kind).toBe("publication");
+    // a missing key on a present template reads undefined, never throws
+    expect((product.fields as Record<string, unknown>).missing).toBeUndefined();
+  });
+
+  it("fields is an empty object when primaryExtensionTemplate is unset or absent", () => {
+    expect(normalizeSearchHit(hit, "USD").product.fields).toEqual({});
+    expect(
+      normalizeSearchHit(hit, "USD", {
+        primaryExtensionTemplate: "products(not-here)",
+      }).product.fields
+    ).toEqual({});
+  });
+
+  it("Tier 3: retains the raw extensions block", () => {
+    const { product } = normalizeSearchHit(hit, "USD");
+    expect(product.extensions).toEqual(hit.attributes.extensions);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/field-format.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/field-format.ts
@@ -103,7 +103,55 @@ export type FormatSpec =
   | "currency"
   | "date"
   | "number"
-  | "raw";
+  | "raw"
+  | "titlecase";
+
+/**
+ * Search highlight rendering for the `query_by` fields (`name`, `description`).
+ * - `off` — plain text only (the default; inert).
+ * - `auto` — render the `<mark>`-wrapped highlighted/snippet variant when the
+ *   current product carries one (i.e. it's a search hit), plain text otherwise
+ *   (inert on a PDP).
+ * - `on` — always render the highlight markup (no PDP heuristic); falls back to
+ *   plain text when no markup exists.
+ *
+ * In every mode the only thing rendered as HTML is the backend-supplied
+ * `<mark>` markup — never the raw field value. That keeps the `html:true`
+ * footgun out of the designer's hands (the reason highlight folds in here, per
+ * ADR-0011 D3).
+ */
+export type HighlightMode = "off" | "auto" | "on";
+
+/**
+ * Resolve the highlight markup for a top-level field, or `undefined` to render
+ * the plain value as text. Highlights only ever apply to the `query_by` fields,
+ * so any other leaf returns `undefined`. Reads the `SearchHitProduct` extras off
+ * the current product; absent on a PDP product, which makes both `auto` and
+ * `on` inert there (there is no markup to render).
+ */
+export function resolveHighlightHtml(
+  product: unknown,
+  leafId: string,
+  mode: HighlightMode,
+): string | undefined {
+  if (mode === "off") return undefined;
+  const p = product as
+    | {
+        _highlightedName?: string;
+        _highlightedDescription?: string;
+        _snippetedDescription?: string;
+      }
+    | undefined
+    | null;
+  if (leafId === "name") {
+    return p?._highlightedName;
+  }
+  if (leafId === "description") {
+    return p?._snippetedDescription || p?._highlightedDescription;
+  }
+  // Highlights only apply to the query_by fields.
+  return undefined;
+}
 
 /** Fallback locale (hard-coded so SSR and CSR agree on Intl output). */
 export const DEFAULT_LOCALE = "en-US";
@@ -136,10 +184,24 @@ export function formatValue(
       return formatCurrency(value, locale, currency);
     case "date":
       return formatDate(value, locale);
+    case "titlecase":
+      return formatTitlecase(value);
     case "auto":
     default:
       return formatAuto(value, locale);
   }
+}
+
+/**
+ * Title-case an enum-ish value for display — `"publication"` → "Publication",
+ * `"in_force"` → "In Force" — so single-token status/kind fields render
+ * without a ternary in the binding. Reuses `humanizeFieldKey` (splits on
+ * `-`/`_`/camelCase and title-cases). Non-strings fall through to the plain
+ * display value.
+ */
+function formatTitlecase(value: unknown): string {
+  if (typeof value === "string") return humanizeFieldKey(value);
+  return formatDisplayValue(value);
 }
 
 function formatAuto(value: unknown, locale: string): string {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize-hit.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize-hit.ts
@@ -1,0 +1,252 @@
+/**
+ * normalizeSearchHit — the search-side product normalizer (ADR-0011 D7 / D1).
+ *
+ * Produces a `SearchHitProduct`: the shared base `Product` contract every
+ * normalizer emits, plus a typed search superset
+ * (`_highlighted*` / `_score` / `_rawTypesenseHit` / `rawHit`) and the tiered,
+ * designer-bindable surface (`fields` + the slug-keyed `extensionsMap`).
+ *
+ * It shares the same primitives the PDP path (`normalizeProduct`) uses —
+ * `formatCurrency`, `buildExtensionsMap`, `normalizeExtensions`, `isPresent` —
+ * so a hit's `currentProduct` is shape-identical to the PDP's. That is what
+ * lets the ADR-0006 field components and the `currentProduct.fields.<key>`
+ * bindings work unchanged across PDP and search. The input-key mapping (the EP
+ * catalog-search field-name conventions) stays here, per-source; the *contract*
+ * is shared.
+ *
+ * Absent base fields read as absent (`isPresent` is false for `""`/`[]`/`{}`)
+ * and every map access is null-safe (the `buildExtensionsMap` Proxy), so no
+ * binding against a missing field can throw.
+ */
+
+import type { Product } from "../types/product";
+import type { ExtensionFieldMap, ProductExtensionsMap } from "./extensions-map";
+import { buildExtensionsMap } from "./extensions-map";
+import { formatCurrency } from "./formatCurrency";
+import { normalizeExtensions } from "./field-format";
+
+export const DEFAULT_PRODUCT_PATH_PREFIX = "/product";
+
+// 1x1 transparent gif — keeps the <img src> attribute non-empty so the browser
+// doesn't issue a self-referential request (and React's empty-string warning
+// stays silent) while the surrounding styles render the visual placeholder.
+const TRANSPARENT_PIXEL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+const EMPTY_FIELDS: ExtensionFieldMap = Object.freeze({});
+
+/**
+ * The search superset of the shared base `Product`. Adds the InstantSearch
+ * extras and the tiered designer surface; every added member is additive, so a
+ * `SearchHitProduct` is assignable wherever a `Product` is expected (the
+ * Tier-0 "same components across PDP and search" guarantee).
+ */
+export interface SearchHitProduct extends Product {
+  /**
+   * Base `ProductPrice` plus the pre-formatted, currency-aware string the
+   * search backend supplies. Optional/additive: the PDP path doesn't set it,
+   * and the `EPProductField` "Price (formatted)" leaf formats currency itself,
+   * so cross-source parity holds through the field component regardless.
+   */
+  price: Product["price"] & { formatted?: string };
+  /**
+   * Tier 1 — flat, slug-free map of the configured primary extension
+   * template's fields, e.g. `currentProduct.fields.title`. Always an object
+   * (frozen `{}` when the template is unset or absent), so `.fields.<key>`
+   * never throws and reads `undefined` for a missing key.
+   */
+  fields: ExtensionFieldMap;
+  /**
+   * Tier 3 — the raw `attributes.extensions` block exactly as it arrived on
+   * the hit (`extensions["products(slug)"].field`). Retained for back-compat
+   * and advanced use; prefer `fields` (Tier 1) or the `productExtensions` map
+   * (Tier 2).
+   */
+  extensions: Record<string, unknown>;
+  /** Highlighted (`<mark>`-wrapped) name, when the query matched it. */
+  _highlightedName?: string;
+  /** Highlighted (`<mark>`-wrapped) full description, when matched. */
+  _highlightedDescription?: string;
+  /** Snippeted (`<mark>`-wrapped excerpt) description, when matched. */
+  _snippetedDescription?: string;
+  /** Relevance score, when the backend exposes one. */
+  _score?: number;
+  /** The untouched Typesense hit, for advanced escape-hatch bindings. */
+  _rawTypesenseHit?: Record<string, unknown>;
+  /** The untouched InstantSearch hit. */
+  rawHit: Record<string, unknown>;
+}
+
+/** A normalized hit: the bindable product plus its per-hit, null-safe slug map. */
+export interface NormalizedHit {
+  product: SearchHitProduct;
+  /**
+   * Tier 2 — the ADR-0007 slug-keyed, null-safe Proxy map, scoped to this hit.
+   * Published per hit as `$ctx.productExtensions`, identical in shape to the
+   * PDP provider's map.
+   */
+  extensionsMap: ProductExtensionsMap;
+}
+
+export interface NormalizeHitOptions {
+  productPathPrefix?: string;
+  /**
+   * Raw template slug (e.g. `products(iso-standard)`) whose fields flatten onto
+   * `currentProduct.fields`. Unset → `fields` is an empty object.
+   */
+  primaryExtensionTemplate?: string;
+}
+
+/** The hit wire path for the EP `attributes.extensions` block. */
+function readHitExtensions(hit: Record<string, any>): Record<string, unknown> {
+  return hit.attributes?.extensions || hit.extensions || {};
+}
+
+/**
+ * Normalize an InstantSearch hit to the shared base `Product` shape plus the
+ * search superset. The EP catalog-search adapter surfaces various field-name
+ * conventions; this resolves each one.
+ */
+export function normalizeSearchHit(
+  hit: Record<string, any>,
+  currencyCode: string,
+  options: NormalizeHitOptions = {}
+): NormalizedHit {
+  const {
+    productPathPrefix = DEFAULT_PRODUCT_PATH_PREFIX,
+    primaryExtensionTemplate = "",
+  } = options;
+
+  const name = hit.ep_name || hit.name || hit.attributes?.name || "";
+  const slug = hit.ep_slug || hit.slug || hit.attributes?.slug || "";
+  const sku = hit.ep_sku || hit.sku || hit.attributes?.sku || "";
+  const description =
+    hit.ep_description || hit.description || hit.attributes?.description || "";
+
+  // Image: prefer the inlined `main_image` record that EPCatalogSearchProvider
+  // requests via `include: ["main_image"]` (adapter v0.1.0+ resolves the
+  // included block against each hit's relationship reference). Fallbacks cover
+  // catalogs that already denormalize a URL onto the hit root.
+  const imageUrl =
+    hit.main_image?.link?.href ||
+    hit.ep_main_image?.link?.href ||
+    hit.ep_main_image_url ||
+    hit.main_image_url ||
+    "";
+
+  // Price resolution — EP catalog search exposes prices in two shapes
+  // depending on catalog config:
+  //   1. `meta.display_price.without_tax`  → preferred; pre-formatted, currency-aware
+  //   2. `attributes.price[CURRENCY].amount` (in cents) → raw fallback
+  // We also keep the older `ep_price` / `price` paths for back-compat with
+  // search backends that flatten the price object onto the hit root.
+  const displayPrice =
+    hit.meta?.display_price?.without_tax ||
+    hit.meta?.display_price?.with_tax ||
+    null;
+  const attrPriceObj =
+    hit.attributes?.price?.[currencyCode] || hit.attributes?.price?.USD || null;
+  const flatPriceObj =
+    hit.ep_price?.[currencyCode] ||
+    hit.price?.[currencyCode] ||
+    hit.ep_price?.USD ||
+    hit.price?.USD ||
+    null;
+  const priceValue =
+    displayPrice?.float_price ??
+    flatPriceObj?.float_price ??
+    flatPriceObj?.amount ??
+    (attrPriceObj?.amount != null ? attrPriceObj.amount / 100 : undefined) ??
+    hit.price?.value ??
+    0;
+  const priceCurrency = displayPrice?.currency || currencyCode || "USD";
+  const formatted =
+    displayPrice?.formatted || formatCurrency(priceValue, priceCurrency);
+
+  // Highlight results from InstantSearch.
+  //
+  // The EP catalog-search backend keys highlights by the BARE query_by field
+  // names (`name`, `description`) while the document nests them under
+  // `attributes.…` — the adapter's document-driven highlight walk therefore
+  // drops them from `_highlightResult`/`_snippetResult`. Recover from the raw
+  // Typesense hit (`highlight.<field>.{value,snippet}`), keeping the adapter
+  // paths as fallbacks for backends where they do line up.
+  const highlighted = hit._highlightResult || hit._highlight || {};
+  const snippeted = hit._snippetResult || {};
+  const rawTypesenseHit = hit._rawTypesenseHit;
+  const rawHighlight = rawTypesenseHit?.highlight || {};
+  const highlightedName =
+    rawHighlight.name?.value ||
+    rawHighlight.name?.snippet ||
+    highlighted.ep_name?.value ||
+    highlighted.name?.value ||
+    highlighted.attributes?.name?.value ||
+    undefined;
+  const highlightedDescription =
+    rawHighlight.description?.value ||
+    highlighted.ep_description?.value ||
+    highlighted.description?.value ||
+    highlighted.attributes?.description?.value ||
+    undefined;
+  // Snippet = the shortened, `<mark>`-highlighted excerpt Typesense builds for
+  // long fields (e.g. a description/abstract snippet on a hit card).
+  const snippetedDescription =
+    rawHighlight.description?.snippet ||
+    snippeted.description?.value ||
+    snippeted.attributes?.description?.value ||
+    undefined;
+
+  // Template extensions — the catalog-search document carries the same
+  // `attributes.extensions` block as the shopper product API. Build the
+  // tiered surface from the shared primitives:
+  //   - `extensions` (Tier 3): the raw block, untouched.
+  //   - `extensionsMap` (Tier 2): the null-safe slug-keyed Proxy (ADR-0007),
+  //     published per hit as `$ctx.productExtensions`.
+  //   - `fields` (Tier 1): the primary template's fields flattened slug-free.
+  const rawExtensions = readHitExtensions(hit);
+  const extensionsMap = buildExtensionsMap(normalizeExtensions(rawExtensions));
+  const fields: ExtensionFieldMap = primaryExtensionTemplate
+    ? extensionsMap[primaryExtensionTemplate]
+    : EMPTY_FIELDS;
+
+  // Strip the trailing slash so both "/product" and "/product/" work.
+  const pathPrefix = (productPathPrefix || DEFAULT_PRODUCT_PATH_PREFIX).replace(
+    /\/+$/,
+    ""
+  );
+  const id = hit.objectID || hit.id || "";
+
+  const product: SearchHitProduct = {
+    id,
+    name,
+    slug,
+    sku,
+    description,
+    // PDP route — configurable via the `productPathPrefix` prop so storefronts
+    // with a different route shape (e.g. `/products`, `/en/products`) link
+    // correctly. Falls back to an id-based URL when the hit lacks a slug.
+    path: `${pathPrefix}/${slug || id}`,
+    images: [{ url: imageUrl || TRANSPARENT_PIXEL, alt: name }],
+    // A search hit carries no variant data; an empty array is the honest
+    // base-contract value (presence reads absent) and keeps the shape
+    // identical to the PDP's `Product`.
+    variants: [],
+    price: { value: priceValue, currencyCode: priceCurrency, formatted },
+    options: [],
+    extensions: rawExtensions,
+    fields,
+    // The search document has the shopper-product shape ({attributes, id,
+    // meta, …}), so wrapping it as `{ data: hit }` matches the PDP's `rawData`
+    // contract (see extractRawExtensions in utils/field-format.ts) and lets the
+    // ADR-0006 field components resolve inside hit cards unchanged.
+    rawData: { data: hit } as Product["rawData"],
+    _highlightedName: highlightedName,
+    _highlightedDescription: highlightedDescription,
+    _snippetedDescription: snippetedDescription,
+    _score: hit._score ?? hit._rankingInfo?.relevance ?? undefined,
+    _rawTypesenseHit: rawTypesenseHit,
+    rawHit: hit,
+  };
+
+  return { product, extensionsMap };
+}


### PR DESCRIPTION
## Summary

Brings the **catalog-search** components up to the ADR-0006/0007 insulation floor under one governing principle — **progressive disclosure**: the common case is a discoverable, zero-lookup, zero-wiring action; every advanced path stays reachable underneath; and **no enhancement removes a capability** (every convenience opt-outs to the exact prior behaviour).

Implements **ADR-0011** ("Catalog-search designer ergonomics: a tiered, progressively-disclosed data surface"). Closes #355 (under the #304 umbrella).

## Slice 1 — discoverable, tiered hit *data* surface

- **D7 (shared base `Product` contract):** extract the hit normalizer into `utils/normalize-hit.ts` (`normalizeSearchHit` → `SearchHitProduct extends Product`), built from the same primitives the PDP path uses (`formatCurrency`, `buildExtensionsMap`, `normalizeExtensions`). A hit's `currentProduct` is shape-identical to the PDP's, so the ADR-0006 field components and bindings work unchanged across PDP + search. Absent base fields read as absent (never throw).
- **D1 (discoverable hit fields):** `EPSearchHits` publishes per hit
  - Tier 1 — `$ctx.currentProduct.fields.<key>`: flat, slug-free, null-safe, flattening a configurable `primaryExtensionTemplate` prop (autocompletes in the picker, no `(… || {})`, no slug brackets);
  - Tier 2 — `$ctx.productExtensions["<slug>"].field`: the ADR-0007 slug-keyed Proxy map, scoped per hit;
  - Tier 3 — raw `extensions` / `rawData` retained.
- **D3 (fields):** fold `highlight: auto | on | off` and a `titlecase` format into **`EPProductField`** — one field-render surface across PDP + search. Only the backend's `<mark>` markup is ever rendered as HTML, never the raw value, so the `html:true` footgun is removed rather than handed to designers.
- **D8/D9:** `EPSearchHits` ships a batteries-included-but-unstyled default card built from the field components, and collapses to a single render (pure inner fed `items`, the InstantSearch hook in the data wrapper) per the #305 headless-styling contract.

## Slice 2 — zero-wiring facets & pagination

- **D2 (auto-wiring):** refinement items and single-select items are auto-wired via the prop-getter pattern the autocomplete already uses (`onClick` + keyboard + `role` + selection `aria-*`). A **defaulted-on, disableable** `autoWire` prop; OFF is byte-for-byte today's function-on-context behaviour, and `toggle` stays on context as the escape.
- **D5/D6 (`EPSingleSelectFacet`):** new component (`useMenu`, replace semantics, radiogroup a11y) splitting `singleSelect` out of `EPRefinementList`. Per-item context is identical, so slot content ports across a mode change. Opt-in `includeAllOption` emits an "All" pseudo-item (refined when nothing is, clears on select) flagged `isAllOption`. `EPRefinementList` + `EPClearRefinements` keep working unchanged.
- **D4 (pagination windowing):** `EPSearchPagination` exposes a windowed `pageItems` model — ellipsis sentinels, `isFirst`/`isLast`/`isCurrent` flags, a per-item pre-bound `goTo`, and a `windowSize` prop. Raw `pages: number[]` + `goTo` retained.

## Cross-cutting

- **D3 (provider):** `EPCatalogSearchProvider` gains `excludeVariationChildren` (**default on**) emitting `meta.product_types:!=child`, AND'd with `baseFilter`. **Deliberate non-additive default** — variation children near-universally don't belong in hits, and the package has no external consumers depending on the old behaviour. Turn off to include them.
- **D8 (insert section):** every catalog-search component groups under one `"EP Catalog Search"` insert-menu section; the provider's default slot is a complete, working unstyled scaffold (search box + scope facet + hits + empty + pagination).

## Verification

- **1816 package tests pass** (`catalog-search-components` jest suite + new unit/acceptance tests: `normalize-hit`, `pagination-window`, `product-field-highlight`, `format-value` titlecase, provider `excludeVariationChildren`, `EPSingleSelectFacet`).
- `assertHeadlessStylingContract` passes for the new `EPSingleSelectFacet` and the refactored `EPRefinementList` / `EPSearchHits`.
- `tsc --noEmit` clean across all touched files.
- All enhancements opt-out to prior behaviour; existing component instances render without re-authoring.

## Behaviour change to call out

`excludeVariationChildren` defaults **on** — searches that previously returned PXM variation children will stop doing so. This is intentional and documented above; set the prop to `false` to restore the old behaviour.
