### PR TITLE
feat(ep-commerce): locale/currency-aware cart read, cart-item field-display, add-to-cart event

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
@@ -8,9 +8,10 @@ import registerComponent, {
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import useCart from "../cart/use-cart";
-import { DEFAULT_CURRENCY_CODE, FOCUS_TRAP_DELAY_MS } from "../const";
+import { FOCUS_TRAP_DELAY_MS } from "../const";
+import { useCommerce } from "../elastic-path";
 import { Registerable } from "../registerable";
-import { formatCurrency } from "../utils/formatCurrency";
+import { deriveCartData } from "../utils/cart-data";
 import { createLogger } from "../utils/logger";
 import { MOCK_CART_DATA } from "../utils/design-time-data";
 import { useDrawerOpen, setDrawerOpen } from "./CartDrawerContext";
@@ -197,6 +198,8 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
   } = props;
 
   const { data: cart, error: cartError } = useCart();
+  const { providerRef } = useCommerce();
+  const currencyDisplay = providerRef?.current?.currencyDisplay ?? "symbol";
   const inEditor = !!usePlasmicCanvasContext();
   const [drawerOpen] = useDrawerOpen();
   const drawerRef = useRef<HTMLDivElement>(null);
@@ -281,25 +284,12 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
     };
   }, [isOpen, trapFocus, inEditor, inline]);
 
