### PR TITLE
feat(ep-commerce): add EPCartItemQuantitySelect quantity control

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/CartDrawerContext.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/CartDrawerContext.tsx
@@ -51,8 +51,14 @@ export interface CartItemQuantityContextValue {
   isLoading: boolean;
   canDecrement: boolean;
   canIncrement: boolean;
+  /** The minimum allowed quantity (below this the item is removed, not set). */
+  minQuantity: number;
+  /** The maximum allowed quantity. */
+  maxQuantity: number;
   increment: () => void;
   decrement: () => void;
+  /** Set an explicit quantity (clamped to [minQuantity, maxQuantity]). */
+  setQuantity: (next: number) => void;
 }
 
 export const CartItemQuantityContext =

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityControl.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityControl.tsx
@@ -164,13 +164,29 @@ export function EPCartItemQuantityControl(
     doUpdate(newQty);
   }, [canDecrement, effectiveQuantity, doUpdate]);
 
+  const setQuantity = useCallback(
+    (next: number) => {
+      const clamped = Math.min(
+        maxQuantity,
+        Math.max(minQuantity, Math.trunc(next))
+      );
+      if (clamped === effectiveQuantity) return;
+      setLocalQuantity(clamped);
+      doUpdate(clamped);
+    },
+    [minQuantity, maxQuantity, effectiveQuantity, doUpdate]
+  );
+
   const contextValue: CartItemQuantityContextValue = {
     quantity: effectiveQuantity,
     isLoading: effectiveIsLoading,
     canDecrement,
     canIncrement,
+    minQuantity,
+    maxQuantity,
     increment,
     decrement,
+    setQuantity,
   };
 
   return (

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantitySelect.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantitySelect.tsx
@@ -1,0 +1,180 @@
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useEffect, useRef, useState } from "react";
+import { Registerable } from "../registerable";
+import {
+  getDropdownOptions,
+  getQuantityMode,
+  parseQuantityInput,
+} from "../utils/quantity-select";
+import { useCartItemQuantity } from "./CartDrawerContext";
+
+type Variant = "dropdown" | "input";
+type PreviewState = "auto" | "low" | "high";
+
+interface EPCartItemQuantitySelectProps {
+  className?: string;
+  /**
+   * `dropdown` (mini-cart): a `<select>` for low quantities that hands off to a
+   * number input once the threshold is reached. `input` (cart page): always a
+   * plain number input. Mirrors iso.org's two cart surfaces.
+   */
+  variant?: Variant;
+  /** Dropdown lists 1..threshold-1, then a terminal "{threshold}+" option. */
+  threshold?: number;
+  previewState?: PreviewState;
+}
+
+const DEFAULT_THRESHOLD = 5;
+const FALLBACK_MIN = 1;
+const FALLBACK_MAX = 99;
+
+export const epCartItemQuantitySelectMeta: CodeComponentMeta<EPCartItemQuantitySelectProps> =
+  {
+    name: "plasmic-commerce-ep-cart-item-quantity-select",
+    displayName: "EP Cart Item Quantity Select",
+    description:
+      "Editable quantity control for a cart item. As a dropdown (mini-cart) it offers low quantities and switches to a typeable input past the threshold; as an input it is always a plain number field. Must be inside an EP Cart Item Quantity Control.",
+    props: {
+      variant: {
+        type: "choice",
+        options: [
+          { label: "Dropdown (with input overflow)", value: "dropdown" },
+          { label: "Number input", value: "input" },
+        ],
+        defaultValue: "dropdown",
+        displayName: "Variant",
+      },
+      threshold: {
+        type: "number",
+        defaultValue: DEFAULT_THRESHOLD,
+        displayName: "Dropdown threshold",
+        description:
+          'Dropdown lists 1..(threshold-1) then a terminal "{threshold}+" option that switches to a number input. Only applies to the dropdown variant.',
+        hidden: (props) => props.variant === "input",
+      },
+      previewState: {
+        type: "choice",
+        options: ["auto", "low", "high"],
+        defaultValue: "auto",
+        displayName: "Preview State",
+        description:
+          "Force a preview state for design-time editing (low = dropdown, high = input).",
+        advanced: true,
+      },
+    },
+    defaultStyles: {
+      minWidth: "56px",
+      height: "32px",
+      padding: "4px 8px",
+      borderWidth: "1px",
+      borderStyle: "solid",
+      borderColor: "#cccccc",
+      borderRadius: "4px",
+      backgroundColor: "#ffffff",
+      fontSize: "15px",
+      color: "#333333",
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPCartItemQuantitySelect",
+  };
+
+export function EPCartItemQuantitySelect(
+  props: EPCartItemQuantitySelectProps
+) {
+  const {
+    className,
+    variant = "dropdown",
+    threshold = DEFAULT_THRESHOLD,
+    previewState = "auto",
+  } = props;
+
+  const ctx = useCartItemQuantity();
+  const inEditor = !!usePlasmicCanvasContext();
+
+  const useMock = previewState !== "auto" || (!ctx && inEditor);
+  const mockQuantity = previewState === "high" ? 8 : 2;
+
+  const min = ctx?.minQuantity ?? FALLBACK_MIN;
+  const max = ctx?.maxQuantity ?? FALLBACK_MAX;
+  const quantity = useMock ? mockQuantity : ctx?.quantity ?? min;
+  const isLoading = useMock ? false : ctx?.isLoading ?? false;
+  const commit = (next: number) => {
+    if (useMock) return;
+    ctx?.setQuantity(next);
+  };
+
+  // Local editable string for the input, kept in sync with the resolved
+  // quantity so external mutations (server resolve, +/- elsewhere) reflect here.
+  const [inputValue, setInputValue] = useState(String(quantity));
+  const prevQuantity = useRef(quantity);
+  useEffect(() => {
+    if (prevQuantity.current !== quantity) {
+      setInputValue(String(quantity));
+      prevQuantity.current = quantity;
+    }
+  }, [quantity]);
+
+  const mode =
+    variant === "input" ? "input" : getQuantityMode(quantity, threshold);
+
+  if (mode === "input") {
+    const commitInput = () => {
+      const parsed = parseQuantityInput(inputValue, min, max);
+      setInputValue(String(parsed));
+      commit(parsed);
+    };
+    return (
+      <input
+        className={className}
+        type="number"
+        inputMode="numeric"
+        min={min}
+        max={max}
+        step={1}
+        value={inputValue}
+        disabled={isLoading}
+        aria-label="Quantity"
+        onChange={(e) => setInputValue(e.target.value)}
+        onBlur={commitInput}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commitInput();
+          }
+        }}
+      />
+    );
+  }
+
+  const options = getDropdownOptions(threshold, min);
+  return (
+    <select
+      className={className}
+      value={String(quantity)}
+      disabled={isLoading}
+      aria-label="Quantity"
+      onChange={(e) => commit(Number(e.target.value))}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function registerEPCartItemQuantitySelect(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPCartItemQuantitySelectProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPCartItemQuantitySelect,
+    customMeta ?? epCartItemQuantitySelectMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/index.ts
@@ -7,6 +7,7 @@ export { EPCartItemImage, registerEPCartItemImage } from "./EPCartItemImage";
 export { EPCartItemRemoveButton, registerEPCartItemRemoveButton } from "./EPCartItemRemoveButton";
 export { EPCartItemQuantityControl, registerEPCartItemQuantityControl } from "./EPCartItemQuantityControl";
 export { EPCartItemQuantityButton, registerEPCartItemQuantityButton } from "./EPCartItemQuantityButton";
+export { EPCartItemQuantitySelect, registerEPCartItemQuantitySelect } from "./EPCartItemQuantitySelect";
 export { EPCartField, registerEPCartField } from "./EPCartField";
 export {
   useDrawerOpen,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -24,6 +24,7 @@ import { registerEPCartItemImage } from "./cart-drawer/EPCartItemImage";
 import { registerEPCartItemRemoveButton } from "./cart-drawer/EPCartItemRemoveButton";
 import { registerEPCartItemQuantityButton } from "./cart-drawer/EPCartItemQuantityButton";
 import { registerEPCartItemQuantityControl } from "./cart-drawer/EPCartItemQuantityControl";
+import { registerEPCartItemQuantitySelect } from "./cart-drawer/EPCartItemQuantitySelect";
 import { registerEPCartItemList } from "./cart-drawer/EPCartItemList";
 import { registerEPCartDrawer, registerEPCartInline } from "./cart-drawer/EPCartDrawer";
 import { registerEPCartPopover } from "./cart-drawer/EPCartPopover";
@@ -139,6 +140,7 @@ export function registerAll(loader?: Registerable) {
   registerEPCartItemRemoveButton(loader);
   registerEPCartItemQuantityButton(loader);
   registerEPCartItemQuantityControl(loader);
+  registerEPCartItemQuantitySelect(loader);
   registerEPCartItemList(loader);
   registerEPCartDrawer(loader);
   registerEPCartInline(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/quantity-select.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/__tests__/quantity-select.test.ts
@@ -1,0 +1,79 @@
+import {
+  getDropdownOptions,
+  getQuantityMode,
+  parseQuantityInput,
+} from "../quantity-select";
+
+describe("getQuantityMode", () => {
+  it("shows the dropdown below the threshold", () => {
+    expect(getQuantityMode(1, 5)).toBe("dropdown");
+    expect(getQuantityMode(4, 5)).toBe("dropdown");
+  });
+
+  it("switches to the input at and above the threshold", () => {
+    expect(getQuantityMode(5, 5)).toBe("input");
+    expect(getQuantityMode(42, 5)).toBe("input");
+  });
+});
+
+describe("getDropdownOptions", () => {
+  it("lists 1..4 then a terminal 5+ (min=1, threshold=5)", () => {
+    expect(getDropdownOptions(5)).toEqual([
+      { value: 1, label: "1", isOverflow: false },
+      { value: 2, label: "2", isOverflow: false },
+      { value: 3, label: "3", isOverflow: false },
+      { value: 4, label: "4", isOverflow: false },
+      { value: 5, label: "5+", isOverflow: true },
+    ]);
+  });
+
+  it("honours a custom minimum", () => {
+    expect(getDropdownOptions(4, 2)).toEqual([
+      { value: 2, label: "2", isOverflow: false },
+      { value: 3, label: "3", isOverflow: false },
+      { value: 4, label: "4+", isOverflow: true },
+    ]);
+  });
+
+  it("yields only the overflow option when min equals threshold", () => {
+    expect(getDropdownOptions(1, 1)).toEqual([
+      { value: 1, label: "1+", isOverflow: true },
+    ]);
+  });
+
+  it("marks exactly one overflow option", () => {
+    const overflow = getDropdownOptions(5).filter((o) => o.isOverflow);
+    expect(overflow).toHaveLength(1);
+    expect(overflow[0].value).toBe(5);
+  });
+});
+
+describe("parseQuantityInput", () => {
+  it("parses a valid integer string", () => {
+    expect(parseQuantityInput("7", 1, 99)).toBe(7);
+  });
+
+  it("clamps below the minimum", () => {
+    expect(parseQuantityInput("0", 1, 99)).toBe(1);
+    expect(parseQuantityInput("-3", 1, 99)).toBe(1);
+  });
+
+  it("clamps above the maximum", () => {
+    expect(parseQuantityInput("250", 1, 99)).toBe(99);
+  });
+
+  it("falls back to the minimum for empty or non-numeric input", () => {
+    expect(parseQuantityInput("", 1, 99)).toBe(1);
+    expect(parseQuantityInput("   ", 1, 99)).toBe(1);
+    expect(parseQuantityInput("abc", 1, 99)).toBe(1);
+  });
+
+  it("truncates fractional values", () => {
+    expect(parseQuantityInput("3.9", 1, 99)).toBe(3);
+    expect(parseQuantityInput(4.2, 1, 99)).toBe(4);
+  });
+
+  it("accepts a numeric argument", () => {
+    expect(parseQuantityInput(12, 1, 99)).toBe(12);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/quantity-select.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/quantity-select.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure logic for the cart-item quantity selector.
+ *
+ * iso.org's mini-cart renders quantity as a `<select>` for low values
+ * (1, 2, 3, 4) plus a terminal "5+" option that switches the control to a
+ * typeable number `<input>`. Once the quantity reaches the threshold the
+ * dropdown can no longer represent it, so the input takes over.
+ *
+ * These helpers are framework-free so the dropdown-vs-input decision, the
+ * option list, and the parse/clamp of typed values are unit-testable in
+ * isolation from the React component.
+ */
+
+export type QuantityMode = "dropdown" | "input";
+
+export interface QuantityOption {
+  /** The numeric quantity this option commits. */
+  value: number;
+  /** The visible label ("1".."4", or "5+" for the terminal option). */
+  label: string;
+  /** True for the terminal "N+" option that hands off to the number input. */
+  isOverflow: boolean;
+}
+
+/**
+ * Which control to show for a given quantity. The dropdown can represent
+ * `min .. threshold - 1`; at or above `threshold` only the input can.
+ */
+export function getQuantityMode(
+  quantity: number,
+  threshold: number
+): QuantityMode {
+  return quantity >= threshold ? "input" : "dropdown";
+}
+
+/**
+ * The dropdown's options: one per concrete value from `min` up to
+ * `threshold - 1`, then a terminal `${threshold}+` overflow option that
+ * switches the control to the number input.
+ *
+ * Example (min=1, threshold=5): 1, 2, 3, 4, 5+.
+ */
+export function getDropdownOptions(
+  threshold: number,
+  min = 1
+): QuantityOption[] {
+  const options: QuantityOption[] = [];
+  for (let v = min; v < threshold; v++) {
+    options.push({ value: v, label: String(v), isOverflow: false });
+  }
+  options.push({
+    value: threshold,
+    label: `${threshold}+`,
+    isOverflow: true,
+  });
+  return options;
+}
+
+/**
+ * Parse and clamp a raw typed value to a valid integer quantity in
+ * `[min, max]`. Non-numeric, empty, or fractional input falls back to `min`;
+ * out-of-range values are clamped to the nearest bound.
+ */
+export function parseQuantityInput(
+  raw: string | number,
+  min: number,
+  max: number
+): number {
+  const n =
+    typeof raw === "number" ? raw : parseInt(String(raw).trim(), 10);
+  if (!Number.isFinite(n)) return min;
+  const floored = Math.trunc(n);
+  if (floored < min) return min;
+  if (floored > max) return max;
+  return floored;
+}


### PR DESCRIPTION
## Summary

Adds an editable cart-item quantity control, `EPCartItemQuantitySelect`, that mirrors the two storefront cart surfaces:

- **Dropdown variant** (mini-cart): a `<select>` listing low quantities (`1 .. threshold-1`) plus a terminal `"{threshold}+"` overflow option; choosing the overflow option hands off to a typeable number `<input>`. Default threshold `5` → `1, 2, 3, 4, 5+`.
- **Input variant** (cart page): always a plain number field.

This replaces the read-only `−/+` stepper on surfaces where shoppers need to type or pick a quantity directly.

## Changes

- **New** `cart-drawer/EPCartItemQuantitySelect.tsx` — leaf component with `variant` (`dropdown` | `input`) and `threshold` props; reads quantity from the surrounding `EPCartItemQuantityControl` context. Must live inside an `EP Cart Item Quantity Control`.
- **`cart-drawer/CartDrawerContext.tsx`** — add `setQuantity`, `minQuantity`, `maxQuantity` to `CartItemQuantityContextValue`.
- **`cart-drawer/EPCartItemQuantityControl.tsx`** — implement `setQuantity` (clamp to `[min, max]` + update) and expose min/max on the context. Existing `increment`/`decrement` unchanged.
- **New** `utils/quantity-select.ts` — pure, framework-free helpers (`getQuantityMode`, `getDropdownOptions`, `parseQuantityInput`) with unit tests.
- Registered in `cart-drawer/index.ts` and `index.tsx`.

## Behaviour

The displayed control derives purely from the current quantity: `< threshold` → dropdown; selecting the `N+` option sets quantity to `threshold` → input appears; typing back below `threshold` reverts to the dropdown. Typed values are parsed, truncated to integers, and clamped to `[min, max]`; invalid/empty input falls back to `min`.

## Testing

- `quantity-select` unit tests (mode selection, option list, parse/clamp) — 12 tests.
- Full cart-drawer component suite green (123 tests).
- Manually verified both variants against a live cart: dropdown → `5+` → input, free-typing a value, and reverting below the threshold, with each change persisting to the cart.