-  // Build enriched cart data for DataProvider
-  const cartData = useMemo(() => {
-    if (!cart) return null;
-    const currencyCode = cart.currency?.code ?? DEFAULT_CURRENCY_CODE;
-    return {
-      id: cart.id,
-      lineItems: cart.lineItems,
-      itemCount: cart.lineItems.reduce(
-        (sum, item) => sum + (item.quantity ?? 1),
-        0
-      ),
-      isEmpty: cart.lineItems.length === 0,
-      subtotalPrice: cart.subtotalPrice,
-      totalPrice: cart.totalPrice,
-      formattedSubtotal: formatCurrency(cart.subtotalPrice, currencyCode),
-      formattedTotal: formatCurrency(cart.totalPrice, currencyCode),
-      currencyCode,
-    };
-  }, [cart]);
+  // Build enriched cart data for DataProvider — formatted money honours the
+  // provider's currencyDisplay preference (symbol vs. ISO code prefix).
+  const cartData = useMemo(
+    () => deriveCartData(cart, { currencyDisplay }),
+    [cart, currencyDisplay]
+  );
 
   // --- Preview state handling ---
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
@@ -8,19 +8,27 @@ import registerComponent, {
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import useCart from "../cart/use-cart";
-import { FOCUS_TRAP_DELAY_MS } from "../const";
+import {
+  CART_BACKDROP_Z_INDEX,
+  CART_OVERLAY_Z_INDEX,
+  FOCUS_TRAP_DELAY_MS,
+} from "../const";
 import { useCommerce } from "../elastic-path";
 import { Registerable } from "../registerable";
 import { deriveCartData } from "../utils/cart-data";
 import { createLogger } from "../utils/logger";
-import { MOCK_CART_DATA } from "../utils/design-time-data";
+import { MOCK_CART_DATA, MOCK_EMPTY_CART_DATA } from "../utils/design-time-data";
 import { useDrawerOpen, setDrawerOpen } from "./CartDrawerContext";
+import {
+  OverlayEditorOpenProps,
+  useOverlayEditorOpen,
+} from "./use-overlay-editor-open";
 
 const log = createLogger("EPCartDrawer");
 
 type PreviewState = "auto" | "withItems" | "empty" | "loading" | "error";
 
-interface EPCartDrawerProps {
+interface EPCartDrawerProps extends OverlayEditorOpenProps {
   children?: React.ReactNode;
   emptyContent?: React.ReactNode;
   loadingContent?: React.ReactNode;
@@ -162,7 +170,7 @@ const BACKDROP_STYLES: React.CSSProperties = {
   left: 0,
   right: 0,
   bottom: 0,
-  zIndex: 9998,
+  zIndex: CART_BACKDROP_Z_INDEX,
   background: "rgba(0, 0, 0, 0.4)",
 };
 
@@ -174,7 +182,7 @@ function getDrawerPositionStyles(
     top: 0,
     bottom: 0,
     [side]: 0,
-    zIndex: 9999,
+    zIndex: CART_OVERLAY_Z_INDEX,
     overflowY: "auto",
   };
 }
@@ -201,6 +209,10 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
   const { providerRef } = useCommerce();
   const currencyDisplay = providerRef?.current?.currencyDisplay ?? "symbol";
   const inEditor = !!usePlasmicCanvasContext();
+  // Open the drawer in the Studio canvas when this node (or a descendant) is
+  // selected in the outline. The drawer has no trigger slot (its trigger is a
+  // separate EPCartDrawerTrigger component), so no slot needs excluding.
+  const autoOpenForEditing = useOverlayEditorOpen(props);
   const [drawerOpen] = useDrawerOpen();
   const drawerRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
@@ -303,8 +315,17 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
   // Design-time: render inline so designer can see, select, and style.
   // The defaultStyles on the meta give the drawer its initial dimensions,
   // background, and padding — the designer can override via Plasmic Studio.
+  //
+  // Inline mode (the dedicated cart page) always renders. Drawer mode renders
+  // only when "open" for editing — selected in the outline (autoOpenForEditing),
+  // an explicit previewState, or a bound isOpen — so it doesn't clutter the
+  // canvas the rest of the time.
   // -----------------------------------------------------------------------
   if (inEditor) {
+    const editorOpen =
+      inline || previewState !== "auto" || autoOpenForEditing || isOpen;
+    if (!editorOpen) return null;
+
     if (previewState === "loading") {
       return (
         <div className={className} data-ep-cart-drawer="" data-side={side}>
@@ -321,10 +342,7 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
     }
     if (previewState === "empty") {
       return (
-        <DataProvider
-          name="cartData"
-          data={{ ...MOCK_CART_DATA, lineItems: [], itemCount: 0, isEmpty: true }}
-        >
+        <DataProvider name="cartData" data={MOCK_EMPTY_CART_DATA}>
           <div
             className={className}
             role="dialog"

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemField.tsx
@@ -1,10 +1,15 @@
-import { useSelector, usePlasmicCanvasContext } from "@plasmicapp/host";
+import {
+  DataProvider,
+  useSelector,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
 import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
 import React from "react";
 import { Registerable } from "../registerable";
 import { MOCK_CART_LINE_ITEMS } from "../utils/design-time-data";
+import { CartItemOption, formatOptionValues } from "../utils/option-values";
 
 type CartItemFieldName =
   | "name"
@@ -14,6 +19,7 @@ type CartItemFieldName =
   | "formattedListPrice"
   | "formattedLineTotal"
   | "options"
+  | "optionValues"
   | "productId"
   | "variantId"
   | "locationName"
@@ -25,6 +31,7 @@ type PreviewState = "auto" | "withData";
 
 interface EPCartItemFieldProps {
   field: CartItemFieldName;
+  children?: React.ReactNode;
   className?: string;
   previewState?: PreviewState;
 }
@@ -33,7 +40,7 @@ export const epCartItemFieldMeta: CodeComponentMeta<EPCartItemFieldProps> = {
   name: "plasmic-commerce-ep-cart-item-field",
   displayName: "EP Cart Item Field",
   description:
-    "Displays a field from the current cart item (name, price, quantity, etc.). Must be inside an EP Cart Item List.",
+    "Displays a field from the current cart item (name, price, quantity, options, …). Renders the value as text by default; drop children to fully compose the rendering against the resolved value ($ctx.resolvedValue / options / hasValue). Must be inside an EP Cart Item List.",
   props: {
     field: {
       type: "choice",
@@ -44,7 +51,8 @@ export const epCartItemFieldMeta: CodeComponentMeta<EPCartItemFieldProps> = {
         { label: "Formatted Price", value: "formattedPrice" },
         { label: "Formatted List Price", value: "formattedListPrice" },
         { label: "Formatted Line Total", value: "formattedLineTotal" },
-        { label: "Options", value: "options" },
+        { label: "Options (Name: Value)", value: "options" },
+        { label: "Option Values (Value / Value)", value: "optionValues" },
         { label: "Location Name", value: "locationName" },
         { label: "Location Slug", value: "locationSlug" },
         { label: "Stock Available", value: "stockAvailable" },
@@ -54,6 +62,13 @@ export const epCartItemFieldMeta: CodeComponentMeta<EPCartItemFieldProps> = {
       ],
       defaultValue: "name",
       displayName: "Field",
+    },
+    children: {
+      type: "slot",
+      displayName: "Children (custom render)",
+      description:
+        "Optional. When filled, you compose the rendering; descendants read $ctx.resolvedValue (string), $ctx.options ({name,value}[]), and $ctx.hasValue (boolean). Leave empty for the sensible default text.",
+      hidePlaceholder: true,
     },
     previewState: {
       type: "choice",
@@ -67,33 +82,75 @@ export const epCartItemFieldMeta: CodeComponentMeta<EPCartItemFieldProps> = {
   },
   importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
   importName: "EPCartItemField",
+  providesData: true,
 };
 
+/** Resolve the display string + structured options + presence for a field. */
+function resolveCartItemField(
+  item: Record<string, any>,
+  field: CartItemFieldName
+): { resolvedValue: string; options: CartItemOption[]; hasValue: boolean } {
+  const options = (item.options as CartItemOption[] | undefined) ?? [];
+
+  if (field === "options") {
+    const resolvedValue = options
+      .map((o) => `${o.name}: ${o.value}`)
+      .join(", ");
+    return { resolvedValue, options, hasValue: options.length > 0 };
+  }
+
+  if (field === "optionValues") {
+    const resolvedValue = formatOptionValues(options);
+    return { resolvedValue, options, hasValue: resolvedValue !== "" };
+  }
+
+  const raw = item[field];
+  const resolvedValue = raw == null ? "" : String(raw);
+  return { resolvedValue, options, hasValue: resolvedValue !== "" };
+}
+
 export function EPCartItemField(props: EPCartItemFieldProps) {
-  const { field, className, previewState = "auto" } = props;
+  const { field, children, className, previewState = "auto" } = props;
 
   const currentItem = useSelector("currentCartItem") as
     | Record<string, any>
     | undefined;
   const inEditor = !!usePlasmicCanvasContext();
 
-  const useMock =
-    previewState === "withData" || (!currentItem && inEditor);
-
+  const useMock = previewState === "withData" || (!currentItem && inEditor);
   const effectiveItem = useMock ? MOCK_CART_LINE_ITEMS[0] : currentItem;
 
   if (!effectiveItem) return null;
 
-  if (field === "options") {
-    const options = effectiveItem.options as
-      | { name: string; value: string }[]
-      | undefined;
-    const display = options?.map((o) => `${o.name}: ${o.value}`).join(", ");
-    return <span className={className}>{display ?? ""}</span>;
+  const { resolvedValue, options, hasValue } = resolveCartItemField(
+    effectiveItem,
+    field
+  );
+
+  // Slot filled → designer fully composes the rendering against the resolved
+  // value; the presence flag lets them gate surrounding markup themselves.
+  const hasChildren = React.Children.count(children) > 0;
+  if (hasChildren) {
+    return (
+      <DataProvider name="resolvedValue" data={resolvedValue}>
+        <DataProvider name="options" data={options}>
+          <DataProvider name="hasValue" data={hasValue}>
+            <div className={className} data-ep-cart-item-field="">
+              {children}
+            </div>
+          </DataProvider>
+        </DataProvider>
+      </DataProvider>
+    );
   }
 
-  const value = effectiveItem[field];
-  return <span className={className}>{value ?? ""}</span>;
+  // Default: render the resolved value as text (empty options → empty string,
+  // never "undefined" or stray separators).
+  return (
+    <span className={className} data-ep-cart-item-field="">
+      {resolvedValue}
+    </span>
+  );
 }
 
 export function registerEPCartItemField(

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemList.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemList.tsx
@@ -10,7 +10,7 @@ import registerComponent, {
 import React, { useMemo } from "react";
 import { DEFAULT_CURRENCY_CODE, DEFAULT_LOW_STOCK_THRESHOLD } from "../const";
 import { Registerable } from "../registerable";
-import { formatCurrency } from "../utils/formatCurrency";
+import { CurrencyDisplay, formatCurrency } from "../utils/formatCurrency";
 import { createLogger } from "../utils/logger";
 import { useLocations } from "../inventory/use-locations";
 import { useStock } from "../inventory/use-stock";
@@ -114,7 +114,8 @@ function enrichLineItem(
   item: any,
   currencyCode: string,
   locationMap: Record<string, string>,
-  stockMap: Record<string, Record<string, number>>
+  stockMap: Record<string, Record<string, number>>,
+  currencyDisplay: CurrencyDisplay = "symbol"
 ): EnrichedCartItem {
   const price = item.variant?.price ?? item.price ?? 0;
   const listPrice = item.variant?.listPrice ?? item.listPrice ?? price;
@@ -152,10 +153,10 @@ function enrichLineItem(
     sku: item.variant?.sku ?? item.sku ?? "",
     price,
     listPrice,
-    formattedPrice: formatCurrency(price, currencyCode),
-    formattedListPrice: formatCurrency(listPrice, currencyCode),
+    formattedPrice: formatCurrency(price, currencyCode, currencyDisplay),
+    formattedListPrice: formatCurrency(listPrice, currencyCode, currencyDisplay),
     lineTotal,
-    formattedLineTotal: formatCurrency(lineTotal, currencyCode),
+    formattedLineTotal: formatCurrency(lineTotal, currencyCode, currencyDisplay),
     imageUrl: item.variant?.image?.url ?? "",
     imageAlt: item.variant?.image?.alt ?? item.name ?? "",
     options: item.options ?? [],
@@ -171,7 +172,7 @@ export function EPCartItemList(props: EPCartItemListProps) {
   const { children, className, maxItems, previewState = "auto" } = props;
 
   const cartData = useSelector("cartData") as
-    | { lineItems?: any[]; currencyCode?: string }
+    | { lineItems?: any[]; currencyCode?: string; currencyDisplay?: CurrencyDisplay }
     | undefined;
   const inEditor = !!usePlasmicCanvasContext();
 
@@ -243,8 +244,9 @@ export function EPCartItemList(props: EPCartItemListProps) {
     }
     if (!cartData?.lineItems) return [];
     const currencyCode = cartData.currencyCode ?? DEFAULT_CURRENCY_CODE;
+    const currencyDisplay = cartData.currencyDisplay ?? "symbol";
     return cartData.lineItems.map((item) =>
-      enrichLineItem(item, currencyCode, locationMap, stockMap)
+      enrichLineItem(item, currencyCode, locationMap, stockMap, currencyDisplay)
     );
   }, [useMock, cartData, locationMap, stockMap]);
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartPopover.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartPopover.tsx
@@ -1,0 +1,324 @@
+import {
+  DataProvider,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import useCart from "../cart/use-cart";
+import { useCommerce } from "../elastic-path";
+import { Registerable } from "../registerable";
+import { deriveCartData } from "../utils/cart-data";
+import { MOCK_CART_DATA, MOCK_EMPTY_CART_DATA } from "../utils/design-time-data";
+import {
+  getPopoverPositionStyles,
+  PopoverPlacement,
+} from "../utils/popover-position";
+import {
+  OverlayEditorOpenProps,
+  useOverlayEditorOpen,
+} from "./use-overlay-editor-open";
+
+type PreviewState = "auto" | "withItems" | "empty" | "loading" | "error";
+
+interface EPCartPopoverProps extends OverlayEditorOpenProps {
+  trigger?: React.ReactNode;
+  children?: React.ReactNode;
+  emptyContent?: React.ReactNode;
+  loadingContent?: React.ReactNode;
+  errorContent?: React.ReactNode;
+  className?: string;
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+  placement?: PopoverPlacement;
+  offset?: number;
+  closeOnOutsideClick?: boolean;
+  closeOnEscape?: boolean;
+  previewState?: PreviewState;
+}
+
+export const epCartPopoverMeta: CodeComponentMeta<EPCartPopoverProps> = {
+  name: "plasmic-commerce-ep-cart-popover",
+  displayName: "EP Cart Popover",
+  description:
+    "Anchored cart popover. A trigger button toggles a panel that displays cart contents, positioned relative to the trigger. Fetches cart data and provides it to child components — no portal needed.",
+  defaultStyles: {
+    width: "360px",
+    maxWidth: "90vw",
+    padding: "8px",
+    backgroundColor: "#ffffff",
+    borderRadius: "8px",
+    boxShadow: "0 8px 24px rgba(0, 0, 0, 0.2)",
+    overflow: "hidden",
+  },
+  props: {
+    trigger: {
+      type: "slot",
+      displayName: "Trigger",
+      defaultValue: [{ type: "text", value: "Cart (0)" }],
+    },
+    children: {
+      type: "slot",
+      defaultValue: [
+        {
+          type: "component",
+          name: "plasmic-commerce-ep-cart-item-list",
+        },
+        {
+          type: "component",
+          name: "plasmic-commerce-ep-cart-field",
+          props: { field: "formattedTotal" },
+        },
+      ],
+    },
+    emptyContent: {
+      type: "slot",
+      displayName: "Empty Content",
+      defaultValue: { type: "text", value: "Your cart is empty" },
+    },
+    loadingContent: {
+      type: "slot",
+      displayName: "Loading Content",
+      defaultValue: { type: "text", value: "Loading cart..." },
+    },
+    errorContent: {
+      type: "slot",
+      displayName: "Error Content",
+      defaultValue: { type: "text", value: "Failed to load cart" },
+    },
+    isOpen: {
+      type: "boolean",
+      displayName: "Open",
+      description:
+        "Controls whether the popover is open. Bind to a Plasmic state variable for two-way control; leave unbound to let the trigger manage it.",
+    },
+    onOpenChange: {
+      type: "eventHandler" as const,
+      argTypes: [{ name: "isOpen", type: "boolean" }],
+    },
+    placement: {
+      type: "choice",
+      options: ["bottom-end", "bottom-start", "top-end", "top-start"],
+      defaultValue: "bottom-end",
+      displayName: "Placement",
+      description: "Where the panel anchors relative to the trigger",
+    },
+    offset: {
+      type: "number",
+      defaultValue: 8,
+      displayName: "Offset",
+      description: "Gap (px) between the trigger and the panel",
+      advanced: true,
+    },
+    closeOnOutsideClick: {
+      type: "boolean",
+      defaultValue: true,
+      displayName: "Close on Outside Click",
+      advanced: true,
+    },
+    closeOnEscape: {
+      type: "boolean",
+      defaultValue: true,
+      displayName: "Close on Escape",
+      advanced: true,
+    },
+    previewState: {
+      type: "choice",
+      options: ["auto", "withItems", "empty", "loading", "error"],
+      defaultValue: "auto",
+      displayName: "Preview State",
+      description:
+        "Force the panel open with sample data for design-time editing",
+      advanced: true,
+    },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPCartPopover",
+  providesData: true,
+  states: {
+    isOpen: {
+      type: "writable",
+      variableType: "boolean",
+      valueProp: "isOpen",
+      onChangeProp: "onOpenChange",
+    },
+  },
+};
+
+// Structural styles for the wrapper — only positioning, so the panel can be
+// absolutely anchored to the trigger. Visual styles for the panel come from
+// Plasmic's className via defaultStyles so the designer can override them.
+const WRAPPER_STYLES: React.CSSProperties = {
+  position: "relative",
+  display: "inline-block",
+};
+
+export function EPCartPopover(props: EPCartPopoverProps) {
+  const {
+    trigger,
+    children,
+    emptyContent,
+    loadingContent,
+    errorContent,
+    className,
+    isOpen: isOpenProp,
+    onOpenChange,
+    placement = "bottom-end",
+    offset = 8,
+    closeOnOutsideClick = true,
+    closeOnEscape = true,
+    previewState = "auto",
+  } = props;
+
+  const { data: cart, error: cartError } = useCart();
+  const { providerRef } = useCommerce();
+  const currencyDisplay = providerRef?.current?.currencyDisplay ?? "symbol";
+  const inEditor = !!usePlasmicCanvasContext();
+  // Open the panel in the Studio canvas when this component (or a descendant)
+  // is selected in the outline — unless the trigger slot itself is selected.
+  const autoOpenForEditing = useOverlayEditorOpen(props, {
+    triggerSlotName: "trigger",
+  });
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Open state: controlled when `isOpen` is bound, otherwise component-local.
+  const isControlled = isOpenProp !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isOpen = isControlled ? !!isOpenProp : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const toggle = useCallback(() => setOpen(!isOpen), [setOpen, isOpen]);
+  const close = useCallback(() => setOpen(false), [setOpen]);
+
+  // Escape key handler
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape || inEditor) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        close();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, closeOnEscape, close, inEditor]);
+
+  // Outside-click handler — close when a click lands outside the wrapper.
+  useEffect(() => {
+    if (!isOpen || !closeOnOutsideClick || inEditor) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        close();
+      }
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [isOpen, closeOnOutsideClick, close, inEditor]);
+
+  // Build enriched cart data for DataProvider — formatted money honours the
+  // provider's currencyDisplay preference (symbol vs. ISO code prefix).
+  const cartData = useMemo(
+    () => deriveCartData(cart, { currencyDisplay }),
+    [cart, currencyDisplay]
+  );
+
+  // --- Preview state handling ---
+
+  const useMock =
+    previewState === "withItems" ||
+    (previewState === "auto" && !cart && inEditor);
+
+  const effectiveCartData = useMock ? MOCK_CART_DATA : cartData;
+
+  // In the editor the panel opens when this node is selected in the outline
+  // (autoOpenForEditing) or when a previewState is explicitly chosen, so the
+  // designer can see, select, and style it. previewState then selects which
+  // content branch to render.
+  const panelOpen = inEditor
+    ? previewState !== "auto" || autoOpenForEditing || isOpen
+    : isOpen;
+
+  const positionStyles = getPopoverPositionStyles(placement, offset);
+
+  // Resolve which content to show inside the panel.
+  let panelContent: React.ReactNode = null;
+  if (panelOpen) {
+    if (inEditor && previewState === "loading") {
+      panelContent = loadingContent;
+    } else if (inEditor && previewState === "error") {
+      panelContent = errorContent;
+    } else if (inEditor && previewState === "empty") {
+      panelContent = emptyContent;
+    } else if (!cart && !cartError && !useMock) {
+      panelContent = loadingContent;
+    } else if (cartError) {
+      panelContent = errorContent;
+    } else {
+      panelContent = effectiveCartData?.isEmpty ? emptyContent : children;
+    }
+  }
+
+  // DataProvider for the empty editor branch needs an emptied mock so child
+  // components render against a zero-item cart.
+  const providedData =
+    inEditor && previewState === "empty"
+      ? MOCK_EMPTY_CART_DATA
+      : effectiveCartData;
+
+  return (
+    <div ref={wrapperRef} style={WRAPPER_STYLES} data-ep-cart-popover-wrapper="">
+      <div
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        data-ep-cart-popover-trigger=""
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+      >
+        {trigger}
+      </div>
+
+      {panelOpen && (
+        <DataProvider name="cartData" data={providedData}>
+          <div
+            className={className}
+            role="dialog"
+            aria-label="Shopping cart"
+            data-ep-cart-popover=""
+            data-placement={placement}
+            data-open={isOpen || undefined}
+            style={positionStyles}
+          >
+            {panelContent}
+          </div>
+        </DataProvider>
+      )}
+    </div>
+  );
+}
+
+export function registerEPCartPopover(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPCartPopoverProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPCartPopover, customMeta ?? epCartPopoverMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
@@ -55,6 +55,7 @@ jest.mock("../../utils/getLocationSlug", () => ({
 // are controllable per-test via mockUseSelector and mockRepeatedElement.
 const mockUseSelector = jest.fn();
 const mockUsePlasmicCanvasContext = jest.fn();
+const mockUsePlasmicCanvasComponentInfo = jest.fn();
 const mockRepeatedElement = jest.fn(
   (_idx: number, children: React.ReactNode) => children
 );
@@ -69,6 +70,8 @@ jest.mock("@plasmicapp/host", () => ({
   }) => children,
   useSelector: (...args: any[]) => mockUseSelector(...args),
   usePlasmicCanvasContext: () => mockUsePlasmicCanvasContext(),
+  usePlasmicCanvasComponentInfo: (...args: any[]) =>
+    mockUsePlasmicCanvasComponentInfo(...args),
   repeatedElement: (...args: any[]) => mockRepeatedElement(...args),
 }));
 
@@ -446,6 +449,9 @@ describe("EPCartDrawer", () => {
   describe("editor mode", () => {
     beforeEach(() => {
       mockUsePlasmicCanvasContext.mockReturnValue({});
+      // Drawer mode renders in the canvas only when selected in the outline;
+      // default editor-mode tests to "selected" so they exercise the open panel.
+      mockUsePlasmicCanvasComponentInfo.mockReturnValue({ isSelected: true });
     });
 
     it("renders inline (no portal) in editor", () => {
@@ -460,6 +466,14 @@ describe("EPCartDrawer", () => {
       render(<EPCartDrawer><div>Mock content</div></EPCartDrawer>);
       // Should render children (mock cart is non-empty)
       expect(screen.getByText("Mock content")).toBeTruthy();
+    });
+
+    it("stays closed in the canvas until selected in the outline", () => {
+      mockUsePlasmicCanvasComponentInfo.mockReturnValue({ isSelected: false });
+      mockUseCart.mockReturnValue({ data: mockCart, error: null });
+      render(<EPCartDrawer><div>Hidden content</div></EPCartDrawer>);
+      // Not selected, no previewState, no isOpen → drawer renders nothing.
+      expect(screen.queryByText("Hidden content")).toBeNull();
     });
 
     it("shows loading preview state", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/index.ts
@@ -1,4 +1,5 @@
 export { EPCartDrawer, registerEPCartDrawer, registerEPCartInline } from "./EPCartDrawer";
+export { EPCartPopover, registerEPCartPopover } from "./EPCartPopover";
 export { EPCartDrawerTrigger, registerEPCartDrawerTrigger } from "./EPCartDrawerTrigger";
 export { EPCartItemList, registerEPCartItemList } from "./EPCartItemList";
 export { EPCartItemField, registerEPCartItemField } from "./EPCartItemField";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/use-overlay-editor-open.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/use-overlay-editor-open.ts
@@ -1,0 +1,43 @@
+import {
+  usePlasmicCanvasComponentInfo,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+
+/** The design-time selection props Plasmic Studio auto-injects into code components. */
+export interface OverlayEditorOpenProps {
+  /** Studio callback — fire it to tell the editor this overlay auto-opened its content. */
+  plasmicNotifyAutoOpenedContent?: () => void;
+  /** Carries the current outline-selection state; read via usePlasmicCanvasComponentInfo. */
+  __plasmic_selection_prop__?: {
+    isSelected: boolean;
+    selectedSlotName?: string;
+  };
+}
+
+/**
+ * Returns whether an overlay (drawer/popover panel) should be force-opened for
+ * editing in the Studio canvas because its node — or a descendant — is selected
+ * in the outline tree, so the designer can see and style it without a manual
+ * toggle. Mirrors react-aria's `useIsOpen` auto-open behaviour.
+ *
+ * If `triggerSlotName` is given, selecting that slot does NOT open the panel —
+ * that lets the designer edit the trigger without the panel covering it.
+ * Returns `false` outside the canvas (runtime/preview), where the real open
+ * state governs instead.
+ */
+export function useOverlayEditorOpen(
+  props: OverlayEditorOpenProps,
+  opts: { triggerSlotName?: string } = {}
+): boolean {
+  const inEditor = !!usePlasmicCanvasContext();
+  const selection = usePlasmicCanvasComponentInfo?.(props) ?? null;
+  const isSelected = selection?.isSelected ?? false;
+  const isTriggerSlotSelected =
+    !!opts.triggerSlotName && selection?.selectedSlotName === opts.triggerSlotName;
+
+  const autoOpen = inEditor && isSelected && !isTriggerSlotSelected;
+  if (autoOpen) {
+    props.plasmicNotifyAutoOpenedContent?.();
+  }
+  return autoOpen;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/use-cart.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/use-cart.test.tsx
@@ -112,6 +112,7 @@ describe("useCart handler.fetcher", () => {
       client: "mock-client",
       path: { cartID: "cart-abc" },
       query: { include: ["items"] },
+      headers: { "Accept-Language": "en-US" },
     });
     expect(result).toEqual({ id: "cart-abc", lineItems: [] });
   });
@@ -125,6 +126,25 @@ describe("useCart handler.fetcher", () => {
     await callFetcher();
 
     expect(mockNormalizeCart).toHaveBeenCalledWith(cartResp.data, "en-US");
+  });
+
+  it("sends X-Moltin-Currency + Accept-Language when the provider sets a currency", async () => {
+    mockGetCartId.mockReturnValue("cart-abc");
+    mockGetACart.mockResolvedValue(makeCartResponse("cart-abc"));
+    mockNormalizeCart.mockReturnValue({ id: "cart-abc", lineItems: [] });
+
+    await handler.fetcher({
+      input: {},
+      options: handler.fetchOptions,
+      fetch: jest.fn(),
+      provider: { locale: "en-GB", currency: "GBP", client: "mock-client" },
+    });
+
+    expect(mockGetACart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { "Accept-Language": "en-GB", "X-Moltin-Currency": "GBP" },
+      })
+    );
   });
 
   it("creates new cart when no cartId cookie exists", async () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/use-cart.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/use-cart.tsx
@@ -13,6 +13,7 @@ import {
 } from "./cart-session";
 import { handleAPIError } from "../utils/errorHandling";
 import { getEPClient } from "../utils/getEPClient";
+import { buildCartReadHeaders } from "../utils/cart-read-headers";
 import { createLogger } from "../utils/logger";
 
 const log = createLogger("useCart");
@@ -32,6 +33,14 @@ export const handler: SWRHook<GetCartHook> = {
     const cartId = await getCartIdFromSession();
     let activeCart;
 
+    // Re-price the cart for the active locale/currency at read time. Headers
+    // are omitted when the provider doesn't supply a value (policy stays in
+    // the storefront).
+    const headers = buildCartReadHeaders({
+      locale: provider?.locale,
+      currency: (provider as { currency?: string })?.currency,
+    });
+
     try {
       if (cartId) {
         // Get existing cart with items included
@@ -41,6 +50,7 @@ export const handler: SWRHook<GetCartHook> = {
           query: {
             include: ["items"],
           },
+          headers,
         });
         activeCart = response.data;
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/const.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/const.ts
@@ -14,6 +14,14 @@ export const DEFAULT_DEBOUNCE_MS = 500
 /** Delay before focusing the cart drawer after open, allowing CSS transitions to complete. */
 export const FOCUS_TRAP_DELAY_MS = 50
 
+// --- Cart overlay stacking ---
+
+/** z-index for cart overlay surfaces (drawer panel, anchored popover panel). */
+export const CART_OVERLAY_Z_INDEX = 9999
+
+/** z-index for the cart drawer backdrop (sits just below {@link CART_OVERLAY_Z_INDEX}). */
+export const CART_BACKDROP_Z_INDEX = 9998
+
 // --- Stock threshold defaults ---
 
 /** Stock level at or below which items are considered "low stock". */

--- a/plasmicpkgs/commerce-providers/elastic-path/src/elastic-path.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/elastic-path.tsx
@@ -15,5 +15,10 @@ export const useCommerce = () => useCoreCommerce<ElasticPathProvider>();
 export const getCommerceProvider = (
   creds: ElasticPathCredentials,
   locale: string,
-  serverToken?: string
-) => getCoreCommerceProvider(getElasticPathProvider(creds, locale, serverToken));
+  serverToken?: string,
+  currency?: string,
+  currencyDisplay: "symbol" | "code" = "symbol"
+) =>
+  getCoreCommerceProvider(
+    getElasticPathProvider(creds, locale, serverToken, currency, currencyDisplay)
+  );

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getCart.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/getCart.test.ts
@@ -66,6 +66,23 @@ describe("epGetCart", () => {
     );
   });
 
+  it("sends locale + currency cart-read headers from the session (SSR parity)", async () => {
+    mockGetACart.mockResolvedValue({
+      data: { data: { id: "cart-id", type: "cart", attributes: {}, meta: {} }, included: { items: [] } },
+    });
+
+    await withEpSession(
+      { ...SESSION_BASE, cartId: "cart-id", locale: "en-GB", currency: "GBP" },
+      () => epGetCart()
+    );
+
+    expect(mockGetACart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { "Accept-Language": "en-GB", "X-Moltin-Currency": "GBP" },
+      })
+    );
+  });
+
   it("returns null when no cartId is on the ALS session (anonymous visitor)", async () => {
     const result = await withEpSession(SESSION_BASE, () => epGetCart());
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
@@ -20,6 +20,7 @@ export interface BuildEpCtxSessionInput {
   cartId?: string;
   accountId?: string;
   locale?: string;
+  currency?: string;
 }
 
 export interface EpCtx {
@@ -30,6 +31,7 @@ export interface EpCtx {
   cartId?: string;
   accountId?: string;
   locale?: string;
+  currency?: string;
 }
 
 export function buildEpCtx(
@@ -51,5 +53,6 @@ export function buildEpCtx(
     cartId: opts.session.cartId,
     accountId: opts.session.accountId,
     locale: opts.session.locale,
+    currency: opts.session.currency,
   };
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
@@ -1,5 +1,6 @@
 import { getACart } from "@epcc-sdk/sdks-shopper";
 import { normalizeCart } from "../utils/normalize";
+import { buildCartReadHeaders } from "../utils/cart-read-headers";
 import { buildEpClient, isUsableAuth } from "./ep-client";
 import { getCurrentEpSession } from "./session-context";
 import { callEpProxy, shouldUseProxy } from "./proxy-fetch";
@@ -41,6 +42,12 @@ export async function epGetCart(
       client,
       path: { cartID: auth.cartId },
       query: { include: ["items"] },
+      // SSR parity with the client cart read: re-price for the shopper's
+      // locale/currency at read time (headers omitted when unset).
+      headers: buildCartReadHeaders({
+        locale: auth.locale,
+        currency: auth.currency,
+      }),
     });
     if (!response.data) return null;
     return normalizeCart(response.data, auth.locale ?? "en-US");

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/types.ts
@@ -21,4 +21,6 @@ export interface EpServerAuth {
   accountId?: string;
   /** Locale for price formatting / content negotiation. Defaults to "en-US". */
   locale?: string;
+  /** ISO 4217 currency for the cart read (X-Moltin-Currency). Storefront-resolved. */
+  currency?: string;
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -23,6 +23,7 @@ import { registerEPCartItemQuantityButton } from "./cart-drawer/EPCartItemQuanti
 import { registerEPCartItemQuantityControl } from "./cart-drawer/EPCartItemQuantityControl";
 import { registerEPCartItemList } from "./cart-drawer/EPCartItemList";
 import { registerEPCartDrawer, registerEPCartInline } from "./cart-drawer/EPCartDrawer";
+import { registerEPCartPopover } from "./cart-drawer/EPCartPopover";
 import { registerEPCartDrawerTrigger } from "./cart-drawer/EPCartDrawerTrigger";
 import { registerEPBundleProvider } from "./bundle/composable/EPBundleProvider";
 import { registerEPBundleComponentList } from "./bundle/composable/EPBundleComponentList";
@@ -133,6 +134,7 @@ export function registerAll(loader?: Registerable) {
   registerEPCartItemList(loader);
   registerEPCartDrawer(loader);
   registerEPCartInline(loader);
+  registerEPCartPopover(loader);
   registerEPCartDrawerTrigger(loader);
 
   // Composable bundle configurator

--- a/plasmicpkgs/commerce-providers/elastic-path/src/provider.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/provider.ts
@@ -51,12 +51,16 @@ const createFetcher = (creds: ElasticPathCredentials): Fetcher => {
 export const getElasticPathProvider = (
   creds: ElasticPathCredentials,
   locale: string,
-  serverToken?: string
+  serverToken?: string,
+  currency?: string,
+  currencyDisplay: "symbol" | "code" = "symbol"
 ) => {
   const client = initElasticPathClient(creds, serverToken);
 
   return {
     locale,
+    currency,
+    currencyDisplay,
     cartCookie: ELASTICPATH_CART_COOKIE,
     cart: {
       useCart,
@@ -73,6 +77,10 @@ export const getElasticPathProvider = (
 
 export type ElasticPathProvider = {
   locale: string;
+  /** ISO 4217 currency for the cart read (X-Moltin-Currency). Storefront-resolved. */
+  currency?: string;
+  /** Money display preference threaded into cart-data formatting. */
+  currencyDisplay: "symbol" | "code";
   cartCookie: string;
   fetcher: Fetcher; // Required by commerce package interface
   client: Client;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/registerCommerceProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/registerCommerceProvider.tsx
@@ -14,6 +14,8 @@ import { epProviderGetServerInfo } from "./auth/ep-provider-server-info";
 interface CommerceProviderProps extends ElasticPathCredentials {
   children?: React.ReactNode;
   locale?: string;
+  currency?: string;
+  currencyDisplay?: "symbol" | "code";
   customHost?: string;
   serverCartMode?: boolean;
   serverToken?: string;
@@ -52,6 +54,25 @@ export const commerceProviderMeta: any = {
       defaultValue: "en-US",
       description: "Locale for currency formatting and localization",
     },
+    currency: {
+      type: "string",
+      displayName: "Currency",
+      description:
+        "ISO 4217 currency code (e.g. USD, GBP, CHF) sent with the cart read so line prices and totals re-price for the active locale. Leave empty to use the cart's stored currency. Bind to your per-locale currency resolution.",
+      advanced: true,
+    },
+    currencyDisplay: {
+      type: "choice",
+      options: [
+        { label: "Symbol ($179.00)", value: "symbol" },
+        { label: "Code (USD 179.00)", value: "code" },
+      ],
+      defaultValue: "symbol",
+      displayName: "Currency Display",
+      description:
+        "How money renders across cart line prices and totals: a currency symbol or its ISO code prefix.",
+      advanced: true,
+    },
     serverCartMode: {
       type: "boolean",
       displayName: "Server Cart Mode",
@@ -80,6 +101,8 @@ export function CommerceProviderComponent(props: CommerceProviderProps) {
     host,
     customHost,
     locale = "en-US",
+    currency,
+    currencyDisplay = "symbol",
     serverCartMode = false,
     serverToken,
   } = props;
@@ -108,8 +131,8 @@ export function CommerceProviderComponent(props: CommerceProviderProps) {
   );
 
   const CommerceProvider = React.useMemo(
-    () => getCommerceProvider(creds, locale, serverToken),
-    [creds, locale, serverToken]
+    () => getCommerceProvider(creds, locale, serverToken, currency, currencyDisplay),
+    [creds, locale, serverToken, currency, currencyDisplay]
   );
 
   const ActionsProvider = serverCartMode

--- a/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.tsx
@@ -27,6 +27,8 @@ interface EPAddToCartButtonProps {
   children?: React.ReactNode;
   className?: string;
   previewState?: PreviewState;
+  /** Fired after the item is successfully added to the cart. */
+  onAddedToCart?: () => void;
 }
 
 export const epAddToCartButtonMeta: CodeComponentMeta<EPAddToCartButtonProps> = {
@@ -53,6 +55,13 @@ export const epAddToCartButtonMeta: CodeComponentMeta<EPAddToCartButtonProps> = 
         "Force a preview state with sample data for design-time editing",
       advanced: true,
     },
+    onAddedToCart: {
+      type: "eventHandler" as const,
+      displayName: "On Added To Cart",
+      description:
+        "Fires after the item is successfully added to the cart. Wire to open a confirmation modal, toast, or drawer.",
+      argTypes: [],
+    },
   },
   importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
   importName: "EPAddToCartButton",
@@ -60,7 +69,7 @@ export const epAddToCartButtonMeta: CodeComponentMeta<EPAddToCartButtonProps> = 
 };
 
 export function EPAddToCartButton(props: EPAddToCartButtonProps) {
-  const { children, className, previewState = "auto" } = props;
+  const { children, className, previewState = "auto", onAddedToCart } = props;
 
   const product = useSelector("currentProduct") as Product | undefined;
   const form = useFormContext();
@@ -124,6 +133,11 @@ export function EPAddToCartButton(props: EPAddToCartButtonProps) {
       await swrMutate(epCartCacheKey());
 
       log.info("Item added to cart successfully");
+
+      // Notify consumers (e.g. open a confirmation modal). Fired only on a
+      // successful add — never when the add is aborted (no product / invalid
+      // quantity) or errors.
+      onAddedToCart?.();
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to add item to cart";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/cart-data.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/cart-data.test.ts
@@ -1,0 +1,53 @@
+import { deriveCartData, DerivableCart } from "../cart-data";
+
+const CART: DerivableCart = {
+  id: "cart-1",
+  lineItems: [
+    { id: "li-1", quantity: 2 },
+    { id: "li-2", quantity: 1 },
+  ],
+  subtotalPrice: 179,
+  totalPrice: 179,
+  currency: { code: "USD" },
+};
+
+describe("deriveCartData", () => {
+  it("returns null for a null/undefined cart", () => {
+    expect(deriveCartData(null)).toBeNull();
+    expect(deriveCartData(undefined)).toBeNull();
+  });
+
+  it("sums itemCount from line-item quantities and flags non-empty", () => {
+    const data = deriveCartData(CART)!;
+    expect(data.itemCount).toBe(3);
+    expect(data.isEmpty).toBe(false);
+  });
+
+  it("flags an empty cart", () => {
+    const data = deriveCartData({ ...CART, lineItems: [] })!;
+    expect(data.isEmpty).toBe(true);
+    expect(data.itemCount).toBe(0);
+  });
+
+  it("propagates the currency code, defaulting when absent", () => {
+    expect(deriveCartData(CART)!.currencyCode).toBe("USD");
+    expect(
+      deriveCartData({ ...CART, currency: undefined })!.currencyCode
+    ).toBe("USD"); // DEFAULT_CURRENCY_CODE
+  });
+
+  it("formats subtotal/total with the symbol display by default", () => {
+    const data = deriveCartData(CART)!;
+    expect(data.currencyDisplay).toBe("symbol");
+    expect(data.formattedSubtotal).toContain("179");
+    expect(data.formattedSubtotal).toContain("$");
+  });
+
+  it("honours currencyDisplay 'code' on subtotal and total", () => {
+    const data = deriveCartData(CART, { currencyDisplay: "code" })!;
+    expect(data.currencyDisplay).toBe("code");
+    expect(data.formattedSubtotal).toContain("USD");
+    expect(data.formattedSubtotal).not.toContain("$");
+    expect(data.formattedTotal).toContain("USD");
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/cart-read-headers.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/cart-read-headers.test.ts
@@ -1,0 +1,31 @@
+import { buildCartReadHeaders } from "../cart-read-headers";
+
+describe("buildCartReadHeaders", () => {
+  it("sets Accept-Language from locale and X-Moltin-Currency from currency", () => {
+    expect(buildCartReadHeaders({ locale: "en-GB", currency: "GBP" })).toEqual({
+      "Accept-Language": "en-GB",
+      "X-Moltin-Currency": "GBP",
+    });
+  });
+
+  it("omits X-Moltin-Currency when currency is absent", () => {
+    expect(buildCartReadHeaders({ locale: "en-US" })).toEqual({
+      "Accept-Language": "en-US",
+    });
+  });
+
+  it("omits Accept-Language when locale is absent", () => {
+    expect(buildCartReadHeaders({ currency: "USD" })).toEqual({
+      "X-Moltin-Currency": "USD",
+    });
+  });
+
+  it("returns an empty object when neither is present", () => {
+    expect(buildCartReadHeaders({})).toEqual({});
+    expect(buildCartReadHeaders()).toEqual({});
+  });
+
+  it("omits headers for empty-string values", () => {
+    expect(buildCartReadHeaders({ locale: "", currency: "" })).toEqual({});
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/formatCurrency.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/formatCurrency.test.ts
@@ -47,6 +47,22 @@ describe("formatCurrency", () => {
     const result = formatCurrency(-15.99, "USD");
     expect(result).toContain("15.99");
   });
+
+  it("renders the ISO code prefix with display 'code'", () => {
+    const result = formatCurrency(179, "USD", "code");
+    expect(result).toContain("USD");
+    expect(result).toContain("179");
+    expect(result).not.toContain("$");
+  });
+
+  it("keeps the symbol by default and for display 'symbol'", () => {
+    expect(formatCurrency(179, "USD")).toContain("$");
+    expect(formatCurrency(179, "USD", "symbol")).toContain("$");
+  });
+
+  it("falls back to a code prefix for an invalid currency with display 'code'", () => {
+    expect(formatCurrency(42.5, "INVALID", "code")).toBe("INVALID 42.50");
+  });
 });
 
 describe("formatCurrencyFromCents", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/option-values.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/option-values.test.ts
@@ -1,0 +1,55 @@
+import { formatOptionValues } from "../option-values";
+
+describe("formatOptionValues", () => {
+  it("joins values only, in order, with the default ' / ' separator", () => {
+    expect(
+      formatOptionValues([
+        { name: "Color", value: "Blue" },
+        { name: "Size", value: "Large" },
+      ])
+    ).toBe("Blue / Large");
+  });
+
+  it("preserves option order", () => {
+    expect(
+      formatOptionValues([
+        { name: "Language", value: "English" },
+        { name: "Format", value: "PDF + ePub" },
+      ])
+    ).toBe("English / PDF + ePub");
+  });
+
+  it("renders a single option as just its value", () => {
+    expect(formatOptionValues([{ name: "Size", value: "32" }])).toBe("32");
+  });
+
+  it("returns an empty string for an empty array", () => {
+    expect(formatOptionValues([])).toBe("");
+  });
+
+  it("returns an empty string for undefined/null input (no stray separators)", () => {
+    expect(formatOptionValues(undefined)).toBe("");
+    expect(formatOptionValues(null)).toBe("");
+  });
+
+  it("skips options with an empty value", () => {
+    expect(
+      formatOptionValues([
+        { name: "Color", value: "Blue" },
+        { name: "Size", value: "" },
+      ])
+    ).toBe("Blue");
+  });
+
+  it("honours a custom separator", () => {
+    expect(
+      formatOptionValues(
+        [
+          { name: "Color", value: "Blue" },
+          { name: "Size", value: "Large" },
+        ],
+        " · "
+      )
+    ).toBe("Blue · Large");
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/popover-position.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/popover-position.test.ts
@@ -1,0 +1,43 @@
+import { getPopoverPositionStyles } from "../popover-position";
+
+describe("getPopoverPositionStyles", () => {
+  it("anchors bottom-end below the trigger, aligned to its right edge", () => {
+    expect(getPopoverPositionStyles("bottom-end", 8)).toEqual({
+      position: "absolute",
+      zIndex: 9999,
+      top: "100%",
+      marginTop: 8,
+      right: 0,
+    });
+  });
+
+  it("anchors bottom-start below the trigger, aligned to its left edge", () => {
+    expect(getPopoverPositionStyles("bottom-start", 12)).toEqual({
+      position: "absolute",
+      zIndex: 9999,
+      top: "100%",
+      marginTop: 12,
+      left: 0,
+    });
+  });
+
+  it("anchors top-end above the trigger, aligned to its right edge", () => {
+    expect(getPopoverPositionStyles("top-end", 4)).toEqual({
+      position: "absolute",
+      zIndex: 9999,
+      bottom: "100%",
+      marginBottom: 4,
+      right: 0,
+    });
+  });
+
+  it("anchors top-start above the trigger, aligned to its left edge", () => {
+    expect(getPopoverPositionStyles("top-start", 0)).toEqual({
+      position: "absolute",
+      zIndex: 9999,
+      bottom: "100%",
+      marginBottom: 0,
+      left: 0,
+    });
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/cart-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/cart-data.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_CURRENCY_CODE } from "../const";
+import { CurrencyDisplay, formatCurrency } from "./formatCurrency";
+
+/** The minimal cart shape the derivation reads (a normalized cart). */
+export interface DerivableCart {
+  id: string;
+  lineItems: Array<{ quantity?: number; [k: string]: any }>;
+  subtotalPrice: number;
+  totalPrice: number;
+  currency?: { code?: string };
+}
+
+/** Enriched cart data published as `$ctx.cartData` to the cart components. */
+export interface CartData {
+  id: string;
+  lineItems: DerivableCart["lineItems"];
+  itemCount: number;
+  isEmpty: boolean;
+  subtotalPrice: number;
+  totalPrice: number;
+  formattedSubtotal: string;
+  formattedTotal: string;
+  currencyCode: string;
+  currencyDisplay: CurrencyDisplay;
+}
+
+export interface DeriveCartDataOptions {
+  /** "symbol" (default) → `$179.00`; "code" → `USD 179.00`. */
+  currencyDisplay?: CurrencyDisplay;
+}
+
+/**
+ * Derives the enriched, formatted cart data the cart components bind to.
+ *
+ * Pure: takes a normalized cart and a `currencyDisplay` preference and returns
+ * the formatted subtotal/total (honouring the preference) plus the item count
+ * and currency metadata. `currencyDisplay` is carried on the result so per-line
+ * formatting (in the item list) stays consistent with the totals.
+ */
+export function deriveCartData(
+  cart: DerivableCart | null | undefined,
+  options: DeriveCartDataOptions = {}
+): CartData | null {
+  if (!cart) return null;
+  const currencyCode = cart.currency?.code ?? DEFAULT_CURRENCY_CODE;
+  const currencyDisplay = options.currencyDisplay ?? "symbol";
+  return {
+    id: cart.id,
+    lineItems: cart.lineItems,
+    itemCount: cart.lineItems.reduce(
+      (sum, item) => sum + (item.quantity ?? 1),
+      0
+    ),
+    isEmpty: cart.lineItems.length === 0,
+    subtotalPrice: cart.subtotalPrice,
+    totalPrice: cart.totalPrice,
+    formattedSubtotal: formatCurrency(
+      cart.subtotalPrice,
+      currencyCode,
+      currencyDisplay
+    ),
+    formattedTotal: formatCurrency(cart.totalPrice, currencyCode, currencyDisplay),
+    currencyCode,
+    currencyDisplay,
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/cart-read-headers.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/cart-read-headers.ts
@@ -1,0 +1,27 @@
+/**
+ * Builds the request headers for a locale- and currency-aware cart read.
+ *
+ * The cart read re-prices at read time when `X-Moltin-Currency` is sent, and
+ * negotiates localized content via `Accept-Language`. A header is omitted
+ * entirely when its value is absent, so the package stays policy-free — the
+ * storefront resolves the locale→currency mapping and supplies the values.
+ */
+export interface CartReadHeaderInput {
+  /** BCP-47 locale, e.g. "en-US". Sets `Accept-Language` when present. */
+  locale?: string;
+  /** ISO 4217 currency code, e.g. "USD". Sets `X-Moltin-Currency` when present. */
+  currency?: string;
+}
+
+export function buildCartReadHeaders(
+  input: CartReadHeaderInput = {}
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (input.locale) {
+    headers["Accept-Language"] = input.locale;
+  }
+  if (input.currency) {
+    headers["X-Moltin-Currency"] = input.currency;
+  }
+  return headers;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/design-time-data.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/design-time-data.ts
@@ -261,6 +261,14 @@ export const MOCK_CART_DATA = {
   currencyCode: "USD",
 };
 
+/** Empty-cart variant of {@link MOCK_CART_DATA} for the design-time "empty" preview. */
+export const MOCK_EMPTY_CART_DATA = {
+  ...MOCK_CART_DATA,
+  lineItems: [],
+  itemCount: 0,
+  isEmpty: true,
+};
+
 // ---------------------------------------------------------------------------
 // Checkout cart mock data
 // ---------------------------------------------------------------------------

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/formatCurrency.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/formatCurrency.ts
@@ -1,27 +1,38 @@
 import { DEFAULT_CURRENCY_CODE } from "../const";
 
+/** How a currency renders: a symbol (`$179.00`) or its ISO code (`USD 179.00`). */
+export type CurrencyDisplay = "symbol" | "code";
+
 /**
  * Formats a currency amount for display using Intl.NumberFormat.
  *
  * Uses the browser's locale (undefined → system default) so the same
  * currency code renders with the user's preferred number/grouping format.
- * Falls back to a plain `$<amount>` string only when Intl throws — which
- * happens for invalid currency codes, not for missing locale data.
+ * `display` maps to Intl's `currencyDisplay` — `"symbol"` (default) renders
+ * `$179.00`, `"code"` renders `USD 179.00`.
+ * Falls back to a plain string only when Intl throws — which happens for
+ * invalid currency codes, not for missing locale data. The fallback mirrors
+ * the requested display: a `$` prefix for symbol, a code prefix for code.
  *
  * @param amount — Amount in display units (e.g. 29.99, not cents)
  * @param currencyCode — ISO 4217 code (e.g. "USD", "GBP")
+ * @param display — "symbol" (default) or "code"
  */
 export function formatCurrency(
   amount: number,
-  currencyCode: string = DEFAULT_CURRENCY_CODE
+  currencyCode: string = DEFAULT_CURRENCY_CODE,
+  display: CurrencyDisplay = "symbol"
 ): string {
   try {
     return new Intl.NumberFormat(undefined, {
       style: "currency",
       currency: currencyCode,
+      currencyDisplay: display,
     }).format(amount);
   } catch {
-    return `$${amount.toFixed(2)}`;
+    return display === "code"
+      ? `${currencyCode} ${amount.toFixed(2)}`
+      : `$${amount.toFixed(2)}`;
   }
 }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/option-values.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/option-values.ts
@@ -1,0 +1,27 @@
+/** A selected variation option on a cart line item. */
+export interface CartItemOption {
+  name: string;
+  value: string;
+}
+
+/** Default separator for the values-only descriptor (e.g. "Blue / Large"). */
+export const DEFAULT_OPTION_VALUE_SEPARATOR = " / ";
+
+/**
+ * Formats a line item's selected options as a values-only descriptor, joined
+ * by `separator`, preserving the product's option order.
+ *
+ * Unlike the `Name: Value, …` rendering, this drops the labels — `[{Color,
+ * Blue}, {Size, Large}]` → `"Blue / Large"`. Empty/absent input → `""` (no
+ * stray separators), and options with an empty value are skipped.
+ */
+export function formatOptionValues(
+  options: CartItemOption[] | undefined | null,
+  separator: string = DEFAULT_OPTION_VALUE_SEPARATOR
+): string {
+  if (!options || options.length === 0) return "";
+  return options
+    .map((o) => o?.value ?? "")
+    .filter((v) => v !== "")
+    .join(separator);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/popover-position.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/popover-position.ts
@@ -1,0 +1,49 @@
+import type { CSSProperties } from "react";
+import { CART_OVERLAY_Z_INDEX } from "../const";
+
+/** Where the popover panel anchors relative to its trigger. */
+export type PopoverPlacement =
+  | "bottom-end"
+  | "bottom-start"
+  | "top-end"
+  | "top-start";
+
+/**
+ * Computes the absolute-positioning styles for a popover panel anchored to its
+ * trigger within a `position: relative` wrapper.
+ *
+ * Pure: takes a placement and a pixel offset and returns the CSS edges + gap.
+ * `bottom-*` placements drop the panel below the trigger (gap via `marginTop`);
+ * `top-*` placements raise it above (gap via `marginBottom`). `*-start` aligns
+ * the panel's left edge to the trigger; `*-end` aligns the right edge.
+ */
+export function getPopoverPositionStyles(
+  placement: PopoverPlacement,
+  offset: number
+): CSSProperties {
+  const [vertical, horizontal] = placement.split("-") as [
+    "bottom" | "top",
+    "start" | "end"
+  ];
+
+  const base: CSSProperties = {
+    position: "absolute",
+    zIndex: CART_OVERLAY_Z_INDEX,
+  };
+
+  if (vertical === "bottom") {
+    base.top = "100%";
+    base.marginTop = offset;
+  } else {
+    base.bottom = "100%";
+    base.marginBottom = offset;
+  }
+
+  if (horizontal === "start") {
+    base.left = 0;
+  } else {
+    base.right = 0;
+  }
+
+  return base;
+}


### PR DESCRIPTION
Closes #354.

Additive, backward-compatible changes so a cart page can be assembled with correct per-locale pricing and fully composable line items.

## Changes
- **Commerce provider**: new `currency` + `currencyDisplay` props (alongside `locale`), threaded into the cart read and cart-data derivation.
- **Locale/currency-aware cart read**: sends `Accept-Language` + `X-Moltin-Currency` on the inline cart hook (`cart/use-cart`) and the server `getCart` (SSR parity).
- **`EPCartItemField`**: new `optionValues` field (values-only, separator-joined) plus an optional slot exposing `$ctx.resolvedValue` / `options` / `hasValue` via `DataProvider`; the sensible default text renders when the slot is empty.
- **`formatCurrency`**: optional `display: "symbol" | "code"` (default `"symbol"`).
- **Cart-data derivation** honours `currencyDisplay` for subtotal/total and per-line formatting.
- **`EPAddToCartButton`**: new `onAddedToCart` event, fired only after a successful add (wire to a confirmation modal/toast/drawer).

## Tests
Pure helpers extracted with unit tests (root `jest`):
- cart-read header builder
- option-values formatter
- cart-data derivation
- `formatCurrency` display option

Plus updated `use-cart` / `getCart` tests for the new headers. All additive — existing carts, drawers, and mini-carts are unaffected (new provider props defaulted, new field choice + optional slot with default render preserved, new optional `formatCurrency` arg).

## Out of scope
The consumer cart page / header mini-cart UI, add-to-cart modal wiring, and unifying the multiple cart-read code paths (this threads currency/locale into the inline-cart path + the server fetch only).
