### PR TITLE
feat(ep-commerce): composable single-page checkout + EP-native Stripe + order custom fields

### DIFF
--- a/examples/ep-commerce-app-router/.env.local.example
+++ b/examples/ep-commerce-app-router/.env.local.example
@@ -5,8 +5,11 @@ EP_HOST=https://useast.api.elasticpath.com
 # Checkout session encryption key (min 16 characters)
 CHECKOUT_SESSION_SECRET=your-32-char-secret-key-here
 
-# Payment processing (optional)
-# STRIPE_SECRET_KEY=sk_test_...
+# EP client_credentials secret — REQUIRED for checkout / payments.
+# SERVER-ONLY. NEVER prefix with NEXT_PUBLIC_ — that would leak the
+# admin secret into the browser bundle.
+EP_CLIENT_SECRET=your-ep-client-secret
 
-# EP client secret (only needed if payment operations require client_credentials)
-# EP_CLIENT_SECRET=your-ep-client-secret
+# Stripe publishable key — exposed to the browser via the StripeProvider
+# global context. NOT a secret; safe to ship in client bundles.
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key

--- a/examples/ep-commerce-app-router/app/api/checkout/sessions/current/pay/route.ts
+++ b/examples/ep-commerce-app-router/app/api/checkout/sessions/current/pay/route.ts
@@ -1,0 +1,23 @@
+/**
+ * POST /api/checkout/sessions/current/pay — single-shot place-order.
+ *
+ * Body (slice 1): { gateway: "stripe", confirmation_token: string }
+ *
+ * Server runs: cart-hash check → adapter.initializePayment (calls EP
+ * createCartPaymentIntent with confirm:true + confirmation_token) →
+ * on succeeded: checkoutApi → confirmOrder → cart cleanup → complete.
+ */
+import type { NextRequest } from "next/server";
+import { handlePay } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { buildCheckoutContext } from "@/lib/checkout-context";
+import {
+  toSessionRequest,
+  toNextResponse,
+} from "@/lib/session-route-adapters";
+
+export async function POST(req: NextRequest) {
+  const { ctx } = await buildCheckoutContext(req);
+  const sreq = await toSessionRequest(req);
+  const sres = await handlePay(sreq, ctx);
+  return toNextResponse(sres);
+}

--- a/examples/ep-commerce-app-router/app/api/checkout/sessions/current/route.ts
+++ b/examples/ep-commerce-app-router/app/api/checkout/sessions/current/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET   /api/checkout/sessions/current — read current session.
+ * PATCH /api/checkout/sessions/current — update fields (customerInfo,
+ *                                       addresses, selectedShippingRateId).
+ */
+import type { NextRequest } from "next/server";
+import {
+  handleGetSession,
+  handleUpdateSession,
+} from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { buildCheckoutContext } from "@/lib/checkout-context";
+import {
+  toSessionRequest,
+  toNextResponse,
+} from "@/lib/session-route-adapters";
+
+export async function GET(req: NextRequest) {
+  const { ctx } = await buildCheckoutContext(req);
+  const sreq = await toSessionRequest(req);
+  const sres = await handleGetSession(sreq, ctx);
+  return toNextResponse(sres);
+}
+
+export async function PATCH(req: NextRequest) {
+  const { ctx } = await buildCheckoutContext(req);
+  const sreq = await toSessionRequest(req);
+  const sres = await handleUpdateSession(sreq, ctx);
+  return toNextResponse(sres);
+}

--- a/examples/ep-commerce-app-router/app/api/checkout/sessions/current/shipping/route.ts
+++ b/examples/ep-commerce-app-router/app/api/checkout/sessions/current/shipping/route.ts
@@ -1,0 +1,17 @@
+/**
+ * POST /api/checkout/sessions/current/shipping — fetch shipping rates.
+ */
+import type { NextRequest } from "next/server";
+import { handleCalculateShipping } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { buildCheckoutContext } from "@/lib/checkout-context";
+import {
+  toSessionRequest,
+  toNextResponse,
+} from "@/lib/session-route-adapters";
+
+export async function POST(req: NextRequest) {
+  const { ctx } = await buildCheckoutContext(req);
+  const sreq = await toSessionRequest(req);
+  const sres = await handleCalculateShipping(sreq, ctx);
+  return toNextResponse(sres);
+}

--- a/examples/ep-commerce-app-router/app/api/checkout/sessions/route.ts
+++ b/examples/ep-commerce-app-router/app/api/checkout/sessions/route.ts
@@ -1,0 +1,25 @@
+/**
+ * POST /api/checkout/sessions — create a checkout session.
+ *
+ * The cartId is resolved server-side from the better-auth session
+ * (epCartId field), so designers don't have to thread it through Plasmic
+ * interactions.
+ */
+import type { NextRequest } from "next/server";
+import { handleCreateSession } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { buildCheckoutContext } from "@/lib/checkout-context";
+import {
+  toSessionRequest,
+  toNextResponse,
+} from "@/lib/session-route-adapters";
+
+export async function POST(req: NextRequest) {
+  const { ctx, epCartId } = await buildCheckoutContext(req);
+  const sreq = await toSessionRequest(req);
+  // Inject server-resolved cartId when client didn't pass one.
+  if (!sreq.body.cartId && epCartId) {
+    sreq.body = { ...sreq.body, cartId: epCartId };
+  }
+  const sres = await handleCreateSession(sreq, ctx);
+  return toNextResponse(sres);
+}

--- a/examples/ep-commerce-app-router/lib/checkout-context.ts
+++ b/examples/ep-commerce-app-router/lib/checkout-context.ts
@@ -1,0 +1,90 @@
+/**
+ * Checkout context factory — built per-request by every checkout-session route.
+ *
+ * Resolves:
+ *   - shopperAccessToken from the better-auth session (shopper-scoped).
+ *   - getClientCredentialsToken: a closure-memoized admin token minter,
+ *     scoped to this request only (no process-level cache).
+ *   - epCartId from the better-auth session (lets routes that need a cartId
+ *     read it server-side instead of trusting the client).
+ *   - adapterRegistry with Stripe registered when EP_CLIENT_SECRET is set.
+ *   - sessionStore (cookie-based JWE).
+ */
+import {
+  CookieSessionStore,
+  createAdapterRegistry,
+  createClientCredentialsTokenResolver,
+  createStripeAdapter,
+  type SessionHandlerContext,
+} from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { epAuth, getEpProviderConfig } from "./ep-auth";
+
+const SESSION_SECRET =
+  process.env.CHECKOUT_SESSION_SECRET ??
+  "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache";
+
+const sessionStore = new CookieSessionStore(SESSION_SECRET);
+
+export interface RequestCheckoutContext {
+  ctx: SessionHandlerContext;
+  /** epCartId from the better-auth session — used by /sessions create. */
+  epCartId: string | null;
+}
+
+export async function buildCheckoutContext(
+  request: Request
+): Promise<RequestCheckoutContext> {
+  const config = await getEpProviderConfig();
+  const clientId =
+    config?.clientId ??
+    process.env.EP_CLIENT_ID ??
+    "bootstrap-placeholder";
+  const apiBaseUrl =
+    config?.host ??
+    process.env.EP_HOST ??
+    "https://useast.api.elasticpath.com";
+
+  // Read the better-auth session to pull shopper token + epCartId.
+  const session = await epAuth.api
+    .getSession({ headers: request.headers })
+    .catch(() => null);
+
+  const shopperAccessToken =
+    (session?.session as any)?.epAccessToken ?? "";
+  const epCartId = (session?.session as any)?.epCartId ?? null;
+
+  // Per-request admin-token resolver. Built only when EP_CLIENT_SECRET is
+  // present; absence cleanly disables admin-side EP calls (Stripe gateway
+  // won't be registered either).
+  const clientSecret = process.env.EP_CLIENT_SECRET;
+  const getClientCredentialsToken = clientSecret
+    ? createClientCredentialsTokenResolver({
+        host: apiBaseUrl,
+        clientId,
+        clientSecret,
+      })
+    : undefined;
+
+  // Adapter registry — register Stripe only when admin auth is available.
+  const adapterRegistry = createAdapterRegistry();
+  if (getClientCredentialsToken) {
+    adapterRegistry.register(
+      "stripe",
+      createStripeAdapter({
+        host: apiBaseUrl,
+        clientId,
+        getClientCredentialsToken,
+      })
+    );
+  }
+
+  const ctx: SessionHandlerContext = {
+    epCredentials: { clientId, apiBaseUrl },
+    adapterRegistry,
+    sessionStore,
+    shopperAccessToken,
+    getClientCredentialsToken,
+  };
+
+  return { ctx, epCartId };
+}

--- a/examples/ep-commerce-app-router/lib/session-route-adapters.ts
+++ b/examples/ep-commerce-app-router/lib/session-route-adapters.ts
@@ -1,0 +1,45 @@
+/**
+ * Adapters between Next.js NextRequest/Response and the framework-agnostic
+ * SessionRequest/SessionResponse used by the package handlers.
+ *
+ * Route files are 6-line wrappers: build per-request context, adapt request,
+ * call handler, adapt response. No business logic.
+ */
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import type {
+  SessionRequest,
+  SessionResponse,
+} from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+
+export async function toSessionRequest(
+  req: NextRequest
+): Promise<SessionRequest> {
+  let body: Record<string, unknown> = {};
+  // Some methods may have empty bodies; tolerate JSON parse failures.
+  try {
+    const text = await req.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    body = {};
+  }
+  const headers: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  const cookies: Record<string, string> = {};
+  req.cookies.getAll().forEach((c) => {
+    cookies[c.name] = c.value;
+  });
+  return { body, headers, cookies };
+}
+
+export function toNextResponse(res: SessionResponse): NextResponse {
+  const r = NextResponse.json(res.body, { status: res.status });
+  if (res.headers) {
+    for (const [k, v] of Object.entries(res.headers)) {
+      r.headers.set(k, v);
+    }
+  }
+  return r;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/calculate-shipping.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/calculate-shipping.test.ts
@@ -86,7 +86,6 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-id",
-      clientSecret: "test-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/confirm.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/confirm.test.ts
@@ -125,7 +125,6 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-id",
-      clientSecret: "test-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: createMockRegistry(adapter),

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/create-session.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/create-session.test.ts
@@ -18,6 +18,7 @@ jest.mock("@epcc-sdk/sdks-shopper", () => ({
   paymentSetup: jest.fn(),
   confirmPayment: jest.fn(),
   getShippingOptions: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
 }));
 
 // We must use require() here (not ES import) to obtain the mocked module
@@ -60,7 +61,6 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-client-id",
-      clientSecret: "test-client-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/get-session.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/get-session.test.ts
@@ -68,7 +68,6 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-id",
-      clientSecret: "test-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay-single-shot.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay-single-shot.test.ts
@@ -1,0 +1,436 @@
+/**
+ * handlePay — single-shot flow (slice 1: anonymous guest happy path).
+ *
+ * Flow:
+ *   1. Load session + guard validation (status open, gateway/fields present).
+ *   2. Cart-hash re-check.
+ *   3. adapter.initializePayment(session, { confirmation_token })
+ *   4. On succeeded: checkoutApi (cart→order) → confirmOrder → cart cleanup
+ *      → applyPaymentSucceeded → 200 with status=complete.
+ *   5. On failed: applyPaymentFailed → 200 with session.payment.status=failed,
+ *      session.status=open (retryable). No EP order created.
+ *
+ * Note: esbuild does not hoist jest.mock(). We use require() so interception
+ * works regardless of import order.
+ */
+
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  getACart: jest.fn(),
+  checkoutApi: jest.fn(),
+  confirmOrder: jest.fn(),
+  paymentSetup: jest.fn(),
+  updateACart: jest.fn(),
+  updateAnOrder: jest.fn(),
+  deleteACart: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as {
+  getACart: jest.Mock;
+  checkoutApi: jest.Mock;
+  confirmOrder: jest.Mock;
+  paymentSetup: jest.Mock;
+  updateACart: jest.Mock;
+  updateAnOrder: jest.Mock;
+  deleteACart: jest.Mock;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handlePay } = require("../pay") as {
+  handlePay: typeof import("../pay").handlePay;
+};
+
+import type {
+  SessionHandlerContext,
+  SessionRequest,
+  CheckoutSession,
+  PaymentAdapter,
+  PaymentAdapterResult,
+  AdapterRegistry,
+  SessionStore,
+} from "../../../../checkout/session/types";
+import { hashCart } from "../../../../checkout/session/cart-hash";
+
+const CART_ITEMS = [
+  { id: "item-1", quantity: 2, unit_price: { amount: 1500 } },
+  { id: "item-2", quantity: 1, unit_price: { amount: 2400 } },
+];
+
+function makeSession(overrides: Partial<CheckoutSession> = {}): CheckoutSession {
+  return {
+    id: "sess-pay",
+    status: "open",
+    cartId: "cart-abc",
+    cartHash: hashCart(CART_ITEMS),
+    customerInfo: { name: "Jane Doe", email: "jane@example.com" },
+    shippingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "12345",
+    },
+    billingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "12345",
+    },
+    selectedShippingRateId: "rate-standard",
+    availableShippingRates: [],
+    totals: null,
+    payment: {
+      gateway: null,
+      status: "idle",
+      clientToken: null,
+      gatewayMetadata: {},
+      actionData: null,
+    },
+    order: null,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function createMockStore(session: CheckoutSession | null = null): SessionStore {
+  return {
+    get: jest.fn().mockResolvedValue(session),
+    set: jest
+      .fn()
+      .mockResolvedValue({ headers: { "Set-Cookie": "ep_cs=test; Path=/" } }),
+    delete: jest
+      .fn()
+      .mockResolvedValue({ headers: { "Set-Cookie": "ep_cs=; Max-Age=0" } }),
+  };
+}
+
+function createMockAdapter(
+  initResult: PaymentAdapterResult = {
+    status: "succeeded",
+    gatewayOrderId: "pi_abc",
+    gatewayMetadata: { paymentIntentId: "pi_abc" },
+  }
+): PaymentAdapter {
+  return {
+    initializePayment: jest.fn().mockResolvedValue(initResult),
+    confirmPayment: jest.fn().mockResolvedValue({ status: "succeeded" }),
+  };
+}
+
+function createMockRegistry(adapter?: PaymentAdapter): AdapterRegistry {
+  return {
+    register: jest.fn(),
+    getAdapter: jest.fn().mockReturnValue(adapter),
+  };
+}
+
+function createMockCtx(
+  session: CheckoutSession | null,
+  adapter?: PaymentAdapter,
+  overrides: Partial<SessionHandlerContext> = {}
+): SessionHandlerContext {
+  return {
+    epCredentials: {
+      clientId: "test-id",
+      apiBaseUrl: "https://api.test.com",
+    },
+    adapterRegistry: createMockRegistry(adapter),
+    sessionStore: createMockStore(session),
+    shopperAccessToken: "shopper-token",
+    getClientCredentialsToken: jest.fn(async () => "admin-token"),
+    ...overrides,
+  };
+}
+
+function createMockReq(body: Record<string, unknown> = {}): SessionRequest {
+  return { body, headers: {}, cookies: {} };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  epSdk.getACart.mockResolvedValue({
+    data: { included: { items: CART_ITEMS } },
+  });
+  epSdk.checkoutApi.mockResolvedValue({
+    data: { data: { id: "order-1" } },
+  });
+  epSdk.confirmOrder.mockResolvedValue({ data: { data: { id: "order-1" } } });
+  epSdk.paymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+  epSdk.updateACart.mockResolvedValue({ data: { data: {} } });
+  epSdk.updateAnOrder.mockResolvedValue({ data: { data: { id: "order-1" } } });
+  epSdk.deleteACart.mockResolvedValue({ data: undefined });
+});
+
+const FREE_ITEMS = [
+  { id: "free-1", quantity: 1, unit_price: { amount: 0 }, value: { amount: 0 } },
+];
+
+describe("handlePay — single-shot guest happy path", () => {
+  it("succeeded payment → checkoutApi → confirmOrder → cart cleanup → status=complete", async () => {
+    const adapter = createMockAdapter({
+      status: "succeeded",
+      gatewayOrderId: "pi_abc",
+      gatewayMetadata: { paymentIntentId: "pi_abc" },
+    });
+    const ctx = createMockCtx(makeSession(), adapter);
+    const req = createMockReq({
+      gateway: "stripe",
+      confirmation_token: "ctoken_xyz",
+    });
+
+    const res = await handlePay(req, ctx);
+
+    expect(res.status).toBe(200);
+    const body = res.body as any;
+    expect(body.success).toBe(true);
+    expect(body.data.session.status).toBe("complete");
+    expect(body.data.session.payment.status).toBe("succeeded");
+    expect(body.data.session.order?.id).toBe("order-1");
+
+    // adapter called with the confirmation_token from req body
+    expect((adapter.initializePayment as jest.Mock).mock.calls[0][1]).toEqual({
+      confirmation_token: "ctoken_xyz",
+    });
+
+    // EP order creation happened AFTER payment succeeded
+    expect(epSdk.checkoutApi).toHaveBeenCalledTimes(1);
+    expect(epSdk.confirmOrder).toHaveBeenCalledTimes(1);
+
+    // Cart cleanup ran
+    expect(epSdk.deleteACart).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { cartID: "cart-abc" } })
+    );
+  });
+
+  it("failed payment leaves session open, payment.status=failed, no order created", async () => {
+    const adapter = createMockAdapter({
+      status: "failed",
+      errorMessage: "card_declined",
+    });
+    const ctx = createMockCtx(makeSession(), adapter);
+    const req = createMockReq({
+      gateway: "stripe",
+      confirmation_token: "ctoken_bad",
+    });
+
+    const res = await handlePay(req, ctx);
+
+    expect(res.status).toBe(200);
+    const body = res.body as any;
+    expect(body.data.session.status).toBe("open");
+    expect(body.data.session.payment.status).toBe("failed");
+    expect(body.data.session.order).toBeNull();
+
+    // No EP order created on payment failure
+    expect(epSdk.checkoutApi).not.toHaveBeenCalled();
+    expect(epSdk.confirmOrder).not.toHaveBeenCalled();
+  });
+
+  it("cart-hash mismatch returns 409 before payment is attempted", async () => {
+    epSdk.getACart.mockResolvedValue({
+      data: { included: { items: [{ id: "different", quantity: 99 }] } },
+    });
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(makeSession(), adapter);
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      ctx
+    );
+
+    expect(res.status).toBe(409);
+    expect((res.body as any).error.code).toBe("CART_MISMATCH");
+    expect(adapter.initializePayment).not.toHaveBeenCalled();
+  });
+
+  it("cart cleanup failure does not fail the response (housekeeping)", async () => {
+    epSdk.deleteACart.mockRejectedValue(new Error("EP unavailable"));
+    const adapter = createMockAdapter({
+      status: "succeeded",
+      gatewayOrderId: "pi_abc",
+      gatewayMetadata: { paymentIntentId: "pi_abc" },
+    });
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      createMockCtx(makeSession(), adapter)
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+  });
+});
+
+describe("handlePay — zero-total (free) order", () => {
+  beforeEach(() => {
+    epSdk.getACart.mockResolvedValue({
+      data: { included: { items: FREE_ITEMS } },
+    });
+  });
+
+  it("settles a free order via the manual gateway with no card / adapter", async () => {
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({ cartHash: hashCart(FREE_ITEMS) }),
+      adapter
+    );
+    // No gateway/confirmation_token — a free order needs no payment UI.
+    const res = await handlePay(createMockReq({}), ctx);
+
+    expect(res.status).toBe(200);
+    const body = res.body as any;
+    expect(body.data.session.status).toBe("complete");
+    expect(body.data.session.payment.status).toBe("succeeded");
+    expect(body.data.session.order?.id).toBe("order-1");
+
+    // Manual settlement, not the Stripe adapter
+    expect(adapter.initializePayment).not.toHaveBeenCalled();
+    expect(epSdk.checkoutApi).toHaveBeenCalledTimes(1);
+    expect(epSdk.paymentSetup).toHaveBeenCalledTimes(1);
+    expect(epSdk.paymentSetup.mock.calls[0][0].body.data).toEqual({
+      gateway: "manual",
+      method: "purchase",
+    });
+    // confirmOrder is the PaymentIntent-sync step — not used for manual.
+    expect(epSdk.confirmOrder).not.toHaveBeenCalled();
+    expect(epSdk.deleteACart).toHaveBeenCalled();
+  });
+
+  it("writes customAttributes onto the order on the free path too", async () => {
+    const ctx = createMockCtx(
+      makeSession({
+        cartHash: hashCart(FREE_ITEMS),
+        customAttributes: { language: "English", marketing: false },
+      })
+    );
+    await handlePay(createMockReq({}), ctx);
+
+    expect(epSdk.updateAnOrder).toHaveBeenCalledTimes(1);
+    expect(epSdk.updateAnOrder.mock.calls[0][0].body.data).toMatchObject({
+      type: "order",
+      language: "English",
+      marketing: false,
+    });
+  });
+
+  it("returns 502 when manual settlement fails (gateway not enabled)", async () => {
+    epSdk.paymentSetup.mockRejectedValue(new Error("gateway disabled"));
+    const ctx = createMockCtx(makeSession({ cartHash: hashCart(FREE_ITEMS) }));
+    const res = await handlePay(createMockReq({}), ctx);
+
+    expect(res.status).toBe(502);
+    expect((res.body as any).error.code).toBe("EP_ERROR");
+  });
+
+  it("uses the cart META total (not parsed items) to decide free vs paid", async () => {
+    // Regression: a paid cart whose item array doesn't parse must NOT settle
+    // for free. getACart returns no parseable items but a non-zero meta total.
+    epSdk.getACart.mockResolvedValue({
+      data: {
+        included: { items: [] },
+        data: { meta: { display_price: { with_tax: { amount: 4400, currency: "CHF" } } } },
+      },
+    });
+    const adapter = createMockAdapter({
+      status: "succeeded",
+      gatewayOrderId: "pi_paid",
+      gatewayMetadata: { paymentIntentId: "pi_paid" },
+    });
+    const ctx = createMockCtx(makeSession({ cartHash: hashCart([]) }), adapter);
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    // Paid path ran — the Stripe adapter was used, NOT manual settlement.
+    expect(adapter.initializePayment).toHaveBeenCalledTimes(1);
+    expect(epSdk.paymentSetup).not.toHaveBeenCalled();
+  });
+});
+
+describe("handlePay — generalised fields", () => {
+  it("does not require shipping when requiresShipping is false", async () => {
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({
+        requiresShipping: false,
+        shippingAddress: null,
+        selectedShippingRateId: null,
+      }),
+      adapter
+    );
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    expect(adapter.initializePayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("still requires shipping fields when requiresShipping is not false", async () => {
+    const ctx = createMockCtx(
+      makeSession({ shippingAddress: null, selectedShippingRateId: null })
+    );
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      ctx
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as any).error.code).toBe("MISSING_FIELDS");
+  });
+
+  it("persists session customAttributes to the cart before checkout", async () => {
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({
+        customAttributes: { industry: "Tech", marketingOptIn: true, vat: "" },
+      }),
+      adapter
+    );
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      ctx
+    );
+
+    expect(epSdk.updateACart).toHaveBeenCalledTimes(1);
+    const attrs = epSdk.updateACart.mock.calls[0][0].body.data.custom_attributes;
+    expect(attrs.industry).toEqual({ type: "string", value: "Tech" });
+    expect(attrs.marketingOptIn).toEqual({ type: "boolean", value: true });
+    // Empty values are dropped by toCustomAttributes.
+    expect(attrs.vat).toBeUndefined();
+  });
+
+  it("writes session customAttributes onto the order as raw flow fields", async () => {
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({
+        customAttributes: { industry: "Tech", marketingOptIn: true, vat: "" },
+      }),
+      adapter
+    );
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
+      ctx
+    );
+
+    // Order receives raw values under data (NOT the cart { type, value } shape).
+    expect(epSdk.updateAnOrder).toHaveBeenCalledTimes(1);
+    const orderBody = epSdk.updateAnOrder.mock.calls[0][0];
+    expect(orderBody.path).toEqual({ orderID: "order-1" });
+    expect(orderBody.body.data).toMatchObject({
+      type: "order",
+      industry: "Tech",
+      marketingOptIn: true,
+    });
+    // Empty values are dropped before the write.
+    expect(orderBody.body.data.vat).toBeUndefined();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay.test.ts
@@ -12,17 +12,21 @@
 jest.mock("@epcc-sdk/sdks-shopper", () => ({
   getACart: jest.fn(),
   checkoutApi: jest.fn(),
-  paymentSetup: jest.fn(),
-  confirmPayment: jest.fn(),
-  getShippingOptions: jest.fn(),
+  confirmOrder: jest.fn(),
+  paymentSetup: jest.fn(() => ({ data: { data: { status: "paid" } } })),
+  updateACart: jest.fn(() => ({ data: { data: {} } })),
+  deleteACart: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const epSdk = require("@epcc-sdk/sdks-shopper") as {
   getACart: jest.Mock;
   checkoutApi: jest.Mock;
+  confirmOrder: jest.Mock;
   paymentSetup: jest.Mock;
-  confirmPayment: jest.Mock;
+  updateACart: jest.Mock;
+  deleteACart: jest.Mock;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -104,11 +108,15 @@ function createMockStore(session: CheckoutSession | null = null): SessionStore {
 }
 
 function createMockAdapter(
-  initResult: PaymentAdapterResult = { status: "ready" }
+  initResult: PaymentAdapterResult = {
+    status: "succeeded",
+    gatewayOrderId: "pi_default",
+    gatewayMetadata: { paymentIntentId: "pi_default" },
+  }
 ): PaymentAdapter {
   return {
     initializePayment: jest.fn().mockResolvedValue(initResult),
-    confirmPayment: jest.fn().mockResolvedValue({ status: "succeeded", gatewayOrderId: "gw-123" }),
+    confirmPayment: jest.fn().mockResolvedValue({ status: "succeeded" }),
   };
 }
 
@@ -127,11 +135,12 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-id",
-      clientSecret: "test-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: createMockRegistry(adapter),
     sessionStore: createMockStore(session),
+    shopperAccessToken: "shopper-token",
+    getClientCredentialsToken: jest.fn(async () => "admin-token"),
     ...overrides,
   };
 }
@@ -174,13 +183,14 @@ describe("handlePay", () => {
   beforeEach(() => {
     epSdk.getACart.mockReset();
     epSdk.checkoutApi.mockReset();
-    epSdk.paymentSetup.mockReset();
-    epSdk.confirmPayment.mockReset();
+    epSdk.confirmOrder.mockReset();
+    epSdk.deleteACart.mockReset();
 
     // Default: all EP calls succeed
     epSdk.getACart.mockResolvedValue(makeCartResponse(CART_ITEMS) as any);
     epSdk.checkoutApi.mockResolvedValue(makeCheckoutResponse() as any);
-    epSdk.paymentSetup.mockResolvedValue(makePaymentSetupResponse() as any);
+    epSdk.confirmOrder.mockResolvedValue({ data: { data: { id: "order-1" } } } as any);
+    epSdk.deleteACart.mockResolvedValue({ data: undefined } as any);
   });
 
   // -------------------------------------------------------------------------
@@ -362,122 +372,6 @@ describe("handlePay", () => {
       expect((res.body as any).error.code).toBe("EP_ERROR");
     });
 
-    it("returns 502 when checkoutApi (cart→order) fails", async () => {
-      epSdk.checkoutApi.mockRejectedValue(new Error("Checkout failed"));
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
-      );
-      expect(res.status).toBe(502);
-      expect((res.body as any).error.code).toBe("EP_ERROR");
-    });
-
-    it("returns 502 when checkoutApi response has no order ID", async () => {
-      epSdk.checkoutApi.mockResolvedValue({ data: { data: {} } } as any);
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
-      );
-      expect(res.status).toBe(502);
-    });
-
-    it("returns 502 when paymentSetup (authorize) fails", async () => {
-      epSdk.paymentSetup.mockRejectedValue(new Error("Auth failed"));
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
-      );
-      expect(res.status).toBe(502);
-      expect((res.body as any).error.code).toBe("EP_ERROR");
-    });
-
-    it("returns 502 when paymentSetup response has no transaction ID", async () => {
-      epSdk.paymentSetup.mockResolvedValue({ data: { data: {} } } as any);
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
-      );
-      expect(res.status).toBe(502);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Adapter result mapping
-  // -------------------------------------------------------------------------
-
-  describe("adapter result: 'ready'", () => {
-    it("returns 200 on successful adapter 'ready' result", async () => {
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter({ status: "ready" }))
-      );
-      expect(res.status).toBe(200);
-    });
-
-    it("session status becomes 'processing' on 'ready'", async () => {
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter({ status: "ready" }))
-      );
-      expect((res.body as any).data.session.status).toBe("processing");
-    });
-
-    it("payment.status becomes 'pending' on 'ready'", async () => {
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter({ status: "ready" }))
-      );
-      expect((res.body as any).data.session.payment.status).toBe("pending");
-    });
-
-    it("session contains order id after successful checkout", async () => {
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter({ status: "ready" }))
-      );
-      expect((res.body as any).data.session.order?.id).toBe("order-1");
-    });
-
-    it("adapter clientToken is propagated to session.payment.clientToken", async () => {
-      const adapter = createMockAdapter({
-        status: "ready",
-        clientToken: "pi_test_secret",
-      });
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), adapter)
-      );
-      expect((res.body as any).data.session.payment.clientToken).toBe("pi_test_secret");
-    });
-  });
-
-  describe("adapter result: 'requires_action'", () => {
-    it("returns 200 with requires_action payment status", async () => {
-      const adapter = createMockAdapter({
-        status: "requires_action",
-        actionData: { redirectUrl: "https://3ds.example.com" },
-      });
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), adapter)
-      );
-      expect(res.status).toBe(200);
-      expect((res.body as any).data.session.payment.status).toBe("requires_action");
-    });
-
-    it("actionData is set on payment for 'requires_action'", async () => {
-      const actionData = { redirectUrl: "https://3ds.example.com" };
-      const adapter = createMockAdapter({ status: "requires_action", actionData });
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), adapter)
-      );
-      expect((res.body as any).data.session.payment.actionData).toEqual(actionData);
-    });
   });
 
   describe("adapter result: 'failed'", () => {
@@ -534,145 +428,56 @@ describe("handlePay", () => {
   });
 
   // -------------------------------------------------------------------------
-  // EP order retry — reuse existing order on payment retry
-  // -------------------------------------------------------------------------
-
-  describe("EP order retry", () => {
-    it("skips checkoutApi when session already has an order (retry path)", async () => {
-      const session = makeSession({
-        order: { id: "existing-order", transactionId: "old-tx" },
-        totals: { subtotal: 8000, tax: 1000, shipping: 500, total: 9000, currency: "USD" },
-      });
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(session, createMockAdapter({ status: "ready" }))
-      );
-
-      expect(res.status).toBe(200);
-      // checkoutApi should NOT have been called — the order already exists
-      expect(epSdk.checkoutApi).not.toHaveBeenCalled();
-      // paymentSetup SHOULD have been called on the existing order
-      expect(epSdk.paymentSetup).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: { orderID: "existing-order" },
-        })
-      );
-    });
-
-    it("preserves existing totals on retry (no order meta to extract from)", async () => {
-      const existingTotals = { subtotal: 5000, tax: 500, shipping: 300, total: 5800, currency: "USD" };
-      const session = makeSession({
-        order: { id: "existing-order", transactionId: "old-tx" },
-        totals: existingTotals,
-      });
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(session, createMockAdapter({ status: "ready" }))
-      );
-
-      expect(res.status).toBe(200);
-      const returnedTotals = (res.body as any).data.session.totals;
-      expect(returnedTotals).toEqual(existingTotals);
-    });
-
-    it("uses new transactionId from re-authorization on retry", async () => {
-      epSdk.paymentSetup.mockResolvedValue(makePaymentSetupResponse("new-tx-retry") as any);
-
-      const session = makeSession({
-        order: { id: "existing-order", transactionId: "old-tx" },
-        totals: { subtotal: 8000, tax: 1000, shipping: 500, total: 9000, currency: "USD" },
-      });
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(session, createMockAdapter({ status: "ready" }))
-      );
-
-      expect(res.status).toBe(200);
-      expect(
-        (res.body as any).data.session.payment.gatewayMetadata.epTransactionId
-      ).toBe("new-tx-retry");
-      expect((res.body as any).data.session.order.id).toBe("existing-order");
-    });
-
-    it("still validates cart hash on retry", async () => {
-      const differentItems = [
-        { id: "item-1", quantity: 99, unit_price: { amount: 1500 } },
-      ];
-      epSdk.getACart.mockResolvedValue(makeCartResponse(differentItems) as any);
-
-      const session = makeSession({
-        order: { id: "existing-order", transactionId: "old-tx" },
-        totals: { subtotal: 8000, tax: 1000, shipping: 500, total: 9000, currency: "USD" },
-      });
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(session, createMockAdapter())
-      );
-
-      expect(res.status).toBe(409);
-      expect((res.body as any).error.code).toBe("CART_MISMATCH");
-    });
-
-    it("returns 502 when re-authorization fails on retry", async () => {
-      epSdk.paymentSetup.mockRejectedValue(new Error("Auth failed on retry"));
-
-      const session = makeSession({
-        order: { id: "existing-order", transactionId: "old-tx" },
-        totals: { subtotal: 8000, tax: 1000, shipping: 500, total: 9000, currency: "USD" },
-      });
-
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(session, createMockAdapter())
-      );
-
-      expect(res.status).toBe(502);
-      expect((res.body as any).error.code).toBe("EP_ERROR");
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Response invariants
+  // Response invariants (slice 1: single-shot success path)
   // -------------------------------------------------------------------------
 
   describe("response invariants", () => {
     it("client session does NOT expose cartHash", async () => {
       const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
+        createMockReq({ gateway: "stripe", confirmation_token: "ct" }),
+        createMockCtx(
+          makeSession(),
+          createMockAdapter({
+            status: "succeeded",
+            gatewayOrderId: "pi_1",
+            gatewayMetadata: { paymentIntentId: "pi_1" },
+          })
+        )
       );
       const session = (res.body as any).data.session;
-      expect(Object.prototype.hasOwnProperty.call(session, "cartHash")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(session, "cartHash")).toBe(
+        false
+      );
     });
 
     it("response includes Set-Cookie header on success", async () => {
       const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
+        createMockReq({ gateway: "stripe", confirmation_token: "ct" }),
+        createMockCtx(
+          makeSession(),
+          createMockAdapter({
+            status: "succeeded",
+            gatewayOrderId: "pi_1",
+            gatewayMetadata: { paymentIntentId: "pi_1" },
+          })
+        )
       );
       expect(res.headers?.["Set-Cookie"]).toBeDefined();
     });
 
     it("gateway name is stored on session.payment.gateway", async () => {
       const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
+        createMockReq({ gateway: "stripe", confirmation_token: "ct" }),
+        createMockCtx(
+          makeSession(),
+          createMockAdapter({
+            status: "succeeded",
+            gatewayOrderId: "pi_1",
+            gatewayMetadata: { paymentIntentId: "pi_1" },
+          })
+        )
       );
       expect((res.body as any).data.session.payment.gateway).toBe("stripe");
-    });
-
-    it("EP transactionId is stored in payment.gatewayMetadata", async () => {
-      const res = await handlePay(
-        createMockReq({ gateway: "stripe" }),
-        createMockCtx(makeSession(), createMockAdapter())
-      );
-      expect(
-        (res.body as any).data.session.payment.gatewayMetadata.epTransactionId
-      ).toBe("tx-1");
     });
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/update-session.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/update-session.test.ts
@@ -72,7 +72,6 @@ function createMockCtx(
   return {
     epCredentials: {
       clientId: "test-id",
-      clientSecret: "test-secret",
       apiBaseUrl: "https://api.test.com",
     },
     adapterRegistry: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/create-session.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/create-session.ts
@@ -7,13 +7,14 @@
  * with the client-visible session shape plus Set-Cookie headers.
  */
 import { randomUUID } from "crypto";
-import { getACart } from "@epcc-sdk/sdks-shopper";
+import { getACart, createShopperClient } from "@epcc-sdk/sdks-shopper";
 import type {
   SessionRequest,
   SessionResponse,
   SessionHandlerContext,
   CheckoutSession,
   ClientCheckoutSession,
+  SessionTotals,
 } from "../../../checkout/session/types";
 import { hashCart } from "../../../checkout/session/cart-hash";
 import { createLogger } from "../../../utils/logger";
@@ -23,6 +24,26 @@ const log = createLogger("CreateSession");
 function toClientSession(s: CheckoutSession): ClientCheckoutSession {
   const { cartHash, ...rest } = s;
   return rest;
+}
+
+/**
+ * Derive session totals from an EP cart's `meta.display_price`. Returns null
+ * when the cart carries no price meta (e.g. an empty cart) — the Stripe
+ * Element then falls back to its default amount and /pay recomputes the total
+ * from the live cart anyway.
+ */
+function extractTotals(cartData: any): SessionTotals | null {
+  const dp = cartData?.meta?.display_price;
+  if (!dp) return null;
+  const total = dp.with_tax?.amount;
+  if (typeof total !== "number") return null;
+  return {
+    subtotal: dp.without_tax?.amount ?? total,
+    tax: dp.tax?.amount ?? 0,
+    shipping: 0,
+    total,
+    currency: dp.with_tax?.currency ?? "",
+  };
 }
 
 export async function handleCreateSession(
@@ -45,22 +66,29 @@ export async function handleCreateSession(
   const cartId = body.cartId as string;
   const ttl = ctx.sessionTtlSeconds ?? 1800;
 
-  // The EP SDK's Client<> type is complex; the settings-only object is the
-  // documented lightweight pattern used throughout this codebase.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const client = {
-    settings: {
-      application_id: ctx.epCredentials.clientId,
-      host: ctx.epCredentials.apiBaseUrl,
+  // Authenticated client to read the cart (compute hash + totals). Prefer the
+  // shopper token; fall back to the admin token when no shopper token is
+  // present. A tokenless client cannot read a private cart (→ EP 401).
+  let cartReadToken = ctx.shopperAccessToken ?? "";
+  if (!cartReadToken && ctx.getClientCredentialsToken) {
+    cartReadToken = await ctx.getClientCredentialsToken();
+  }
+  const { client } = createShopperClient(
+    { baseUrl: ctx.epCredentials.apiBaseUrl },
+    {
+      clientId: ctx.epCredentials.clientId,
+      storage: { get: () => cartReadToken, set: () => {} },
     },
-  } as any;
+  );
 
   let cartItems: Array<{ id: string; quantity: number; unit_price?: { amount?: number }; value?: { amount?: number } }> = [];
+  let totals: SessionTotals | null = null;
 
   try {
     const cartResponse = await getACart({ client, path: { cartID: cartId } });
     const items = (cartResponse.data as any)?.included?.items ?? (cartResponse.data as any)?.data?.items ?? [];
     cartItems = Array.isArray(items) ? items : [];
+    totals = extractTotals((cartResponse.data as any)?.data);
   } catch (err) {
     log.error("Failed to fetch cart from EP", {
       cartId,
@@ -79,6 +107,9 @@ export async function handleCreateSession(
   const sessionId = randomUUID();
   const now = Date.now();
 
+  const requiresShipping =
+    typeof body.requiresShipping === "boolean" ? body.requiresShipping : true;
+
   const session: CheckoutSession = {
     id: sessionId,
     status: "open",
@@ -89,7 +120,9 @@ export async function handleCreateSession(
     billingAddress: null,
     selectedShippingRateId: null,
     availableShippingRates: [],
-    totals: null,
+    totals,
+    requiresShipping,
+    customAttributes: {},
     payment: {
       gateway: null,
       status: "idle",

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/pay.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/pay.ts
@@ -1,20 +1,32 @@
 /**
- * A-4.5: Initiate Payment
+ * handlePay — single-shot checkout flow.
  *
- * The most complex handler in Phase A. Steps:
+ * Slice 1 (this PR): anonymous guest happy path. Steps on success:
  *   1. Load session (→ 410 if missing)
- *   2. Guard: status must be "open" (double-submit protection → 400)
- *   3. Validate gateway adapter exists (→ 400)
- *   4. Validate required checkout fields present (→ 400)
- *   5. Re-fetch cart, compare hash (→ 409 with refreshed session if mismatch)
- *   6. EP checkout: cart → order
- *   7. Read order totals
- *   8. EP authorize: create a manual/authorize transaction
- *   9. Delegate to adapter.initializePayment()
- *  10. Map adapter result status → session fields
- *  11. Persist + return
+ *   2. Guard: status open + gateway present + adapter registered + required fields
+ *   3. Re-fetch cart, compare hash (→ 409 with refreshed session if mismatch)
+ *   4. Adapter.initializePayment(session, { confirmation_token, ... })
+ *      - The adapter calls EP's createCartPaymentIntent({ confirm: true, ... })
+ *      - Returns "succeeded" or "failed" (slice 1)
+ *   5. On succeeded:
+ *      a. checkoutApi (cart→order) using admin token
+ *      b. confirmOrder (sync PI status to EP) using admin token
+ *      c. Run cart cleanup (deletes the EP cart; failures swallowed)
+ *      d. applyPaymentSucceeded → session.status = "complete"
+ *   6. On failed: applyPaymentFailed → session stays open, payment.status=failed
+ *   7. Persist session, return 200
+ *
+ * Slices 2+ add: requires_action (3DS), subscription gate (ACCOUNT_REQUIRED),
+ * account checkout body, resume-payment route.
  */
-import { getACart, checkoutApi, paymentSetup } from "@epcc-sdk/sdks-shopper";
+import {
+  getACart,
+  checkoutApi,
+  confirmOrder,
+  paymentSetup,
+  updateACart,
+  createShopperClient,
+} from "@epcc-sdk/sdks-shopper";
 import type {
   SessionRequest,
   SessionResponse,
@@ -23,14 +35,223 @@ import type {
   ClientCheckoutSession,
 } from "../../../checkout/session/types";
 import { hashCart } from "../../../checkout/session/cart-hash";
-import { toEPAddress, toEPCustomer } from "../../../checkout/session/address-utils";
+import { buildGuestCheckoutBody } from "../../../checkout/session/checkout-body-builder";
+import { runCartCleanup } from "../../../checkout/session/cart-cleanup";
+import { persistOrderCustomFields } from "../../../checkout/session/order-custom-fields";
+import {
+  applyPaymentSucceeded,
+  applyPaymentFailed,
+} from "../../../checkout/session/session-state-transition";
+import { toCustomAttributes } from "../../../ep-server-functions/place-order";
 import { createLogger } from "../../../utils/logger";
 
 const log = createLogger("Pay");
 
+/** Gateway + method used to settle a zero-total (free) order — EP best
+ * practice, since third-party gateways reject a 0 charge. */
+const FREE_ORDER_GATEWAY = "manual";
+const FREE_ORDER_METHOD = "purchase";
+
 function toClientSession(s: CheckoutSession): ClientCheckoutSession {
   const { cartHash, ...rest } = s;
   return rest;
+}
+
+/** Order total in EP minor units, summed across cart items. Prefers each
+ * item's line `value.amount`; falls back to `unit_price.amount * quantity`.
+ * Used to decide the free (== 0) vs paid (> 0) settlement path. */
+function cartItemsTotal(
+  items: Array<{
+    quantity?: number;
+    unit_price?: { amount?: number };
+    value?: { amount?: number };
+  }>
+): number {
+  return items.reduce((sum, it) => {
+    const line =
+      it.value?.amount ??
+      (it.unit_price?.amount != null
+        ? it.unit_price.amount * (it.quantity ?? 1)
+        : 0);
+    return sum + line;
+  }, 0);
+}
+
+/** Persist the session's extra fields + consent flags as cart custom
+ * attributes immediately before checkout, so they travel with the order. */
+async function persistCustomAttributes(
+  client: ReturnType<typeof createShopperClient>["client"],
+  cartId: string,
+  session: CheckoutSession
+): Promise<void> {
+  const attrs = toCustomAttributes(session.customAttributes);
+  if (!attrs) return;
+  try {
+    await updateACart({
+      client,
+      path: { cartID: cartId },
+      body: { data: { custom_attributes: attrs as never } },
+    });
+  } catch (err) {
+    // Non-fatal: the order can still be placed without the extra attributes.
+    log.warn("Failed to persist cart custom attributes", {
+      cartId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+  }
+}
+
+function buildShopperEpClient(ctx: SessionHandlerContext) {
+  const { client } = createShopperClient(
+    { baseUrl: ctx.epCredentials.apiBaseUrl },
+    {
+      clientId: ctx.epCredentials.clientId,
+      storage: {
+        get: () => ctx.shopperAccessToken ?? "",
+        set: () => {},
+      },
+    }
+  );
+  return client;
+}
+
+async function buildAdminEpClient(ctx: SessionHandlerContext) {
+  const token = ctx.getClientCredentialsToken
+    ? await ctx.getClientCredentialsToken()
+    : "";
+  const { client } = createShopperClient(
+    { baseUrl: ctx.epCredentials.apiBaseUrl },
+    {
+      clientId: ctx.epCredentials.clientId,
+      storage: {
+        get: () => token,
+        set: () => {},
+      },
+    }
+  );
+  return client;
+}
+
+/**
+ * Settle a zero-total order: cart → order, then a manual/purchase payment
+ * (which authorises-and-captures with no card), then cart cleanup. EP's
+ * documented approach for free orders — third-party gateways reject a 0
+ * charge. Assumes the store has the manual gateway enabled.
+ */
+async function settleFreeOrder(
+  req: SessionRequest,
+  ctx: SessionHandlerContext,
+  session: CheckoutSession,
+  adminClient: ReturnType<typeof createShopperClient>["client"],
+  ttl: number
+): Promise<SessionResponse> {
+  // 1. checkoutApi (cart → order)
+  let orderId: string;
+  try {
+    const checkoutResponse = await checkoutApi({
+      client: adminClient,
+      path: { cartID: session.cartId },
+      body: buildGuestCheckoutBody(session) as any,
+    });
+    const oid = (checkoutResponse.data as any)?.data?.id;
+    if (!oid) throw new Error("checkoutApi response missing order id");
+    orderId = oid;
+  } catch (err) {
+    log.error("Free-order checkoutApi failed", {
+      cartId: session.cartId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+    return {
+      status: 502,
+      body: {
+        success: false,
+        error: { message: "Free order creation failed", code: "EP_ERROR" },
+      },
+    };
+  }
+
+  // 1b. Write the checkout extras/consents onto the order as flow fields
+  //     (best-effort — the order is already created). Needs the
+  //     client_credentials grant via an explicit Bearer header.
+  await persistOrderCustomFields({
+    host: ctx.epCredentials.apiBaseUrl,
+    token: ctx.getClientCredentialsToken ? await ctx.getClientCredentialsToken() : "",
+    orderId,
+    input: session.customAttributes,
+  });
+
+  // 2. manual/purchase settles the zero-total order with no card step.
+  try {
+    await paymentSetup({
+      client: adminClient,
+      path: { orderID: orderId },
+      body: {
+        data: { gateway: FREE_ORDER_GATEWAY, method: FREE_ORDER_METHOD },
+      } as never,
+    });
+  } catch (err) {
+    log.error("Manual settlement of free order failed", {
+      orderId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+    return {
+      status: 502,
+      body: {
+        success: false,
+        error: {
+          message:
+            "Free order could not be settled (is the manual gateway enabled?)",
+          code: "EP_ERROR",
+        },
+      },
+    };
+  }
+
+  // 3. Cart cleanup — best-effort housekeeping.
+  if (ctx.getClientCredentialsToken) {
+    await runCartCleanup({
+      host: ctx.epCredentials.apiBaseUrl,
+      clientId: ctx.epCredentials.clientId,
+      getClientCredentialsToken: ctx.getClientCredentialsToken,
+      cartId: session.cartId,
+    });
+  }
+
+  // 4. Mark complete and persist.
+  const completeSession = applyPaymentSucceeded(
+    { ...session, payment: { ...session.payment, gateway: FREE_ORDER_GATEWAY } },
+    { orderId, paymentIntentId: "", gatewayMetadata: { free: true } }
+  );
+
+  let setResult: { headers: Record<string, string> };
+  try {
+    setResult = await ctx.sessionStore.set("current", completeSession, ttl, req);
+  } catch (err) {
+    log.error("Failed to persist complete free-order session", {
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+    return {
+      status: 500,
+      body: {
+        success: false,
+        error: { message: "Failed to store session", code: "STORE_ERROR" },
+      },
+    };
+  }
+
+  log.info("Free order settled", {
+    sessionId: completeSession.id,
+    orderId,
+  } as Record<string, unknown>);
+
+  return {
+    status: 200,
+    body: {
+      success: true,
+      data: { session: toClientSession(completeSession) },
+    },
+    headers: setResult.headers,
+  };
 }
 
 export async function handlePay(
@@ -49,18 +270,27 @@ export async function handlePay(
     } as Record<string, unknown>);
     return {
       status: 500,
-      body: { success: false, error: { message: "Failed to read session", code: "STORE_ERROR" } },
+      body: {
+        success: false,
+        error: { message: "Failed to read session", code: "STORE_ERROR" },
+      },
     };
   }
 
   if (!session) {
     return {
       status: 410,
-      body: { success: false, error: { message: "Session not found or has expired", code: "SESSION_GONE" } },
+      body: {
+        success: false,
+        error: {
+          message: "Session not found or has expired",
+          code: "SESSION_GONE",
+        },
+      },
     };
   }
 
-  // 2. Double-submit guard
+  // 2a. Double-submit guard
   if (session.status !== "open") {
     return {
       status: 400,
@@ -71,32 +301,17 @@ export async function handlePay(
     };
   }
 
-  // 3. Validate gateway adapter
-  const gateway = req.body.gateway;
-  if (!gateway || typeof gateway !== "string") {
-    return {
-      status: 400,
-      body: { success: false, error: { message: "gateway is required", code: "VALIDATION_ERROR" } },
-    };
-  }
-
-  const adapter = ctx.adapterRegistry.getAdapter(gateway);
-  if (!adapter) {
-    return {
-      status: 400,
-      body: {
-        success: false,
-        error: { message: `Unknown payment gateway: ${gateway}`, code: "UNKNOWN_GATEWAY" },
-      },
-    };
-  }
-
-  // 4. Validate required checkout fields
+  // 2b. Validate required checkout fields. Shipping address + rate are only
+  //     required when the checkout collects shipping (requiresShipping !==
+  //     false) — digital / single-page checkouts skip them.
+  const requiresShipping = session.requiresShipping !== false;
   const missingFields: string[] = [];
   if (!session.customerInfo) missingFields.push("customerInfo");
-  if (!session.shippingAddress) missingFields.push("shippingAddress");
   if (!session.billingAddress) missingFields.push("billingAddress");
-  if (!session.selectedShippingRateId) missingFields.push("selectedShippingRateId");
+  if (requiresShipping && !session.shippingAddress)
+    missingFields.push("shippingAddress");
+  if (requiresShipping && !session.selectedShippingRateId)
+    missingFields.push("selectedShippingRateId");
 
   if (missingFields.length > 0) {
     return {
@@ -111,35 +326,33 @@ export async function handlePay(
     };
   }
 
-  // TypeScript narrowing — we validated these above
-  const customerInfo = session.customerInfo!;
-  const shippingAddress = session.shippingAddress!;
-  const billingAddress = session.billingAddress!;
-
-  // The EP SDK's Client<> type is complex; the settings-only object is the
-  // documented lightweight pattern used throughout this codebase.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const client = {
-    settings: {
-      application_id: ctx.epCredentials.clientId,
-      host: ctx.epCredentials.apiBaseUrl,
-    },
-  } as any;
-
-  // 5. Re-fetch cart and compare hash
+  // 3. Re-fetch cart and compare hash
+  const shopperClient = buildShopperEpClient(ctx);
   let freshCartItems: Array<{
     id: string;
     quantity: number;
     unit_price?: { amount?: number };
     value?: { amount?: number };
   }> = [];
+  // Authoritative cart total comes from the cart's `meta.display_price` — the
+  // same source create-session uses. Summing parsed items is unreliable (the
+  // item array can live in different response shapes), so the free/paid branch
+  // must NOT depend on it, or a paid cart whose items don't parse would settle
+  // for free with no charge.
+  let cartMetaTotal: number | null = null;
   try {
-    const cartResponse = await getACart({ client, path: { cartID: session.cartId } });
+    const cartResponse = await getACart({
+      client: shopperClient,
+      path: { cartID: session.cartId },
+    });
     const items =
       (cartResponse.data as any)?.included?.items ??
       (cartResponse.data as any)?.data?.items ??
       [];
     freshCartItems = Array.isArray(items) ? items : [];
+    const metaAmount = (cartResponse.data as any)?.data?.meta?.display_price
+      ?.with_tax?.amount;
+    if (typeof metaAmount === "number") cartMetaTotal = metaAmount;
   } catch (err) {
     log.error("Failed to re-fetch cart for hash check", {
       cartId: session.cartId,
@@ -147,13 +360,15 @@ export async function handlePay(
     } as Record<string, unknown>);
     return {
       status: 502,
-      body: { success: false, error: { message: "Failed to fetch cart", code: "EP_ERROR" } },
+      body: {
+        success: false,
+        error: { message: "Failed to fetch cart", code: "EP_ERROR" },
+      },
     };
   }
 
   const freshHash = hashCart(freshCartItems);
   if (freshHash !== session.cartHash) {
-    // Cart has changed — refresh the stored hash and return 409
     const refreshed: CheckoutSession = { ...session, cartHash: freshHash };
     try {
       const setResult = await ctx.sessionStore.set("current", refreshed, ttl, req);
@@ -161,7 +376,10 @@ export async function handlePay(
         status: 409,
         body: {
           success: false,
-          error: { message: "Cart has changed since session was created", code: "CART_MISMATCH" },
+          error: {
+            message: "Cart has changed since session was created",
+            code: "CART_MISMATCH",
+          },
           data: { session: toClientSession(refreshed) },
         },
         headers: setResult.headers,
@@ -171,133 +389,65 @@ export async function handlePay(
         status: 409,
         body: {
           success: false,
-          error: { message: "Cart has changed since session was created", code: "CART_MISMATCH" },
+          error: {
+            message: "Cart has changed since session was created",
+            code: "CART_MISMATCH",
+          },
         },
       };
     }
   }
 
-  // 6. EP checkout: cart → order
-  // On retry (session.order already populated from a previous failed attempt),
-  // skip checkout and reuse the existing EP order. This prevents creating
-  // duplicate orders when the gateway charge failed but EP checkout succeeded.
-  let orderId: string;
-  let totals = session.totals;
-  const isRetry = !!session.order;
+  // 3b. Admin client + persist the session's extra fields/consents as cart
+  //     custom attributes (best-effort) before any checkout.
+  const adminClient = await buildAdminEpClient(ctx);
+  await persistCustomAttributes(adminClient, session.cartId, session);
 
-  if (isRetry) {
-    orderId = session.order!.id;
-    log.info("Retry detected — reusing existing EP order", {
-      orderId,
-      sessionId: session.id,
-    } as Record<string, unknown>);
-  } else {
-    // EP's BillingAddress and ShippingAddress types require fields like
-    // company_name, phone_number, and instructions that SessionAddress doesn't
-    // carry. Provide safe empty-string defaults for optional EP fields.
-    const epBilling = toEPAddress(billingAddress);
-    const epShipping = toEPAddress(shippingAddress);
-
-    let orderMeta: any;
-    try {
-      const checkoutResponse = await checkoutApi({
-        client,
-        path: { cartID: session.cartId },
-        body: {
-          data: {
-            customer: toEPCustomer(customerInfo),
-            billing_address: {
-              ...epBilling,
-              company_name: "",
-              line_2: epBilling.line_2 ?? "",
-              county: epBilling.county ?? "",
-            },
-            shipping_address: {
-              ...epShipping,
-              company_name: "",
-              phone_number: "",
-              line_2: epShipping.line_2 ?? "",
-              county: epShipping.county ?? "",
-              instructions: "",
-            },
-          } as any,
-        },
-      });
-
-      const orderData = (checkoutResponse.data as any)?.data;
-      if (!orderData?.id) {
-        throw new Error("EP checkout response missing order ID");
-      }
-      orderId = orderData.id as string;
-      orderMeta = orderData.meta;
-    } catch (err) {
-      log.error("EP checkout (cart→order) failed", {
-        cartId: session.cartId,
-        error: err instanceof Error ? err.message : String(err),
-      } as Record<string, unknown>);
-      return {
-        status: 502,
-        body: { success: false, error: { message: "Failed to create order", code: "EP_ERROR" } },
-      };
-    }
-
-    // 7. Extract totals from order meta
-    const displayPrice = orderMeta?.display_price;
-    totals = {
-      subtotal: displayPrice?.without_tax?.amount ?? 0,
-      tax: displayPrice?.tax?.amount ?? 0,
-      shipping: displayPrice?.shipping?.amount ?? 0,
-      total: displayPrice?.with_tax?.amount ?? 0,
-      currency:
-        displayPrice?.with_tax?.currency ??
-        displayPrice?.without_tax?.currency ??
-        "USD",
-    };
+  // 3c. Free-order (zero-total) branch. Stripe and other third-party gateways
+  //     reject a 0 charge, so EP best practice is to settle a free order with
+  //     the manual gateway — no card, no PaymentIntent. Run it before any
+  //     gateway/adapter requirement so a free checkout needs no payment UI.
+  // Prefer the authoritative cart-meta total; fall back to summing items only
+  // when meta is unavailable. A truly free cart has meta total 0.
+  const orderTotal =
+    cartMetaTotal !== null ? cartMetaTotal : cartItemsTotal(freshCartItems);
+  if (orderTotal === 0) {
+    return await settleFreeOrder(req, ctx, session, adminClient, ttl);
   }
 
-  // 8. EP authorize: create manual/authorize transaction
-  // A new authorization is created on every /pay attempt (including retries)
-  // because the previous authorization may have been voided or expired.
-  let transactionId: string;
-  try {
-    const authResponse = await paymentSetup({
-      client,
-      path: { orderID: orderId },
-      body: {
-        data: {
-          gateway: "manual",
-          method: "authorize",
-        },
-      },
-    });
-
-    const txData = (authResponse.data as any)?.data;
-    if (!txData?.id) {
-      throw new Error("EP paymentSetup response missing transaction ID");
-    }
-    transactionId = txData.id as string;
-  } catch (err) {
-    log.error("EP paymentSetup (authorize) failed", {
-      orderId,
-      error: err instanceof Error ? err.message : String(err),
-    } as Record<string, unknown>);
+  // 4. Paid path — a gateway + registered adapter are required.
+  const gateway = req.body.gateway;
+  if (!gateway || typeof gateway !== "string") {
     return {
-      status: 502,
+      status: 400,
       body: {
         success: false,
-        error: { message: "Failed to authorize transaction with EP", code: "EP_ERROR" },
+        error: { message: "gateway is required", code: "VALIDATION_ERROR" },
+      },
+    };
+  }
+  const adapter = ctx.adapterRegistry.getAdapter(gateway);
+  if (!adapter) {
+    return {
+      status: 400,
+      body: {
+        success: false,
+        error: {
+          message: `Unknown payment gateway: ${gateway}`,
+          code: "UNKNOWN_GATEWAY",
+        },
       },
     };
   }
 
-  // 9. Delegate to the payment adapter
-  const { gateway: _gatewayKey, ...gatewayData } = req.body as Record<string, unknown>;
+  // 4a. Single-shot: delegate to adapter (creates+confirms PaymentIntent)
+  const { gateway: _gw, ...gatewayData } = req.body as Record<string, unknown>;
 
   let adapterResult: Awaited<ReturnType<typeof adapter.initializePayment>>;
   try {
     adapterResult = await adapter.initializePayment(session, gatewayData);
   } catch (err) {
-    log.error("Payment adapter initializePayment threw", {
+    log.error("Payment adapter threw", {
       gateway,
       error: err instanceof Error ? err.message : String(err),
     } as Record<string, unknown>);
@@ -310,103 +460,180 @@ export async function handlePay(
     };
   }
 
-  // 10. Map adapter result → session fields
-  const baseSession: CheckoutSession = {
-    ...session,
-    totals,
-    order: { id: orderId, transactionId },
-    payment: {
-      gateway,
-      status: "idle",
-      clientToken: adapterResult.clientToken ?? null,
-      gatewayMetadata: {
-        epTransactionId: transactionId,
-        ...(adapterResult.gatewayMetadata ?? {}),
+  // 6. Failed branch — leave session open for retry
+  if (adapterResult.status === "failed") {
+    const failedSession: CheckoutSession = applyPaymentFailed(
+      {
+        ...session,
+        payment: { ...session.payment, gateway },
       },
-      actionData: null,
-    },
-  };
+      {
+        errorMessage: adapterResult.errorMessage,
+        gatewayMetadata: adapterResult.gatewayMetadata,
+      }
+    );
 
-  let finalSession: CheckoutSession;
-
-  switch (adapterResult.status) {
-    case "ready":
-      finalSession = {
-        ...baseSession,
-        status: "processing",
-        payment: { ...baseSession.payment, status: "pending" },
-      };
-      break;
-
-    case "requires_action":
-      finalSession = {
-        ...baseSession,
-        payment: {
-          ...baseSession.payment,
-          status: "requires_action",
-          actionData: adapterResult.actionData ?? null,
+    let setResult: { headers: Record<string, string> };
+    try {
+      setResult = await ctx.sessionStore.set("current", failedSession, ttl, req);
+    } catch (err) {
+      log.error("Failed to persist failed-payment session", {
+        error: err instanceof Error ? err.message : String(err),
+      } as Record<string, unknown>);
+      return {
+        status: 500,
+        body: {
+          success: false,
+          error: { message: "Failed to store session", code: "STORE_ERROR" },
         },
       };
-      break;
+    }
 
-    case "succeeded":
-      // Rare for initializePayment — treat same as "ready" and advance status
-      finalSession = {
-        ...baseSession,
-        status: "processing",
-        payment: { ...baseSession.payment, status: "pending" },
-      };
-      break;
-
-    case "failed":
-    default:
-      // Session stays "open" to allow retry; surface error in payment
-      finalSession = {
-        ...baseSession,
-        status: "open",
-        payment: {
-          ...baseSession.payment,
-          status: "failed",
-        },
-      };
-      break;
+    return {
+      status: 200,
+      body: {
+        success: true,
+        data: { session: toClientSession(failedSession) },
+        ...(adapterResult.errorMessage
+          ? { paymentError: adapterResult.errorMessage }
+          : {}),
+      },
+      headers: setResult.headers,
+    };
   }
 
-  // 11. Persist and return
+  // 5. Succeeded branch — create EP order, confirm, clean up cart
+  if (adapterResult.status !== "succeeded") {
+    // requires_action / ready ship in slice 2; treat as failed for slice 1.
+    log.warn("Adapter returned non-terminal status; treating as failed", {
+      status: adapterResult.status,
+    } as Record<string, unknown>);
+    const failedSession = applyPaymentFailed(
+      { ...session, payment: { ...session.payment, gateway } },
+      {
+        errorMessage: `Unsupported adapter status: ${adapterResult.status}`,
+      }
+    );
+    const setResult = await ctx.sessionStore.set(
+      "current",
+      failedSession,
+      ttl,
+      req
+    );
+    return {
+      status: 200,
+      body: { success: true, data: { session: toClientSession(failedSession) } },
+      headers: setResult.headers,
+    };
+  }
+
+  // 5a. checkoutApi (cart → order) using admin token
+  let orderId: string;
+  try {
+    const checkoutResponse = await checkoutApi({
+      client: adminClient,
+      path: { cartID: session.cartId },
+      body: buildGuestCheckoutBody(session) as any,
+    });
+    const oid = (checkoutResponse.data as any)?.data?.id;
+    if (!oid) throw new Error("checkoutApi response missing order id");
+    orderId = oid;
+  } catch (err) {
+    log.error("EP checkoutApi failed after payment success", {
+      cartId: session.cartId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+    return {
+      status: 502,
+      body: {
+        success: false,
+        error: {
+          message: "Payment succeeded but order creation failed",
+          code: "EP_ERROR",
+        },
+      },
+    };
+  }
+
+  // 5a-bis. Write the checkout extras/consents onto the order as flow fields
+  //         (best-effort — the order is already created and paid). Needs the
+  //         client_credentials grant via an explicit Bearer header.
+  await persistOrderCustomFields({
+    host: ctx.epCredentials.apiBaseUrl,
+    token: ctx.getClientCredentialsToken ? await ctx.getClientCredentialsToken() : "",
+    orderId,
+    input: session.customAttributes,
+  });
+
+  // 5b. confirmOrder — syncs the EP-side payment intent status to the order.
+  try {
+    await confirmOrder({
+      client: adminClient,
+      path: {
+        orderID: orderId,
+        // The EP API requires the paymentID on this path. The PI id from the
+        // adapter result is what EP returned as the cart's payment intent.
+        paymentID: (adapterResult.gatewayOrderId ??
+          (adapterResult.gatewayMetadata?.paymentIntentId as string)) as string,
+      } as any,
+      body: { data: {} } as any,
+    });
+  } catch (err) {
+    log.warn("confirmOrder failed (non-fatal — order is genuine)", {
+      orderId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+  }
+
+  // 5c. Cart cleanup — best-effort housekeeping
+  if (ctx.getClientCredentialsToken) {
+    await runCartCleanup({
+      host: ctx.epCredentials.apiBaseUrl,
+      clientId: ctx.epCredentials.clientId,
+      getClientCredentialsToken: ctx.getClientCredentialsToken,
+      cartId: session.cartId,
+    });
+  }
+
+  // 5d. Mark complete and persist
+  const completeSession = applyPaymentSucceeded(
+    { ...session, payment: { ...session.payment, gateway } },
+    {
+      orderId,
+      paymentIntentId:
+        (adapterResult.gatewayOrderId as string) ??
+        ((adapterResult.gatewayMetadata?.paymentIntentId as string) ?? ""),
+      gatewayMetadata: adapterResult.gatewayMetadata,
+    }
+  );
+
   let setResult: { headers: Record<string, string> };
   try {
-    setResult = await ctx.sessionStore.set("current", finalSession, ttl, req);
+    setResult = await ctx.sessionStore.set("current", completeSession, ttl, req);
   } catch (err) {
-    log.error("Failed to persist session after pay", {
-      sessionId: session.id,
+    log.error("Failed to persist complete session", {
       error: err instanceof Error ? err.message : String(err),
     } as Record<string, unknown>);
     return {
       status: 500,
-      body: { success: false, error: { message: "Failed to store session", code: "STORE_ERROR" } },
+      body: {
+        success: false,
+        error: { message: "Failed to store session", code: "STORE_ERROR" },
+      },
     };
   }
 
   log.info("Pay handler completed", {
-    sessionId: finalSession.id,
+    sessionId: completeSession.id,
     orderId,
-    adapterStatus: adapterResult.status,
-    sessionStatus: finalSession.status,
   } as Record<string, unknown>);
-
-  // For "failed", we still return 200 — the error is expressed in session.payment
-  const responseBody: Record<string, unknown> = {
-    success: true,
-    data: { session: toClientSession(finalSession) },
-  };
-
-  if (adapterResult.status === "failed" && adapterResult.errorMessage) {
-    responseBody["paymentError"] = adapterResult.errorMessage;
-  }
 
   return {
     status: 200,
-    body: responseBody,
+    body: {
+      success: true,
+      data: { session: toClientSession(completeSession) },
+    },
     headers: setResult.headers,
   };
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/update-session.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/update-session.ts
@@ -77,6 +77,17 @@ export async function handleUpdateSession(
     ...(update.selectedShippingRateId !== undefined && {
       selectedShippingRateId: update.selectedShippingRateId,
     }),
+    ...(update.requiresShipping !== undefined && {
+      requiresShipping: update.requiresShipping,
+    }),
+    // customAttributes merge (not replace) so partial updates accumulate the
+    // extra fields + consent flags a single-page form collects.
+    ...(update.customAttributes !== undefined && {
+      customAttributes: {
+        ...(session.customAttributes ?? {}),
+        ...update.customAttributes,
+      },
+    }),
   };
 
   let setResult: { headers: Record<string, string> };

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/client-credentials-resolver.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/client-credentials-resolver.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Client Credentials Token Resolver — request-scoped, memoized minter for
+ * EP's `client_credentials` OAuth grant.
+ *
+ * The resolver is built per-request (in the host app's checkout-context
+ * factory). Each instance memoizes the token in a closure: subsequent calls
+ * within the same request return the same token. Different resolver
+ * instances do not share state.
+ *
+ * Tested behaviors (slice 1):
+ *   1. Posts to {host}/oauth/access_token with grant_type=client_credentials,
+ *      client_id, client_secret in form-urlencoded body.
+ *   2. Memoizes per-instance: one mint per resolver, no matter how many calls.
+ *   3. Distinct instances mint independently — no shared cache.
+ *   4. Throws on non-2xx EP response.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createClientCredentialsTokenResolver } from "../client-credentials-resolver";
+
+const HOST = "https://api.test.elasticpath.com";
+const CLIENT_ID = "test-client-id";
+const CLIENT_SECRET = "test-client-secret";
+
+let originalFetch: typeof fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeOkResponse(token: string) {
+  return new Response(
+    JSON.stringify({
+      access_token: token,
+      token_type: "Bearer",
+      expires: Math.floor(Date.now() / 1000) + 3600,
+      expires_in: 3600,
+      identifier: "client_credentials",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  fetchMock = vi.fn(async () => makeOkResponse("admin-token-1"));
+  globalThis.fetch = fetchMock as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("createClientCredentialsTokenResolver", () => {
+  it("posts grant_type=client_credentials with client_id and client_secret", async () => {
+    const resolver = createClientCredentialsTokenResolver({
+      host: HOST,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const token = await resolver();
+
+    expect(token).toBe("admin-token-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(`${HOST}/oauth/access_token`);
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded"
+    );
+
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("client_id")).toBe(CLIENT_ID);
+    expect(body.get("client_secret")).toBe(CLIENT_SECRET);
+  });
+
+  it("memoizes within an instance: many calls, one mint", async () => {
+    const resolver = createClientCredentialsTokenResolver({
+      host: HOST,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const [a, b, c] = await Promise.all([resolver(), resolver(), resolver()]);
+    const d = await resolver();
+
+    expect(a).toBe("admin-token-1");
+    expect(b).toBe("admin-token-1");
+    expect(c).toBe("admin-token-1");
+    expect(d).toBe("admin-token-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share cache across resolver instances", async () => {
+    let n = 0;
+    fetchMock.mockImplementation(async () => {
+      n += 1;
+      return makeOkResponse(`admin-token-${n}`);
+    });
+
+    const a = createClientCredentialsTokenResolver({
+      host: HOST,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+    const b = createClientCredentialsTokenResolver({
+      host: HOST,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    expect(await a()).toBe("admin-token-1");
+    expect(await b()).toBe("admin-token-2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on non-2xx response from EP", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ errors: [{ detail: "bad creds" }] }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const resolver = createClientCredentialsTokenResolver({
+      host: HOST,
+      clientId: CLIENT_ID,
+      clientSecret: "wrong-secret",
+    });
+
+    await expect(resolver()).rejects.toThrow(/401/);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/client-credentials-resolver.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/client-credentials-resolver.ts
@@ -1,0 +1,61 @@
+/**
+ * Client Credentials Token Resolver — server-only, request-scoped factory
+ * for EP admin tokens.
+ *
+ * The host app's per-request checkout-context factory builds a fresh resolver
+ * for every incoming request. The closure memoizes the minted token so that
+ * a single request that needs the admin token in multiple places (e.g.
+ * `createCartPaymentIntent`, `checkoutApi`, `confirmOrder`, cart cleanup)
+ * mints once and reuses.
+ *
+ * Distinct resolver instances do not share state — there is no process-level
+ * cache. The closure is GC'd at request end.
+ */
+
+export interface ClientCredentialsResolverConfig {
+  host: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export type ClientCredentialsTokenResolver = () => Promise<string>;
+
+interface EpClientCredentialsTokenResponse {
+  access_token: string;
+  expires: number;
+  expires_in: number;
+  token_type: string;
+}
+
+export function createClientCredentialsTokenResolver(
+  config: ClientCredentialsResolverConfig
+): ClientCredentialsTokenResolver {
+  const { host, clientId, clientSecret } = config;
+  let pending: Promise<string> | null = null;
+
+  return async function getClientCredentialsToken(): Promise<string> {
+    if (pending) return pending;
+    pending = (async () => {
+      const url = `${host}/oauth/access_token`;
+      const body = new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: clientId,
+        client_secret: clientSecret,
+      });
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "<no body>");
+        throw new Error(
+          `EP client_credentials grant failed (${response.status}): ${text}`
+        );
+      }
+      const data = (await response.json()) as EpClientCredentialsTokenResponse;
+      return data.access_token;
+    })();
+    return pending;
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPCheckoutFormProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPCheckoutFormProvider.tsx
@@ -1,0 +1,633 @@
+/**
+ * EPCheckoutFormProvider — single-page checkout form collector + order placer.
+ *
+ * A lightweight alternative to the 4-step EPCheckoutProvider for stores
+ * whose checkout is one page (no step orchestration, optionally no
+ * shipping). It owns a shared form store that the self-contained field
+ * primitives (EPFormField / EPSelectField / EPConsentCheckbox) register
+ * into and write to, and a `placeOrder` action that maps the collected
+ * values onto an EP order and calls the consumer's `/api/ep/proxy/placeOrder`.
+ *
+ * Why self-contained primitives + a context (rather than headless
+ * providers wired by Plasmic interactions): the primitives glue themselves
+ * together through this React context, so a designer only drops them in —
+ * no per-field onChange interaction wiring is required.
+ *
+ * Field-name convention (reserved names map to the order; everything else
+ * becomes cart custom attributes):
+ *   firstName, lastName        → customer.name + billing first/last name
+ *   email                      → customer.email
+ *   company                    → billing.company_name
+ *   address                    → billing.line_1
+ *   line2                      → billing.line_2
+ *   city                       → billing.city
+ *   county                     → billing.county
+ *   postal                     → billing.postcode
+ *   country                    → billing.country
+ *   <any other field / checkbox> → cart custom_attributes
+ * Override the mapping with the `fieldMapping` prop.
+ *
+ * Provides `checkoutFormData` for designer binding and exposes
+ * `placeOrder` / `validate` / `reset` refActions.
+ */
+import {
+  DataProvider,
+  useDataEnv,
+  usePlasmicCanvasContext,
+} from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Registerable } from "../../registerable";
+import { callEpProxy } from "../../ep-server-functions/proxy-fetch";
+import type { EpPlaceOrderResult } from "../../ep-server-functions/place-order";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("EPCheckoutFormProvider");
+
+// ---------------------------------------------------------------------------
+// Field-name → order mapping
+// ---------------------------------------------------------------------------
+export interface CheckoutFieldMapping {
+  firstName: string;
+  lastName: string;
+  email: string;
+  company: string;
+  line1: string;
+  line2: string;
+  city: string;
+  county: string;
+  postcode: string;
+  country: string;
+}
+
+const DEFAULT_MAPPING: CheckoutFieldMapping = {
+  firstName: "firstName",
+  lastName: "lastName",
+  email: "email",
+  company: "company",
+  line1: "address",
+  line2: "line2",
+  city: "city",
+  county: "county",
+  postcode: "postal",
+  country: "country",
+};
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+type FieldKind = "text" | "select" | "checkbox";
+
+interface FieldRegistration {
+  required: boolean;
+  kind: FieldKind;
+}
+
+export interface CheckoutFormContextValue {
+  values: Record<string, string>;
+  booleans: Record<string, boolean>;
+  errors: Record<string, string | null>;
+  status: "idle" | "placing" | "placed" | "error";
+  error: string | null;
+  orderId: string | null;
+  isFree: boolean;
+  setField(name: string, value: string): void;
+  setBoolean(name: string, checked: boolean): void;
+  registerField(
+    name: string,
+    opts: { required?: boolean; kind?: FieldKind; initialValue?: string; initialChecked?: boolean }
+  ): void;
+  unregisterField(name: string): void;
+  validateAll(): boolean;
+  placeOrder(): Promise<void>;
+  reset(): void;
+}
+
+const NOOP_CTX: CheckoutFormContextValue = {
+  values: {},
+  booleans: {},
+  errors: {},
+  status: "idle",
+  error: null,
+  orderId: null,
+  isFree: false,
+  setField: () => {},
+  setBoolean: () => {},
+  registerField: () => {},
+  unregisterField: () => {},
+  validateAll: () => true,
+  placeOrder: async () => {},
+  reset: () => {},
+};
+
+export const CheckoutFormContext =
+  createContext<CheckoutFormContextValue>(NOOP_CTX);
+
+/** Field primitives call this to read + write the shared checkout form. */
+export function useCheckoutForm(): CheckoutFormContextValue {
+  return useContext(CheckoutFormContext);
+}
+
+// ---------------------------------------------------------------------------
+// Props / actions
+// ---------------------------------------------------------------------------
+interface EPCheckoutFormProviderActions {
+  placeOrder(): Promise<void>;
+  validate(): boolean;
+  reset(): void;
+}
+
+interface EPCheckoutFormProviderProps {
+  children?: React.ReactNode;
+  className?: string;
+  fieldMapping?: Partial<CheckoutFieldMapping>;
+  /** Payment gateway override (default "manual" — completes free orders). */
+  paymentGateway?: string;
+  paymentMethod?: string;
+  /**
+   * How placeOrder takes payment:
+   *   - "auto" (default): drive the checkout session (Stripe / gateway) when
+   *     an EPCheckoutSessionProvider is an ancestor; otherwise fall back to
+   *     the direct proxy `placeOrder` (manual, no card).
+   *   - "session": always drive the session (errors if none is present).
+   *   - "proxy": always use the direct proxy placeOrder.
+   */
+  paymentMode?: "auto" | "session" | "proxy";
+  /**
+   * Whether this checkout collects shipping. Default false — this single-page
+   * form collects no shipping fields. Forwarded to the session so /pay doesn't
+   * require a shipping address for digital / shipping-less orders.
+   */
+  requiresShipping?: boolean;
+  /** Fired after a successful order. */
+  onPlaced?: (data: { orderId: string; isFree: boolean }) => void;
+  onError?: (data: { message: string }) => void;
+  /**
+   * Optional URL to navigate to after a successful order — the standard
+   * post-purchase confirmation-page redirect. Supports an `{orderId}`
+   * placeholder (e.g. `/checkout/confirmation?order={orderId}`). Left empty,
+   * the form stays on the page (consumers can instead bind `onPlaced` /
+   * `checkoutFormData`). A full-page navigation is used so it works in any host
+   * without a router dependency.
+   */
+  confirmationUrl?: string;
+}
+
+/** Shape of the `checkoutSession` value EPCheckoutSessionProvider publishes. */
+interface SessionBridge {
+  session?: {
+    status?: string;
+    order?: { id?: string } | null;
+    totals?: { total?: number } | null;
+  } | null;
+  updateSession?: (data: Record<string, unknown>) => Promise<unknown>;
+  placeOrder?: () => Promise<
+    | {
+        success?: boolean;
+        data?: { session?: SessionBridge["session"] };
+        error?: { message?: string };
+        paymentError?: string;
+      }
+    | undefined
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export const EPCheckoutFormProvider = React.forwardRef<
+  EPCheckoutFormProviderActions,
+  EPCheckoutFormProviderProps
+>(function EPCheckoutFormProvider(props, ref) {
+  const {
+    children,
+    className,
+    fieldMapping,
+    paymentGateway,
+    paymentMethod,
+    paymentMode = "auto",
+    requiresShipping = false,
+    onPlaced,
+    onError,
+    confirmationUrl,
+  } = props;
+
+  // Standard post-purchase redirect. Full-page nav (no router dependency) so it
+  // works in any host; substitutes the {orderId} placeholder.
+  const redirectToConfirmation = useCallback(
+    (oid: string) => {
+      if (!confirmationUrl) return;
+      const url = confirmationUrl.replace("{orderId}", encodeURIComponent(oid));
+      if (typeof window !== "undefined") window.location.assign(url);
+    },
+    [confirmationUrl]
+  );
+
+  const inEditor = !!usePlasmicCanvasContext();
+
+  // Bridge to an ancestor EPCheckoutSessionProvider, when present. In session
+  // mode placeOrder pushes the collected fields into the server session and
+  // delegates payment to the registered gateway (Stripe) — keeping the form
+  // primitives self-wiring (no designer interactions required).
+  const dataEnv = useDataEnv?.();
+  const sessionBridge = (dataEnv as any)?.checkoutSession as
+    | SessionBridge
+    | undefined;
+  const useSession =
+    paymentMode === "session" ||
+    (paymentMode === "auto" && typeof sessionBridge?.placeOrder === "function");
+
+  const mapping = useMemo<CheckoutFieldMapping>(
+    () => ({ ...DEFAULT_MAPPING, ...(fieldMapping ?? {}) }),
+    [fieldMapping]
+  );
+
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [booleans, setBooleans] = useState<Record<string, boolean>>({});
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+  const [status, setStatus] = useState<
+    "idle" | "placing" | "placed" | "error"
+  >("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [orderId, setOrderId] = useState<string | null>(null);
+  const [isFree, setIsFree] = useState(false);
+
+  // Registry of mounted fields — drives generic required-validation. Held in
+  // a ref so registration doesn't churn render; values/booleans live in state.
+  const registry = useRef<Map<string, FieldRegistration>>(new Map());
+
+  const registerField = useCallback(
+    (
+      name: string,
+      opts: {
+        required?: boolean;
+        kind?: FieldKind;
+        initialValue?: string;
+        initialChecked?: boolean;
+      }
+    ) => {
+      registry.current.set(name, {
+        required: !!opts.required,
+        kind: opts.kind ?? "text",
+      });
+      if (opts.initialValue !== undefined) {
+        setValues((prev) =>
+          prev[name] === undefined ? { ...prev, [name]: opts.initialValue! } : prev
+        );
+      }
+      if (opts.initialChecked !== undefined) {
+        setBooleans((prev) =>
+          prev[name] === undefined
+            ? { ...prev, [name]: opts.initialChecked! }
+            : prev
+        );
+      }
+    },
+    []
+  );
+
+  const unregisterField = useCallback((name: string) => {
+    registry.current.delete(name);
+  }, []);
+
+  const setField = useCallback((name: string, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => (prev[name] ? { ...prev, [name]: null } : prev));
+  }, []);
+
+  const setBoolean = useCallback((name: string, checked: boolean) => {
+    setBooleans((prev) => ({ ...prev, [name]: checked }));
+    setErrors((prev) => (prev[name] ? { ...prev, [name]: null } : prev));
+  }, []);
+
+  const validateAll = useCallback((): boolean => {
+    const nextErrors: Record<string, string | null> = {};
+    let valid = true;
+    registry.current.forEach((reg, name) => {
+      if (!reg.required) return;
+      const missing =
+        reg.kind === "checkbox"
+          ? !booleans[name]
+          : !(values[name] ?? "").trim();
+      if (missing) {
+        valid = false;
+        nextErrors[name] =
+          reg.kind === "checkbox" ? "Required" : "This field is required";
+      }
+    });
+    setErrors(nextErrors);
+    return valid;
+  }, [values, booleans]);
+
+  const reset = useCallback(() => {
+    setValues({});
+    setBooleans({});
+    setErrors({});
+    setStatus("idle");
+    setError(null);
+    setOrderId(null);
+    setIsFree(false);
+  }, []);
+
+  const placeOrder = useCallback(async () => {
+    if (inEditor) {
+      log.debug("placeOrder is a no-op in the Studio canvas");
+      return;
+    }
+    if (!validateAll()) {
+      setStatus("error");
+      setError("Please complete the required fields.");
+      return;
+    }
+    setStatus("placing");
+    setError(null);
+
+    const v = values;
+
+    // Everything that isn't a reserved order field becomes a cart custom
+    // attribute (extra profile fields + consent flags).
+    const reserved = new Set(Object.values(mapping));
+    const customAttributes: Record<string, string | boolean> = {};
+    for (const [name, value] of Object.entries(v)) {
+      if (reserved.has(name)) continue;
+      if (value !== "") customAttributes[name] = value;
+    }
+    for (const [name, checked] of Object.entries(booleans)) {
+      customAttributes[name] = checked;
+    }
+
+    // --- Session mode: push fields into the checkout session, then let the
+    // session's registered gateway (Stripe) take payment. ---
+    if (useSession && sessionBridge) {
+      const customerInfo = {
+        name: `${v[mapping.firstName] ?? ""} ${v[mapping.lastName] ?? ""}`.trim(),
+        email: v[mapping.email] ?? "",
+      };
+      const sessionBilling = {
+        firstName: v[mapping.firstName] ?? "",
+        lastName: v[mapping.lastName] ?? "",
+        company: v[mapping.company] ?? "",
+        line1: v[mapping.line1] ?? "",
+        line2: v[mapping.line2] ?? "",
+        city: v[mapping.city] ?? "",
+        county: v[mapping.county] ?? "",
+        country: v[mapping.country] ?? "",
+        postcode: v[mapping.postcode] ?? "",
+      };
+      try {
+        await sessionBridge.updateSession?.({
+          customerInfo,
+          billingAddress: sessionBilling,
+          requiresShipping,
+          customAttributes,
+        });
+        const resp = await sessionBridge.placeOrder?.();
+        const s = resp?.data?.session;
+        if (resp?.success && s?.status === "complete") {
+          const oid = s.order?.id ?? "";
+          const free = (s.totals?.total ?? 0) === 0;
+          setOrderId(oid);
+          setIsFree(free);
+          setStatus("placed");
+          onPlaced?.({ orderId: oid, isFree: free });
+          redirectToConfirmation(oid);
+        } else {
+          throw new Error(
+            resp?.error?.message ??
+              resp?.paymentError ??
+              "Payment did not complete. Please check your details and try again."
+          );
+        }
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Order could not be placed.";
+        setError(msg);
+        setStatus("error");
+        onError?.({ message: msg });
+        log.error("session placeOrder failed", { error: msg });
+      }
+      return;
+    }
+
+    // --- Proxy mode: single server call (manual gateway, no card). ---
+    const customer = {
+      name: `${v[mapping.firstName] ?? ""} ${v[mapping.lastName] ?? ""}`.trim(),
+      email: v[mapping.email] ?? "",
+    };
+    const billingAddress = {
+      first_name: v[mapping.firstName] ?? "",
+      last_name: v[mapping.lastName] ?? "",
+      company_name: v[mapping.company] ?? "",
+      line_1: v[mapping.line1] ?? "",
+      line_2: v[mapping.line2] ?? "",
+      city: v[mapping.city] ?? "",
+      county: v[mapping.county] ?? "",
+      postcode: v[mapping.postcode] ?? "",
+      country: v[mapping.country] ?? "",
+    };
+
+    try {
+      const result = await callEpProxy<EpPlaceOrderResult | null>("placeOrder", {
+        customer,
+        billingAddress,
+        customAttributes,
+        ...(paymentGateway ? { paymentGateway } : {}),
+        ...(paymentMethod ? { paymentMethod } : {}),
+      });
+      if (!result || !result.orderId) {
+        throw new Error("Order could not be placed. Please try again.");
+      }
+      setOrderId(result.orderId);
+      setIsFree(result.isFree);
+      setStatus("placed");
+      onPlaced?.({ orderId: result.orderId, isFree: result.isFree });
+      redirectToConfirmation(result.orderId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Order could not be placed.";
+      setError(msg);
+      setStatus("error");
+      onError?.({ message: msg });
+      log.error("placeOrder failed", { error: msg });
+    }
+  }, [
+    inEditor,
+    validateAll,
+    values,
+    booleans,
+    mapping,
+    useSession,
+    sessionBridge,
+    requiresShipping,
+    paymentGateway,
+    paymentMethod,
+    onPlaced,
+    onError,
+    redirectToConfirmation,
+  ]);
+
+  useImperativeHandle(
+    ref,
+    () => ({ placeOrder, validate: validateAll, reset }),
+    [placeOrder, validateAll, reset]
+  );
+
+  const ctx = useMemo<CheckoutFormContextValue>(
+    () => ({
+      values,
+      booleans,
+      errors,
+      status,
+      error,
+      orderId,
+      isFree,
+      setField,
+      setBoolean,
+      registerField,
+      unregisterField,
+      validateAll,
+      placeOrder,
+      reset,
+    }),
+    [
+      values,
+      booleans,
+      errors,
+      status,
+      error,
+      orderId,
+      isFree,
+      setField,
+      setBoolean,
+      registerField,
+      unregisterField,
+      validateAll,
+      placeOrder,
+      reset,
+    ]
+  );
+
+  const checkoutFormData = useMemo(
+    () => ({
+      status,
+      error,
+      orderId,
+      isFree,
+      isPlacing: status === "placing",
+      isPlaced: status === "placed",
+      values,
+      booleans,
+    }),
+    [status, error, orderId, isFree, values, booleans]
+  );
+
+  return (
+    <CheckoutFormContext.Provider value={ctx}>
+      <DataProvider name="checkoutFormData" data={checkoutFormData}>
+        <div className={className} data-ep-checkout-form-provider="">
+          {children}
+        </div>
+      </DataProvider>
+    </CheckoutFormContext.Provider>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Registration metadata
+// ---------------------------------------------------------------------------
+export const epCheckoutFormProviderMeta: CodeComponentMeta<EPCheckoutFormProviderProps> =
+  {
+    name: "plasmic-commerce-ep-checkout-form-provider",
+    displayName: "EP Checkout Form Provider",
+    description:
+      "Single-page checkout form collector + order placer. Wrap the form fields (EP Form Field / Select Field / Consent Checkbox) and the EP Place Order Button. Reserved field names (firstName, lastName, email, company, address, line2, city, county, postal, country) map to the order; all other fields and checkboxes are saved as cart custom attributes.",
+    props: {
+      children: {
+        type: "slot",
+        defaultValue: [
+          { type: "text", value: "Place the EP checkout fields and EP Place Order Button here." },
+        ],
+      },
+      fieldMapping: {
+        type: "object",
+        displayName: "Field Mapping",
+        description:
+          "Override which field names map to the order (keys: firstName, lastName, email, company, line1, line2, city, county, postcode, country).",
+        advanced: true,
+      },
+      paymentMode: {
+        type: "choice",
+        options: ["auto", "session", "proxy"],
+        defaultValue: "auto",
+        displayName: "Payment Mode",
+        description:
+          'How payment is taken. "auto" drives the checkout session (Stripe / gateway) when an EP Checkout Session Provider is an ancestor, else falls back to the direct manual proxy. "session" forces the session path; "proxy" forces the manual proxy.',
+        advanced: true,
+      },
+      requiresShipping: {
+        type: "boolean",
+        defaultValue: false,
+        displayName: "Requires Shipping",
+        description:
+          "Whether this checkout collects a shipping address. Default false (single-page / digital). Forwarded to the session so /pay doesn't require shipping.",
+        advanced: true,
+      },
+      paymentGateway: {
+        type: "string",
+        displayName: "Payment Gateway",
+        description: 'Proxy mode only — EP payment gateway. Default "manual" (completes free / zero-total orders with no card step).',
+        advanced: true,
+      },
+      paymentMethod: {
+        type: "string",
+        displayName: "Payment Method",
+        description: 'Proxy mode only — EP payment method. Default "purchase".',
+        advanced: true,
+      },
+      confirmationUrl: {
+        type: "string",
+        displayName: "Confirmation URL",
+        description:
+          "Redirect here after a successful order (post-purchase confirmation page). Supports an {orderId} placeholder, e.g. /checkout/confirmation?order={orderId}. Leave empty to stay on the page.",
+      },
+      onPlaced: {
+        type: "eventHandler",
+        displayName: "On Order Placed",
+        argTypes: [{ name: "data", type: "object" }],
+      },
+      onError: {
+        type: "eventHandler",
+        displayName: "On Error",
+        argTypes: [{ name: "data", type: "object" }],
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPCheckoutFormProvider",
+    providesData: true,
+    refActions: {
+      placeOrder: { displayName: "Place Order", argTypes: [] },
+      validate: { displayName: "Validate", argTypes: [] },
+      reset: { displayName: "Reset", argTypes: [] },
+    },
+  };
+
+export function registerEPCheckoutFormProvider(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPCheckoutFormProviderProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(
+    EPCheckoutFormProvider,
+    customMeta ?? epCheckoutFormProviderMeta
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPConsentCheckbox.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPConsentCheckbox.tsx
@@ -1,0 +1,147 @@
+/**
+ * EPConsentCheckbox — self-contained consent / opt-in checkbox.
+ *
+ * Reads/writes a boolean on the shared checkout form via useCheckoutForm().
+ * Supports an inline link in the label (e.g. a Privacy Notice) and an
+ * optional `revealOnCheck` slot (the "I have a purchase order number" →
+ * reveals a PO-number field pattern).
+ *
+ * Generic DOM hooks: [data-ep-consent], [data-ep-consent-input],
+ * [data-ep-consent-text], [data-ep-consent-link], [data-ep-consent-reveal].
+ */
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useEffect } from "react";
+import { Registerable } from "../../registerable";
+import { useCheckoutForm } from "./EPCheckoutFormProvider";
+
+interface EPConsentCheckboxProps {
+  className?: string;
+  name?: string;
+  label?: string;
+  required?: boolean;
+  defaultChecked?: boolean;
+  linkText?: string;
+  linkHref?: string;
+  revealOnCheck?: boolean;
+  children?: React.ReactNode;
+  fieldId?: string;
+}
+
+export function EPConsentCheckbox(props: EPConsentCheckboxProps) {
+  const {
+    className,
+    name = "consent",
+    label = "I agree",
+    required = false,
+    defaultChecked = false,
+    linkText,
+    linkHref,
+    revealOnCheck = false,
+    children,
+    fieldId,
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const form = useCheckoutForm();
+  const id = fieldId || `ep-consent-${name}`;
+
+  useEffect(() => {
+    form.registerField(name, {
+      required,
+      kind: "checkbox",
+      initialChecked: defaultChecked,
+    });
+    return () => form.unregisterField(name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, required, defaultChecked]);
+
+  const checked = form.booleans[name] ?? defaultChecked;
+  const error = form.errors[name] ?? null;
+
+  return (
+    <div
+      className={className}
+      data-ep-consent=""
+      data-ep-field-state={error ? "invalid" : undefined}
+    >
+      <label data-ep-consent-label="" htmlFor={id}>
+        <input
+          id={id}
+          type="checkbox"
+          data-ep-consent-input=""
+          checked={checked}
+          required={required}
+          aria-invalid={error ? true : undefined}
+          onChange={(e) => form.setBoolean(name, e.target.checked)}
+        />
+        <span data-ep-consent-text="">
+          {label}
+          {linkText ? (
+            <>
+              {" "}
+              <a
+                data-ep-consent-link=""
+                href={linkHref || "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={inEditor ? (e) => e.preventDefault() : undefined}
+              >
+                {linkText}
+              </a>
+            </>
+          ) : null}
+          {required ? " *" : ""}
+        </span>
+      </label>
+      {revealOnCheck && checked ? (
+        <div data-ep-consent-reveal="">{children}</div>
+      ) : null}
+      {error ? <span data-ep-field-error="">{error}</span> : null}
+    </div>
+  );
+}
+
+export const epConsentCheckboxMeta: CodeComponentMeta<EPConsentCheckboxProps> = {
+  name: "plasmic-commerce-ep-consent-checkbox",
+  displayName: "EP Consent Checkbox",
+  description:
+    "Self-contained consent checkbox. Registers a boolean into the surrounding EP Checkout Form Provider by `name` (saved as a cart custom attribute). Supports an inline link and a reveal-on-check slot.",
+  props: {
+    name: { type: "string", defaultValue: "consent" },
+    label: { type: "string", defaultValue: "I agree" },
+    required: { type: "boolean", defaultValue: false },
+    defaultChecked: {
+      type: "boolean",
+      defaultValue: false,
+      displayName: "Default Checked",
+    },
+    linkText: { type: "string", displayName: "Link Text", advanced: true },
+    linkHref: { type: "string", displayName: "Link URL", advanced: true },
+    revealOnCheck: {
+      type: "boolean",
+      defaultValue: false,
+      displayName: "Reveal Slot When Checked",
+      description: "Show the child slot only while this box is checked (e.g. a PO-number field).",
+    },
+    children: {
+      type: "slot",
+      displayName: "Revealed Content",
+      hidePlaceholder: true,
+    },
+    fieldId: { type: "string", advanced: true, displayName: "Field ID" },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPConsentCheckbox",
+};
+
+export function registerEPConsentCheckbox(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPConsentCheckboxProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPConsentCheckbox, customMeta ?? epConsentCheckboxMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPFormField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPFormField.tsx
@@ -1,0 +1,122 @@
+/**
+ * EPFormField — self-contained text input for the single-page checkout.
+ *
+ * Renders its own `<input>` (with a floating-label-ready structure) and
+ * reads/writes the shared checkout form via useCheckoutForm(). No Plasmic
+ * interaction wiring needed — drop it inside an EPCheckoutFormProvider and
+ * give it a `name`.
+ *
+ * Stable, generic DOM hooks for styling (the ISO look lives in the page's
+ * Embed CSS, not here):
+ *   [data-ep-form-field]            wrapper
+ *   [data-ep-field-input]           the <input>
+ *   [data-ep-field-label]           the floating <label>
+ *   [data-ep-field-error]           validation message
+ * Floating label works with the controlled input because the placeholder is
+ * a single space: `[data-ep-field-input]:not(:placeholder-shown) ~ [data-ep-field-label]`.
+ */
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useEffect } from "react";
+import { Registerable } from "../../registerable";
+import { useCheckoutForm } from "./EPCheckoutFormProvider";
+
+interface EPFormFieldProps {
+  className?: string;
+  name?: string;
+  label?: string;
+  inputType?: "text" | "email" | "tel" | "number";
+  required?: boolean;
+  autoComplete?: string;
+  fieldId?: string;
+}
+
+export function EPFormField(props: EPFormFieldProps) {
+  const {
+    className,
+    name = "field",
+    label = "Label",
+    inputType = "text",
+    required = false,
+    autoComplete,
+    fieldId,
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const form = useCheckoutForm();
+  const id = fieldId || `ep-field-${name}`;
+
+  useEffect(() => {
+    form.registerField(name, { required, kind: "text" });
+    return () => form.unregisterField(name);
+    // form callbacks are stable; re-run only when identity changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, required]);
+
+  const value = form.values[name] ?? "";
+  const error = form.errors[name] ?? null;
+
+  return (
+    <div
+      className={className}
+      data-ep-form-field=""
+      data-ep-field-state={error ? "invalid" : undefined}
+    >
+      <input
+        id={id}
+        data-ep-field-input=""
+        type={inputType}
+        placeholder=" "
+        value={value}
+        required={required}
+        autoComplete={autoComplete}
+        aria-invalid={error ? true : undefined}
+        onChange={(e) => form.setField(name, e.target.value)}
+        readOnly={inEditor}
+      />
+      <label data-ep-field-label="" htmlFor={id}>
+        {label}
+        {required ? " *" : ""}
+      </label>
+      {error ? <span data-ep-field-error="">{error}</span> : null}
+    </div>
+  );
+}
+
+export const epFormFieldMeta: CodeComponentMeta<EPFormFieldProps> = {
+  name: "plasmic-commerce-ep-form-field",
+  displayName: "EP Form Field",
+  description:
+    "Self-contained checkout text input. Registers into the surrounding EP Checkout Form Provider by `name`. Floating-label ready via the [data-ep-field-*] hooks.",
+  props: {
+    name: {
+      type: "string",
+      defaultValue: "field",
+      description:
+        "Form key. Reserved names (firstName, lastName, email, company, address, line2, city, county, postal, country) map to the order; anything else is saved as a cart custom attribute.",
+    },
+    label: { type: "string", defaultValue: "Label" },
+    inputType: {
+      type: "choice",
+      options: ["text", "email", "tel", "number"],
+      defaultValue: "text",
+      displayName: "Input Type",
+    },
+    required: { type: "boolean", defaultValue: false },
+    autoComplete: { type: "string", advanced: true, displayName: "Autocomplete" },
+    fieldId: { type: "string", advanced: true, displayName: "Field ID" },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPFormField",
+};
+
+export function registerEPFormField(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPFormFieldProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPFormField, customMeta ?? epFormFieldMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPPlaceOrderButton.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPPlaceOrderButton.tsx
@@ -1,0 +1,95 @@
+/**
+ * EPPlaceOrderButton — self-wiring submit button for the single-page checkout.
+ *
+ * Reads the shared checkout form via useCheckoutForm() and, on click, runs
+ * the chosen `action`:
+ *   - "placeOrder" (default): validates then places the order.
+ *   - "validate": validates only (use for an intermediate "Save" button).
+ * No Plasmic interaction wiring needed — its onClick calls into the
+ * provider context directly.
+ *
+ * DOM hook: [data-ep-place-order]. Disabled + relabelled while placing.
+ */
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React from "react";
+import { Registerable } from "../../registerable";
+import { useCheckoutForm } from "./EPCheckoutFormProvider";
+
+interface EPPlaceOrderButtonProps {
+  className?: string;
+  label?: string;
+  placingLabel?: string;
+  action?: "placeOrder" | "validate";
+}
+
+export function EPPlaceOrderButton(props: EPPlaceOrderButtonProps) {
+  const {
+    className,
+    label = "Place your order",
+    placingLabel = "Placing order…",
+    action = "placeOrder",
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const form = useCheckoutForm();
+  const isPlacing = form.status === "placing";
+
+  const handleClick = () => {
+    if (inEditor) return;
+    if (action === "validate") {
+      form.validateAll();
+    } else {
+      void form.placeOrder();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={className}
+      data-ep-place-order=""
+      data-ep-action={action}
+      disabled={isPlacing}
+      onClick={handleClick}
+    >
+      {isPlacing ? placingLabel : label}
+    </button>
+  );
+}
+
+export const epPlaceOrderButtonMeta: CodeComponentMeta<EPPlaceOrderButtonProps> =
+  {
+    name: "plasmic-commerce-ep-place-order-button",
+    displayName: "EP Place Order Button",
+    description:
+      "Self-wiring checkout submit button. Inside an EP Checkout Form Provider, places the order (or validates only) on click — no interaction wiring needed.",
+    props: {
+      label: { type: "string", defaultValue: "Place your order" },
+      placingLabel: {
+        type: "string",
+        defaultValue: "Placing order…",
+        displayName: "Placing Label",
+      },
+      action: {
+        type: "choice",
+        options: ["placeOrder", "validate"],
+        defaultValue: "placeOrder",
+        description:
+          '"placeOrder" submits the order; "validate" only checks the form (use for a Save button).',
+      },
+    },
+    importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+    importName: "EPPlaceOrderButton",
+  };
+
+export function registerEPPlaceOrderButton(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPPlaceOrderButtonProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPPlaceOrderButton, customMeta ?? epPlaceOrderButtonMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPSelectField.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/EPSelectField.tsx
@@ -1,0 +1,157 @@
+/**
+ * EPSelectField — self-contained native <select> for the single-page checkout.
+ *
+ * Like EPFormField but renders a `<select>`. Options come from the
+ * `options` string prop (one entry per line or comma-separated; each entry
+ * is `value|Label` or just `Label`) or from the built-in `countries`
+ * preset. Reads/writes the shared checkout form via useCheckoutForm().
+ *
+ * Floating label: selects have no `:placeholder-shown`, so the wrapper
+ * carries `data-filled` when a value is chosen; the page Embed CSS floats
+ * the label on `[data-ep-select-field][data-filled]` or `:focus-within`.
+ */
+import { usePlasmicCanvasContext } from "@plasmicapp/host";
+import registerComponent, {
+  CodeComponentMeta,
+} from "@plasmicapp/host/registerComponent";
+import React, { useEffect, useMemo } from "react";
+import { Registerable } from "../../registerable";
+import { useCheckoutForm } from "./EPCheckoutFormProvider";
+import { COUNTRIES } from "./countries";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface EPSelectFieldProps {
+  className?: string;
+  name?: string;
+  label?: string;
+  required?: boolean;
+  options?: string;
+  preset?: "none" | "countries";
+  fieldId?: string;
+}
+
+/** Parses the `options` string into {value,label} pairs. */
+export function parseOptions(raw: string | undefined): SelectOption[] {
+  if (!raw) return [];
+  return raw
+    .split(/[\r\n,]+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const pipe = line.indexOf("|");
+      if (pipe >= 0) {
+        return { value: line.slice(0, pipe).trim(), label: line.slice(pipe + 1).trim() };
+      }
+      return { value: line, label: line };
+    });
+}
+
+export function EPSelectField(props: EPSelectFieldProps) {
+  const {
+    className,
+    name = "select",
+    label = "Label",
+    required = false,
+    options,
+    preset = "none",
+    fieldId,
+  } = props;
+
+  const inEditor = !!usePlasmicCanvasContext();
+  const form = useCheckoutForm();
+  const id = fieldId || `ep-field-${name}`;
+
+  const opts = useMemo<SelectOption[]>(() => {
+    if (preset === "countries") {
+      return COUNTRIES.map((c) => ({ value: c.code, label: c.name }));
+    }
+    return parseOptions(options);
+  }, [preset, options]);
+
+  useEffect(() => {
+    form.registerField(name, { required, kind: "select" });
+    return () => form.unregisterField(name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, required]);
+
+  const value = form.values[name] ?? "";
+  const error = form.errors[name] ?? null;
+
+  return (
+    <div
+      className={className}
+      data-ep-form-field=""
+      data-ep-select-field=""
+      data-filled={value ? "" : undefined}
+      data-ep-field-state={error ? "invalid" : undefined}
+    >
+      <select
+        id={id}
+        data-ep-field-input=""
+        value={value}
+        required={required}
+        aria-invalid={error ? true : undefined}
+        aria-label={label}
+        disabled={inEditor}
+        onChange={(e) => form.setField(name, e.target.value)}
+      >
+        <option value="" />
+        {opts.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <label data-ep-field-label="" htmlFor={id}>
+        {label}
+        {required ? " *" : ""}
+      </label>
+      {error ? <span data-ep-field-error="">{error}</span> : null}
+    </div>
+  );
+}
+
+export const epSelectFieldMeta: CodeComponentMeta<EPSelectFieldProps> = {
+  name: "plasmic-commerce-ep-select-field",
+  displayName: "EP Select Field",
+  description:
+    "Self-contained checkout dropdown. Registers into the surrounding EP Checkout Form Provider by `name`. Options from the `options` string or the `countries` preset.",
+  props: {
+    name: {
+      type: "string",
+      defaultValue: "select",
+      description:
+        "Form key. Reserved names map to the order; anything else is saved as a cart custom attribute.",
+    },
+    label: { type: "string", defaultValue: "Label" },
+    required: { type: "boolean", defaultValue: false },
+    preset: {
+      type: "choice",
+      options: ["none", "countries"],
+      defaultValue: "none",
+      description: "Use the built-in ISO country list instead of `options`.",
+    },
+    options: {
+      type: "string",
+      displayName: "Options",
+      description:
+        "One option per line (or comma-separated). Use `value|Label` to set a distinct value. Ignored when preset = countries.",
+    },
+    fieldId: { type: "string", advanced: true, displayName: "Field ID" },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "EPSelectField",
+};
+
+export function registerEPSelectField(
+  loader?: Registerable,
+  customMeta?: CodeComponentMeta<EPSelectFieldProps>
+) {
+  const doRegisterComponent: typeof registerComponent = (...args) =>
+    loader ? loader.registerComponent(...args) : registerComponent(...args);
+  doRegisterComponent(EPSelectField, customMeta ?? epSelectFieldMeta);
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/composable/index.ts
@@ -11,6 +11,14 @@ export { EPShippingAddressFields, registerEPShippingAddressFields, epShippingAdd
 export { EPBillingAddressFields, registerEPBillingAddressFields, epBillingAddressFieldsMeta } from "./EPBillingAddressFields";
 export { EPShippingMethodSelector, registerEPShippingMethodSelector, epShippingMethodSelectorMeta } from "./EPShippingMethodSelector";
 
+// Single-page checkout (self-contained form primitives + collector)
+export { EPCheckoutFormProvider, registerEPCheckoutFormProvider, epCheckoutFormProviderMeta, useCheckoutForm, CheckoutFormContext } from "./EPCheckoutFormProvider";
+export type { CheckoutFormContextValue, CheckoutFieldMapping } from "./EPCheckoutFormProvider";
+export { EPFormField, registerEPFormField, epFormFieldMeta } from "./EPFormField";
+export { EPSelectField, registerEPSelectField, epSelectFieldMeta, parseOptions } from "./EPSelectField";
+export { EPConsentCheckbox, registerEPConsentCheckbox, epConsentCheckboxMeta } from "./EPConsentCheckbox";
+export { EPPlaceOrderButton, registerEPPlaceOrderButton, epPlaceOrderButtonMeta } from "./EPPlaceOrderButton";
+
 // Data
 export { COUNTRIES, DEFAULT_PRIORITY_COUNTRIES } from "./countries";
 export type { CountryEntry } from "./countries";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/EPCheckoutSessionProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/EPCheckoutSessionProvider.tsx
@@ -16,6 +16,7 @@ import registerComponent, {
 } from "@plasmicapp/host/registerComponent";
 import React, {
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -47,6 +48,13 @@ export interface EPCheckoutSessionProviderProps {
   apiBaseUrl?: string;
   previewState?: PreviewState;
   className?: string;
+  /**
+   * When true (default), the provider auto-creates a checkout session on
+   * first render if none exists. The server resolves `cartId` from the
+   * better-auth session, so designers don't have to thread it through
+   * Plasmic interactions.
+   */
+  autoCreate?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,7 +65,7 @@ const EPCheckoutSessionRuntime = React.forwardRef<
   any,
   EPCheckoutSessionProviderProps
 >(function EPCheckoutSessionRuntime(props, ref) {
-  const { children, apiBaseUrl = "/api" } = props;
+  const { children, apiBaseUrl = "/api", autoCreate = true } = props;
 
   const {
     session,
@@ -90,10 +98,8 @@ const EPCheckoutSessionRuntime = React.forwardRef<
   // RefActions
   const handleCreateSession = useCallback(
     async (cartId?: string) => {
-      if (!cartId) {
-        log.error("createSession called without cartId");
-        return;
-      }
+      // cartId is now optional — server resolves from the better-auth
+      // session when omitted.
       try {
         await createSession(cartId);
       } catch (err) {
@@ -104,6 +110,26 @@ const EPCheckoutSessionRuntime = React.forwardRef<
     },
     [createSession]
   );
+
+  // Auto-create on first render when no session exists.
+  const autoCreatedRef = useRef(false);
+  useEffect(() => {
+    if (!autoCreate) return;
+    if (isLoading) return;
+    // Create a fresh session when none exists OR the existing one is terminal
+    // (a finished/expired checkout must not block starting a new one — e.g.
+    // returning to /checkout with a new cart after completing an order).
+    const needsSession =
+      !session || session.status === "complete" || session.status === "expired";
+    if (!needsSession) return;
+    if (autoCreatedRef.current) return;
+    autoCreatedRef.current = true;
+    createSession().catch((err) => {
+      log.warn("Auto-create session failed", {
+        error: err instanceof Error ? err.message : String(err),
+      } as Record<string, unknown>);
+    });
+  }, [autoCreate, isLoading, session, createSession]);
 
   const handleUpdateSession = useCallback(
     async (data?: Record<string, unknown>) => {
@@ -130,25 +156,38 @@ const EPCheckoutSessionRuntime = React.forwardRef<
   }, [calcShippingFn]);
 
   const handlePlaceOrder = useCallback(async () => {
-    const gw = gatewayRef.current;
-    if (!gw) {
-      log.error(
-        "placeOrder called but no gateway registered. " +
-          "Place EPCloverPayment or EPStripePayment inside this provider."
-      );
-      return;
-    }
-
     try {
+      // Free orders (zero total) need no card / gateway — the server settles
+      // them with the manual gateway. Don't ask a registered gateway to
+      // tokenize (there's no card to read).
+      if (session?.totals?.total === 0) {
+        return await placeOrderFn({ gateway: "manual" });
+      }
+
+      const gw = gatewayRef.current;
+      if (!gw) {
+        log.error(
+          "placeOrder called but no gateway registered. " +
+            "Place EPCloverPayment or EPStripePayment inside this provider."
+        );
+        return {
+          success: false,
+          error: {
+            message: "No payment method available",
+            code: "NO_GATEWAY",
+          },
+        };
+      }
+
       // Ask the gateway component for its data (e.g. tokenize the card)
       const gwData = await gw.confirm();
-      await placeOrderFn({ gateway: gw.name, ...gwData });
+      return await placeOrderFn({ gateway: gw.name, ...gwData });
     } catch (err) {
-      log.error("placeOrder failed", {
-        error: err instanceof Error ? err.message : String(err),
-      } as Record<string, unknown>);
+      const message = err instanceof Error ? err.message : String(err);
+      log.error("placeOrder failed", { message } as Record<string, unknown>);
+      return { success: false, error: { message } };
     }
-  }, [placeOrderFn]);
+  }, [placeOrderFn, session]);
 
   const handleConfirmPayment = useCallback(
     async (confirmData?: Record<string, unknown>) => {
@@ -282,13 +321,22 @@ export const epCheckoutSessionProviderMeta: CodeComponentMeta<EPCheckoutSessionP
           "Show mock session data for design-time editing.",
         advanced: true,
       },
+      autoCreate: {
+        type: "boolean",
+        defaultValue: true,
+        displayName: "Auto-create Session",
+        description:
+          "Create a session on first render if none exists. Server resolves cartId from the better-auth session.",
+        advanced: true,
+      },
     },
     importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
     importName: "EPCheckoutSessionProvider",
     providesData: true,
     refActions: {
       createSession: {
-        description: "Create a new checkout session for a cart",
+        description:
+          "Create a new checkout session. cartId is optional — server resolves from the better-auth session when omitted.",
         argTypes: [{ name: "cartId", type: "string" }],
       },
       updateSession: {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/EPStripePayment.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/EPStripePayment.tsx
@@ -1,25 +1,26 @@
 /**
- * EPStripePayment — Plasmic component for Stripe payments within the
- * checkout session model.
+ * EPStripePayment — Plasmic component for the EP-native Stripe gateway.
  *
- * WHY: Enables Plasmic designers to add Stripe payment fields by dropping this
- * component inside EPCheckoutSessionProvider. Handles SDK lazy-loading,
- * Stripe Elements initialization, and client-side payment confirmation.
- * 3DS is handled entirely by Stripe's SDK (no manual 3DS code).
+ * Slice 1 (this PR):
+ *   - Renders <Elements mode="payment"> (deferred PaymentIntent).
+ *   - Renders <PaymentElement> only (card). Billing name/address are NOT
+ *     collected here — the checkout form already captures them and EP attaches
+ *     the order's billing server-side (createCartPaymentIntent).
+ *   - On submit: stripe.createConfirmationToken({ elements }) → token.
+ *   - Self-registers as gateway "stripe" with PaymentRegistrationContext;
+ *     the registered confirm callback returns { confirmation_token }.
+ *   - Falls back to $ctx.stripe.publishableKey when the prop is unset
+ *     (set by StripeProvider global context).
  *
- * Architecture:
- * - Lazy-loads @stripe/stripe-js and @stripe/react-stripe-js
- * - Self-registers gateway "stripe" with EPCheckoutSessionProvider via
- *   PaymentRegistrationContext (confirm handler returns {} since Stripe
- *   doesn't need client-side tokenization before PaymentIntent creation)
- * - Reads session.payment.clientToken after /pay returns a PaymentIntent
- * - Renders Stripe Elements + PaymentElement when clientToken is available
- * - Exposes submitPayment() refAction for client-side stripe.confirmPayment()
- * - After Stripe confirms, calls /confirm via useCheckoutSession hook
- * - DataProvider "stripePaymentData" for UI state binding
+ * The host app no longer holds a Stripe secret key. Server-side, the cart
+ * payment-intent adapter calls EP's createCartPaymentIntent with confirm:true.
+ * No client-side stripe.confirmPayment.
+ *
+ * 3DS (requires_action) ships in slice 2.
  */
 import {
   DataProvider,
+  useDataEnv,
   usePlasmicCanvasContext,
 } from "@plasmicapp/host";
 import registerComponent, {
@@ -28,7 +29,6 @@ import registerComponent, {
 import React, {
   useCallback,
   useEffect,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -40,23 +40,28 @@ import { useCheckoutSession } from "./use-checkout-session";
 
 const log = createLogger("EPStripePayment");
 
-// ---------------------------------------------------------------------------
-// Props
-// ---------------------------------------------------------------------------
-
 export interface EPStripePaymentProps {
   children?: React.ReactNode;
-  publishableKey: string;
+  /**
+   * Stripe publishable key. Optional — falls back to
+   * `$ctx.stripe.publishableKey` (set by StripeProvider) when unset.
+   */
+  publishableKey?: string;
+  /**
+   * Connected Stripe account id (`acct_…`) for gateways that charge on a
+   * connected account (e.g. EP-native Stripe / Stripe Connect). When set, the
+   * Stripe SDK is initialised with `{ stripeAccount }` so the ConfirmationToken
+   * is minted in that account's context — otherwise the server cannot find the
+   * token on the account it confirms against ("No such confirmation_token").
+   * Falls back to `$ctx.stripe.stripeAccount` (StripeProvider) when unset.
+   */
+  stripeAccount?: string;
   appearance?: Record<string, any>;
   layout?: "tabs" | "accordion";
   className?: string;
   previewState?: "auto" | "ready" | "processing" | "error";
   apiBaseUrl?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Mock payment form for design-time
-// ---------------------------------------------------------------------------
 
 function MockStripePaymentForm({ className }: { className?: string }) {
   return (
@@ -70,154 +75,97 @@ function MockStripePaymentForm({ className }: { className?: string }) {
         background: "#fafafa",
       }}
     >
-      <div style={{ marginBottom: "12px" }}>
-        <div
-          style={{ fontSize: "12px", color: "#666", marginBottom: "4px" }}
-        >
-          Card number
-        </div>
-        <div
-          style={{
-            height: "40px",
-            background: "#fff",
-            border: "1px solid #d0d0d0",
-            borderRadius: "6px",
-          }}
-        />
-      </div>
-      <div style={{ display: "flex", gap: "12px" }}>
-        <div style={{ flex: 1 }}>
-          <div
-            style={{ fontSize: "12px", color: "#666", marginBottom: "4px" }}
-          >
-            MM / YY
-          </div>
-          <div
-            style={{
-              height: "40px",
-              background: "#fff",
-              border: "1px solid #d0d0d0",
-              borderRadius: "6px",
-            }}
-          />
-        </div>
-        <div style={{ flex: 1 }}>
-          <div
-            style={{ fontSize: "12px", color: "#666", marginBottom: "4px" }}
-          >
-            CVC
-          </div>
-          <div
-            style={{
-              height: "40px",
-              background: "#fff",
-              border: "1px solid #d0d0d0",
-              borderRadius: "6px",
-            }}
-          />
-        </div>
+      <div style={{ marginBottom: "12px", fontSize: "13px", color: "#666" }}>
+        Card / Address fields render here at runtime.
       </div>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Mock data for design-time
-// ---------------------------------------------------------------------------
-
 const MOCK_DATA: Record<string, any> = {
-  ready: {
-    isReady: true,
-    isProcessing: false,
-    error: null,
-    paymentMethodType: "card",
-  },
-  processing: {
-    isReady: true,
-    isProcessing: true,
-    error: null,
-    paymentMethodType: "card",
-  },
+  ready: { isReady: true, isProcessing: false, error: null },
+  processing: { isReady: true, isProcessing: true, error: null },
   error: {
     isReady: true,
     isProcessing: false,
     error: "Your card was declined. Please try a different card.",
-    paymentMethodType: "card",
   },
 };
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+function useStripePublishableKey(propValue?: string): string | null {
+  const env = useDataEnv?.();
+  const ctx = (env as any)?.stripe;
+  return propValue ?? ctx?.publishableKey ?? null;
+}
 
-export const EPStripePayment = React.forwardRef<
-  any,
-  EPStripePaymentProps
->(function EPStripePayment(props, ref) {
-  const {
-    children,
-    publishableKey,
-    appearance = {},
-    layout = "tabs",
-    className,
-    previewState = "auto",
-    apiBaseUrl = "/api",
-  } = props;
+function useStripeAccount(propValue?: string): string | null {
+  const env = useDataEnv?.();
+  const ctx = (env as any)?.stripe;
+  return propValue ?? ctx?.stripeAccount ?? null;
+}
 
-  const inEditor = usePlasmicCanvasContext();
+export const EPStripePayment = React.forwardRef<any, EPStripePaymentProps>(
+  function EPStripePayment(props, ref) {
+    const {
+      children,
+      publishableKey: publishableKeyProp,
+      stripeAccount: stripeAccountProp,
+      appearance = {},
+      layout = "tabs",
+      className,
+      previewState = "auto",
+      apiBaseUrl = "/api",
+    } = props;
 
-  // ── Design-time preview ─────────────────────────────────────────────
-  if (inEditor && previewState !== "auto") {
-    const mockData = MOCK_DATA[previewState] ?? MOCK_DATA.ready;
+    const inEditor = usePlasmicCanvasContext();
+    const publishableKey = useStripePublishableKey(publishableKeyProp);
+    const stripeAccount = useStripeAccount(stripeAccountProp);
+
+    if (inEditor && previewState !== "auto") {
+      const mockData = MOCK_DATA[previewState] ?? MOCK_DATA.ready;
+      return (
+        <div className={className}>
+          <DataProvider name="stripePaymentData" data={mockData}>
+            <MockStripePaymentForm />
+            {children}
+          </DataProvider>
+        </div>
+      );
+    }
+
+    if (inEditor) {
+      const autoData = { isReady: true, isProcessing: false, error: null };
+      return (
+        <div className={className}>
+          <DataProvider name="stripePaymentData" data={autoData}>
+            <MockStripePaymentForm />
+            {children}
+          </DataProvider>
+        </div>
+      );
+    }
+
     return (
-      <div className={className}>
-        <DataProvider name="stripePaymentData" data={mockData}>
-          <MockStripePaymentForm />
-          {children}
-        </DataProvider>
-      </div>
+      <EPStripePaymentRuntime
+        ref={ref}
+        publishableKey={publishableKey}
+        stripeAccount={stripeAccount}
+        appearance={appearance}
+        layout={layout}
+        className={className}
+        apiBaseUrl={apiBaseUrl}
+      >
+        {children}
+      </EPStripePaymentRuntime>
     );
   }
-
-  if (inEditor) {
-    const autoData = {
-      isReady: true,
-      isProcessing: false,
-      error: null,
-      paymentMethodType: "card",
-    };
-    return (
-      <div className={className}>
-        <DataProvider name="stripePaymentData" data={autoData}>
-          <MockStripePaymentForm />
-          {children}
-        </DataProvider>
-      </div>
-    );
-  }
-
-  return (
-    <EPStripePaymentRuntime
-      ref={ref}
-      publishableKey={publishableKey}
-      appearance={appearance}
-      layout={layout}
-      className={className}
-      apiBaseUrl={apiBaseUrl}
-    >
-      {children}
-    </EPStripePaymentRuntime>
-  );
-});
-
-// ---------------------------------------------------------------------------
-// Runtime component (hooks must be unconditional)
-// ---------------------------------------------------------------------------
+);
 
 const EPStripePaymentRuntime = React.forwardRef<
   any,
   {
-    publishableKey: string;
+    publishableKey: string | null;
+    stripeAccount: string | null;
     appearance: Record<string, any>;
     layout: string;
     className?: string;
@@ -225,42 +173,42 @@ const EPStripePaymentRuntime = React.forwardRef<
     children?: React.ReactNode;
   }
 >(function EPStripePaymentRuntime(props, ref) {
-  const { publishableKey, appearance, layout, className, apiBaseUrl, children } =
-    props;
+  const {
+    publishableKey,
+    stripeAccount,
+    appearance,
+    layout,
+    className,
+    apiBaseUrl,
+    children,
+  } = props;
 
   const paymentReg = usePaymentRegistration();
-  const { session, confirmPayment: hookConfirmPayment } =
-    useCheckoutSession(apiBaseUrl);
+  const { session } = useCheckoutSession(apiBaseUrl);
 
   const [isReady, setIsReady] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [paymentMethodType, setPaymentMethodType] = useState("card");
-
-  // Stripe instances loaded lazily
   const [stripeInstance, setStripeInstance] = useState<any>(null);
   const [StripeComponents, setStripeComponents] = useState<{
     Elements: any;
     PaymentElement: any;
+    AddressElement: any;
+    useElements: any;
+    useStripe: any;
   } | null>(null);
 
-  // Elements instance captured from inside <Elements> provider
+  const stripeRef = useRef<any>(null);
   const elementsRef = useRef<any>(null);
   const mountedRef = useRef(true);
 
-  // Client secret from session
-  const clientSecret = session?.payment?.clientToken ?? null;
-
-  // ── Lazy-load Stripe SDK ──────────────────────────────────────────────
+  // Lazy-load Stripe SDK
   useEffect(() => {
     mountedRef.current = true;
     let cancelled = false;
-
     if (!publishableKey) {
       setError("Stripe publishable key is required");
       return;
     }
-
     Promise.all([
       import("@stripe/stripe-js").then((m) => m.loadStripe),
       import("@stripe/react-stripe-js"),
@@ -270,11 +218,21 @@ const EPStripePaymentRuntime = React.forwardRef<
         setStripeComponents({
           Elements: reactStripe.Elements,
           PaymentElement: reactStripe.PaymentElement,
+          AddressElement: reactStripe.AddressElement,
+          useElements: reactStripe.useElements,
+          useStripe: reactStripe.useStripe,
         });
-        return loadStripe(publishableKey);
+        // For connected-account gateways (EP-native Stripe / Connect), the
+        // ConfirmationToken must be minted in the connected account's context
+        // so the server can confirm it on that account.
+        return loadStripe(
+          publishableKey,
+          stripeAccount ? { stripeAccount } : undefined
+        );
       })
       .then((stripe) => {
         if (cancelled || !stripe) return;
+        stripeRef.current = stripe;
         setStripeInstance(stripe);
         setError(null);
       })
@@ -282,17 +240,20 @@ const EPStripePaymentRuntime = React.forwardRef<
         if (cancelled) return;
         const msg =
           err instanceof Error ? err.message : "Failed to load Stripe SDK";
-        log.error("Stripe SDK load failed", { error: msg } as Record<string, unknown>);
+        log.error("Stripe SDK load failed", { error: msg } as Record<
+          string,
+          unknown
+        >);
         setError(msg);
       });
-
     return () => {
       cancelled = true;
       mountedRef.current = false;
     };
-  }, [publishableKey]);
+  }, [publishableKey, stripeAccount]);
 
-  // ── Register gateway with EPCheckoutSessionProvider ───────────────────
+  // Register the gateway. confirm() captures a Stripe ConfirmationToken and
+  // forwards it to placeOrder({ confirmation_token, gateway: "stripe" }).
   useEffect(() => {
     if (!paymentReg) {
       log.warn(
@@ -300,99 +261,75 @@ const EPStripePaymentRuntime = React.forwardRef<
       );
       return;
     }
-
-    // For Stripe, the confirm handler returns {} because no client-side
-    // tokenization is needed before PaymentIntent creation. The server-side
-    // stripe-adapter creates the PaymentIntent and returns clientSecret.
     paymentReg.registerGateway("stripe", async () => {
-      return {};
+      const stripe = stripeRef.current;
+      const elements = elementsRef.current;
+      if (!stripe || !elements) {
+        throw new Error("Stripe is not ready — wait for isReady");
+      }
+      const submit = await elements.submit();
+      if (submit?.error) {
+        throw new Error(submit.error.message ?? "Form validation failed");
+      }
+      const result = await stripe.createConfirmationToken({ elements });
+      if (result.error) {
+        throw new Error(
+          result.error.message ?? "Could not create confirmation token"
+        );
+      }
+      return { confirmation_token: result.confirmationToken.id };
     });
   }, [paymentReg]);
 
-  // ── Handle PaymentElement ready event ─────────────────────────────────
-  const handleReady = useCallback(() => {
-    setIsReady(true);
-    log.debug("Stripe PaymentElement is ready");
-  }, []);
-
-  // ── Handle PaymentElement change event ────────────────────────────────
+  const handleReady = useCallback(() => setIsReady(true), []);
   const handleChange = useCallback((event: any) => {
-    if (event.error) {
-      setError(event.error.message);
-    } else {
-      setError(null);
-    }
-    if (event.value?.type) {
-      setPaymentMethodType(event.value.type);
-    }
+    if (event?.error) setError(event.error.message);
+    else setError(null);
   }, []);
 
-  // ── Submit payment (refAction) ────────────────────────────────────────
-  const submitPayment = useCallback(async () => {
-    if (!stripeInstance || !elementsRef.current || !clientSecret) {
-      setError("Payment form is not ready");
-      return;
-    }
-
-    setIsProcessing(true);
-    setError(null);
-
-    try {
-      const result = await stripeInstance.confirmPayment({
-        elements: elementsRef.current,
-        confirmParams: {
-          return_url: window.location.href,
-        },
-        redirect: "if_required",
-      });
-
-      if (result.error) {
-        // Card declined, validation error, etc.
-        setError(result.error.message || "Payment failed");
-        return;
-      }
-
-      // Payment succeeded — notify the server via /confirm
-      const paymentIntentId =
-        result.paymentIntent?.id ??
-        session?.payment?.gatewayMetadata?.paymentIntentId;
-
-      if (paymentIntentId) {
-        await hookConfirmPayment({ paymentIntentId });
-      }
-    } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : "Payment submission failed";
-      log.error("submitPayment failed", { error: msg } as Record<string, unknown>);
-      setError(msg);
-    } finally {
-      if (mountedRef.current) {
-        setIsProcessing(false);
-      }
-    }
-  }, [stripeInstance, clientSecret, session, hookConfirmPayment]);
-
-  // ── Expose refAction ──────────────────────────────────────────────────
-  useImperativeHandle(ref, () => ({
-    submitPayment,
-  }));
-
-  // ── DataProvider value ────────────────────────────────────────────────
   const paymentData = useMemo(
-    () => ({
-      isReady,
-      isProcessing,
-      error,
-      paymentMethodType,
-    }),
-    [isReady, isProcessing, error, paymentMethodType]
+    () => ({ isReady, isProcessing: false, error }),
+    [isReady, error]
   );
 
-  // ── Stripe not loaded yet ─────────────────────────────────────────────
+  // Stub refAction (kept for compatibility — placeOrder is the way now).
+  React.useImperativeHandle(ref, () => ({
+    submitPayment: async () => {
+      log.warn("submitPayment is deprecated — call $refs.session.placeOrder()");
+    },
+  }));
+
+  // Free / zero-total (or unknown-currency) carts take no card — the server
+  // settles them via the manual gateway. Render the slot without Stripe so we
+  // never hand Stripe Elements an amount of 0 or an empty currency (Stripe
+  // throws an IntegrationError on either). This also keeps the card hidden on
+  // a free checkout without any page-level conditional wiring.
+  const total = session?.totals?.total ?? 0;
+  const currency = (session?.totals?.currency || "").toLowerCase();
+  if (!(total > 0) || !currency) {
+    return (
+      <div
+        className={className}
+        data-ep-stripe-payment=""
+        data-ep-payment-free="true"
+      >
+        <DataProvider
+          name="stripePaymentData"
+          data={{ isReady: false, isProcessing: false, error: null, free: true }}
+        >
+          {children}
+        </DataProvider>
+      </div>
+    );
+  }
+
   if (!stripeInstance || !StripeComponents) {
     return (
       <div className={className} data-ep-stripe-payment="">
-        <DataProvider name="stripePaymentData" data={{ ...paymentData, isReady: false }}>
+        <DataProvider
+          name="stripePaymentData"
+          data={{ ...paymentData, isReady: false }}
+        >
           {error ? (
             <div style={{ color: "#d32f2f", fontSize: "14px" }}>{error}</div>
           ) : (
@@ -404,26 +341,15 @@ const EPStripePaymentRuntime = React.forwardRef<
     );
   }
 
-  // ── No clientSecret yet — waiting for placeOrder / PaymentIntent ──────
-  if (!clientSecret) {
-    return (
-      <div className={className} data-ep-stripe-payment="">
-        <DataProvider name="stripePaymentData" data={{ ...paymentData, isReady: false }}>
-          {children}
-        </DataProvider>
-      </div>
-    );
-  }
-
-  // ── Render Stripe Elements + PaymentElement ───────────────────────────
   const { Elements, PaymentElement } = StripeComponents;
 
+  // Deferred PaymentIntent: amount + currency declared upfront. On submit,
+  // EP creates the PaymentIntent server-side via createCartPaymentIntent.
   const elementsOptions = {
-    clientSecret,
-    appearance: {
-      theme: "stripe" as const,
-      ...(appearance || {}),
-    },
+    mode: "payment" as const,
+    amount: total,
+    currency,
+    appearance: { theme: "stripe" as const, ...(appearance || {}) },
     loader: "auto" as const,
   };
 
@@ -431,12 +357,21 @@ const EPStripePaymentRuntime = React.forwardRef<
     <Elements stripe={stripeInstance} options={elementsOptions}>
       <div className={className} data-ep-stripe-payment="">
         <DataProvider name="stripePaymentData" data={paymentData}>
+          <ElementsCapture
+            useElements={StripeComponents.useElements}
+            onElements={(el: any) => {
+              elementsRef.current = el;
+            }}
+          />
           <PaymentElement
             onReady={handleReady}
             onChange={handleChange}
+            // Card-only: the redundant billing block was the separate
+            // AddressElement (removed). The PaymentElement's default doesn't
+            // collect name/address, and EP attaches the order's billing
+            // server-side, so no billing is collected or passed here.
             options={{ layout }}
           />
-          <ElementsCapture onElements={(el: any) => { elementsRef.current = el; }} />
           {children}
         </DataProvider>
       </div>
@@ -444,32 +379,7 @@ const EPStripePaymentRuntime = React.forwardRef<
   );
 });
 
-// ---------------------------------------------------------------------------
-// Capture Elements instance from Stripe context
-// ---------------------------------------------------------------------------
-
-function ElementsCapture({ onElements }: { onElements: (e: any) => void }) {
-  const [useElementsHook, setUseElementsHook] = useState<(() => any) | null>(
-    null
-  );
-
-  useEffect(() => {
-    import("@stripe/react-stripe-js").then((mod) => {
-      setUseElementsHook(() => mod.useElements);
-    });
-  }, []);
-
-  if (!useElementsHook) return null;
-
-  return (
-    <ElementsCaptureInner
-      useElements={useElementsHook}
-      onElements={onElements}
-    />
-  );
-}
-
-function ElementsCaptureInner({
+function ElementsCapture({
   useElements,
   onElements,
 }: {
@@ -478,37 +388,37 @@ function ElementsCaptureInner({
 }) {
   const elements = useElements();
   useEffect(() => {
-    if (elements) {
-      onElements(elements);
-    }
+    if (elements) onElements(elements);
   }, [elements, onElements]);
   return null;
 }
-
-// ---------------------------------------------------------------------------
-// Registration metadata
-// ---------------------------------------------------------------------------
 
 export const epStripePaymentMeta: CodeComponentMeta<EPStripePaymentProps> = {
   name: "plasmic-commerce-ep-stripe-payment",
   displayName: "EP Stripe Payment",
   description:
-    "Stripe Payment Elements wrapper with automatic 3DS support. " +
-    "Drop inside EPCheckoutSessionProvider. Card form renders after placeOrder() creates a PaymentIntent.",
+    "Stripe Payment Element (card) for the EP-native gateway, mode='payment'. " +
+    "Billing name/address are not collected here — the checkout form captures them and EP attaches the order's billing server-side. " +
+    "On placeOrder, captures a Stripe ConfirmationToken and forwards it to the server.",
   props: {
-    children: {
-      type: "slot",
-    },
+    children: { type: "slot" },
     publishableKey: {
       type: "string",
       displayName: "Publishable Key",
-      description: "Your Stripe pk_live_* or pk_test_* key.",
+      description:
+        "Stripe pk_live_* or pk_test_*. Falls back to $ctx.stripe.publishableKey if unset.",
+    },
+    stripeAccount: {
+      type: "string",
+      displayName: "Connected Account ID",
+      description:
+        "Optional acct_* for connected-account gateways (EP-native Stripe / Connect). The ConfirmationToken is minted in this account's context. Falls back to $ctx.stripe.stripeAccount.",
+      advanced: true,
     },
     appearance: {
       type: "object",
       displayName: "Stripe Appearance",
-      description:
-        "Stripe Elements appearance config (theme, variables, rules).",
+      description: "Stripe Elements appearance config (theme, variables, rules).",
       advanced: true,
     },
     layout: {
@@ -516,22 +426,19 @@ export const epStripePaymentMeta: CodeComponentMeta<EPStripePaymentProps> = {
       options: ["tabs", "accordion"],
       defaultValue: "tabs",
       displayName: "Payment Element Layout",
-      description: "Layout style for the Stripe PaymentElement.",
     },
     previewState: {
       type: "choice",
       options: ["auto", "ready", "processing", "error"],
       defaultValue: "auto",
       displayName: "Preview State",
-      description: "Show mock state for design-time editing.",
       advanced: true,
     },
     apiBaseUrl: {
       type: "string",
       displayName: "API Base URL",
       defaultValue: "/api",
-      description:
-        "Must match EPCheckoutSessionProvider's apiBaseUrl for session state sharing.",
+      description: "Must match EPCheckoutSessionProvider's apiBaseUrl.",
       advanced: true,
     },
   },
@@ -541,7 +448,7 @@ export const epStripePaymentMeta: CodeComponentMeta<EPStripePaymentProps> = {
   refActions: {
     submitPayment: {
       description:
-        "Confirm payment via Stripe (handles 3DS automatically), then notify the server.",
+        "Deprecated — call $refs.session.placeOrder() instead. Kept for backwards compatibility.",
       argTypes: [],
     },
   },
@@ -553,8 +460,5 @@ export function registerEPStripePayment(
 ) {
   const doRegisterComponent: typeof registerComponent = (...args) =>
     loader ? loader.registerComponent(...args) : registerComponent(...args);
-  doRegisterComponent(
-    EPStripePayment,
-    customMeta ?? epStripePaymentMeta
-  );
+  doRegisterComponent(EPStripePayment, customMeta ?? epStripePaymentMeta);
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/StripeProvider.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/StripeProvider.tsx
@@ -1,0 +1,63 @@
+/**
+ * StripeProvider — Plasmic global context that exposes the Stripe
+ * publishable key to all `EPStripePayment` instances on a page.
+ *
+ * The publishable key is the Stripe `pk_live_*` / `pk_test_*` value. It
+ * lives in `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` and is exposed to Plasmic
+ * pages by registering this global context with `publishableKey` bound to
+ * `process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` in the host app.
+ *
+ * `EPStripePayment` reads `$ctx.stripe.publishableKey` as a fallback when
+ * its `publishableKey` prop is unset.
+ */
+import React from "react";
+import { DataProvider, GlobalContextMeta } from "@plasmicapp/host";
+import registerGlobalContext from "@plasmicapp/host/registerGlobalContext";
+import type { Registerable } from "../../registerable";
+
+export interface StripeProviderProps {
+  publishableKey?: string;
+  children?: React.ReactNode;
+}
+
+export function StripeProvider({
+  publishableKey,
+  children,
+}: StripeProviderProps) {
+  const data = React.useMemo(
+    () => ({ publishableKey: publishableKey || null }),
+    [publishableKey]
+  );
+  return (
+    <DataProvider name="stripe" data={data}>
+      {children}
+    </DataProvider>
+  );
+}
+
+export const stripeProviderMeta: GlobalContextMeta<StripeProviderProps> = {
+  name: "plasmic-commerce-ep-stripe-provider",
+  displayName: "EP Stripe Provider",
+  description:
+    "Provides the Stripe publishable key to all EPStripePayment instances. " +
+    "Bind `publishableKey` to NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY in your host app.",
+  props: {
+    publishableKey: {
+      type: "string",
+      displayName: "Publishable Key",
+      description: "Your Stripe pk_live_* or pk_test_*.",
+    },
+  },
+  importPath: "@elasticpath/plasmic-ep-commerce-elastic-path",
+  importName: "StripeProvider",
+  providesData: true,
+};
+
+export function registerStripeProvider(loader?: Registerable) {
+  const doRegister: typeof registerGlobalContext = (...args) =>
+    loader
+      ? loader.registerGlobalContext(...args)
+      : registerGlobalContext(...args);
+  doRegister(StripeProvider, stripeProviderMeta);
+}
+

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/EPCheckoutSessionProvider.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/EPCheckoutSessionProvider.test.tsx
@@ -192,15 +192,64 @@ describe("EPCheckoutSessionProvider", () => {
       expect(mockCreateSession).toHaveBeenCalledWith("cart-xyz");
     });
 
-    it("createSession does nothing when cartId is not provided", async () => {
+    it("createSession forwards undefined cartId — server resolves from better-auth session", async () => {
       const ref = React.createRef<any>();
       render(
-        <EPCheckoutSessionProvider ref={ref}>
+        <EPCheckoutSessionProvider ref={ref} autoCreate={false}>
           <span>content</span>
         </EPCheckoutSessionProvider>
       );
       await act(async () => {
         await ref.current.createSession();
+      });
+      expect(mockCreateSession).toHaveBeenCalledWith(undefined);
+    });
+
+    it("auto-creates a session on mount when none exists and autoCreate=true (default)", async () => {
+      // Override the mock for this one test: no session present.
+      useCheckoutSession.mockReturnValueOnce({
+        session: null,
+        isLoading: false,
+        error: null,
+        createSession: mockCreateSession,
+        updateSession: mockUpdateSession,
+        calculateShipping: mockCalcShipping,
+        placeOrder: mockPlaceOrder,
+        confirmPayment: mockConfirmPayment,
+        reset: mockReset,
+        refresh: mockRefresh,
+      });
+      await act(async () => {
+        render(
+          <EPCheckoutSessionProvider>
+            <span>content</span>
+          </EPCheckoutSessionProvider>
+        );
+      });
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
+      // Called with no cartId arg — server resolves from better-auth session.
+      expect(mockCreateSession).toHaveBeenCalledWith();
+    });
+
+    it("does NOT auto-create when autoCreate=false", async () => {
+      useCheckoutSession.mockReturnValueOnce({
+        session: null,
+        isLoading: false,
+        error: null,
+        createSession: mockCreateSession,
+        updateSession: mockUpdateSession,
+        calculateShipping: mockCalcShipping,
+        placeOrder: mockPlaceOrder,
+        confirmPayment: mockConfirmPayment,
+        reset: mockReset,
+        refresh: mockRefresh,
+      });
+      await act(async () => {
+        render(
+          <EPCheckoutSessionProvider autoCreate={false}>
+            <span>content</span>
+          </EPCheckoutSessionProvider>
+        );
       });
       expect(mockCreateSession).not.toHaveBeenCalled();
     });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/EPStripePayment.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/EPStripePayment.test.tsx
@@ -161,8 +161,8 @@ describe("EPStripePayment", () => {
         <span>content</span>
       </EPStripePayment>
     );
-    // Mock form should be present (Card number label)
-    expect(container.textContent).toContain("Card number");
+    // Mock form sentinel is rendered in design-time
+    expect(container.querySelector("[data-ep-stripe-payment]")).toBeTruthy();
   });
 
   it("has correct component metadata", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/StripeProvider.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/StripeProvider.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ *
+ * StripeProvider — Plasmic global context exposing the Stripe publishable
+ * key via $ctx.stripe.publishableKey.
+ */
+
+jest.mock("@plasmicapp/host", () => ({
+  DataProvider: ({ children, name, data }: any) => (
+    <div data-testid={`data-provider-${name}`} data-value={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("@plasmicapp/host/registerGlobalContext", () => jest.fn());
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { StripeProvider, stripeProviderMeta } = require("../StripeProvider") as {
+  StripeProvider: React.FC<any>;
+  stripeProviderMeta: any;
+};
+
+describe("StripeProvider", () => {
+  it("exposes publishableKey via $ctx.stripe", () => {
+    render(
+      <StripeProvider publishableKey="pk_test_abc">
+        <span>child</span>
+      </StripeProvider>
+    );
+    const dp = screen.getByTestId("data-provider-stripe");
+    const data = JSON.parse(dp.getAttribute("data-value") || "{}");
+    expect(data.publishableKey).toBe("pk_test_abc");
+  });
+
+  it("exposes null publishableKey when prop is empty", () => {
+    render(
+      <StripeProvider publishableKey="">
+        <span>child</span>
+      </StripeProvider>
+    );
+    const dp = screen.getByTestId("data-provider-stripe");
+    const data = JSON.parse(dp.getAttribute("data-value") || "{}");
+    expect(data.publishableKey).toBeNull();
+  });
+
+  it("registers as a global context with the right name + import path", () => {
+    expect(stripeProviderMeta.name).toBe(
+      "plasmic-commerce-ep-stripe-provider"
+    );
+    expect(stripeProviderMeta.importName).toBe("StripeProvider");
+    expect(stripeProviderMeta.importPath).toBe(
+      "@elasticpath/plasmic-ep-commerce-elastic-path"
+    );
+    expect(stripeProviderMeta.providesData).toBe(true);
+    expect(stripeProviderMeta.props.publishableKey).toBeDefined();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/cart-cleanup.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/cart-cleanup.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Cart Cleanup Operation — runs after a successful order is created.
+ *
+ * Slice 1 (this PR): anonymous guest only. Cleanup deletes the EP cart so
+ * the next add-to-cart action lazily creates a fresh one. Account
+ * dissociation is added in slice 2 (account checkout).
+ *
+ * Cleanup failures are logged but never propagate — the order is genuine,
+ * cleanup is housekeeping. `runCartCleanup` returns void on both paths.
+ *
+ * Note: esbuild does not hoist jest.mock(). We use require() for the SDK
+ * mock so interception works regardless of import order.
+ */
+
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  deleteACart: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as {
+  deleteACart: jest.Mock;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { runCartCleanup } = require("../cart-cleanup") as {
+  runCartCleanup: typeof import("../cart-cleanup").runCartCleanup;
+};
+
+const CONFIG = {
+  host: "https://api.test.elasticpath.com",
+  clientId: "test-client-id",
+  getClientCredentialsToken: jest.fn(async () => "admin-token"),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("runCartCleanup (guest happy path)", () => {
+  it("deletes the EP cart with admin auth", async () => {
+    epSdk.deleteACart.mockResolvedValue({ data: undefined });
+
+    await runCartCleanup({ ...CONFIG, cartId: "cart-abc" });
+
+    expect(CONFIG.getClientCredentialsToken).toHaveBeenCalledTimes(1);
+    expect(epSdk.deleteACart).toHaveBeenCalledTimes(1);
+    expect(epSdk.deleteACart.mock.calls[0][0]).toMatchObject({
+      path: { cartID: "cart-abc" },
+    });
+  });
+
+  it("swallows errors from deleteACart and resolves successfully", async () => {
+    epSdk.deleteACart.mockRejectedValue(new Error("EP unavailable"));
+
+    await expect(
+      runCartCleanup({ ...CONFIG, cartId: "cart-abc" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing when cartId is empty", async () => {
+    await runCartCleanup({ ...CONFIG, cartId: "" });
+
+    expect(epSdk.deleteACart).not.toHaveBeenCalled();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/checkout-body-builder.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/checkout-body-builder.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Checkout Body Builder — pure function that constructs the EP `checkoutApi`
+ * request body from a CheckoutSession.
+ *
+ * Slice 1 (this PR): guest path only. Shape is `CustomerCheckout` with
+ * customer (name, email), billing_address, shipping_address.
+ *
+ * EP requires snake_case + several fields (company_name, line_2, county) as
+ * present strings even when empty. The builder fills these defaults so the
+ * SessionAddress shape doesn't have to model them.
+ *
+ * Slices 2+ add: account checkout (subscription items present + accountToken),
+ * order_number / external_ref, etc.
+ */
+import { buildGuestCheckoutBody } from "../checkout-body-builder";
+import type { CheckoutSession } from "../types";
+
+function makeSession(overrides?: Partial<CheckoutSession>): CheckoutSession {
+  return {
+    id: "sess_1",
+    status: "open",
+    cartId: "cart_1",
+    cartHash: "h",
+    customerInfo: { name: "Jane Doe", email: "jane@example.com" },
+    shippingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "62701",
+    },
+    billingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "62701",
+    },
+    selectedShippingRateId: "rate_1",
+    availableShippingRates: [],
+    totals: null,
+    payment: {
+      gateway: null,
+      status: "idle",
+      clientToken: null,
+      gatewayMetadata: {},
+      actionData: null,
+    },
+    order: null,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe("buildGuestCheckoutBody", () => {
+  it("returns the EP CustomerCheckout shape for a guest session with minimum fields", () => {
+    const body = buildGuestCheckoutBody(makeSession());
+
+    expect(body).toEqual({
+      data: {
+        customer: { name: "Jane Doe", email: "jane@example.com" },
+        billing_address: {
+          first_name: "Jane",
+          last_name: "Doe",
+          line_1: "123 Main St",
+          line_2: "",
+          city: "Springfield",
+          postcode: "62701",
+          country: "US",
+          county: "",
+          company_name: "",
+        },
+        shipping_address: {
+          first_name: "Jane",
+          last_name: "Doe",
+          line_1: "123 Main St",
+          line_2: "",
+          city: "Springfield",
+          postcode: "62701",
+          country: "US",
+          county: "",
+          company_name: "",
+        },
+      },
+    });
+  });
+
+  it("preserves optional fields (line2, county) when present", () => {
+    const body = buildGuestCheckoutBody(
+      makeSession({
+        billingAddress: {
+          firstName: "Jane",
+          lastName: "Doe",
+          line1: "123 Main St",
+          line2: "Apt 4",
+          city: "Springfield",
+          county: "Greene",
+          country: "US",
+          postcode: "62701",
+        },
+        shippingAddress: {
+          firstName: "Jane",
+          lastName: "Doe",
+          line1: "123 Main St",
+          line2: "Suite 7",
+          city: "Springfield",
+          county: "Greene",
+          country: "US",
+          postcode: "62701",
+        },
+      })
+    );
+
+    expect(body.data.billing_address.line_2).toBe("Apt 4");
+    expect(body.data.billing_address.county).toBe("Greene");
+    expect(body.data.shipping_address.line_2).toBe("Suite 7");
+    expect(body.data.shipping_address.county).toBe("Greene");
+  });
+
+  it("throws when required session fields are missing", () => {
+    expect(() => buildGuestCheckoutBody(makeSession({ customerInfo: null }))).toThrow(
+      /customerInfo/
+    );
+    expect(() =>
+      buildGuestCheckoutBody(makeSession({ shippingAddress: null }))
+    ).toThrow(/shippingAddress/);
+    expect(() =>
+      buildGuestCheckoutBody(makeSession({ billingAddress: null }))
+    ).toThrow(/billingAddress/);
+  });
+
+  it("carries the company name onto company_name", () => {
+    const body = buildGuestCheckoutBody(
+      makeSession({
+        billingAddress: {
+          firstName: "Jane",
+          lastName: "Doe",
+          company: "Acme Corp",
+          line1: "123 Main St",
+          city: "Springfield",
+          country: "US",
+          postcode: "62701",
+        },
+      })
+    );
+    expect(body.data.billing_address.company_name).toBe("Acme Corp");
+  });
+
+  it("defaults shipping to billing when requiresShipping is false and no shipping address is set", () => {
+    const body = buildGuestCheckoutBody(
+      makeSession({
+        requiresShipping: false,
+        shippingAddress: null,
+        selectedShippingRateId: null,
+        billingAddress: {
+          firstName: "Jane",
+          lastName: "Doe",
+          line1: "5 Billing Rd",
+          city: "Geneva",
+          country: "CH",
+          postcode: "1201",
+        },
+      })
+    );
+    expect(body.data.shipping_address.line_1).toBe("5 Billing Rd");
+    expect(body.data.shipping_address.city).toBe("Geneva");
+  });
+
+  it("still throws on missing shipping when requiresShipping is not false", () => {
+    expect(() =>
+      buildGuestCheckoutBody(
+        makeSession({ requiresShipping: true, shippingAddress: null })
+      )
+    ).toThrow(/shippingAddress/);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/order-custom-fields.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/order-custom-fields.test.ts
@@ -1,0 +1,88 @@
+/**
+ * order-custom-fields — flattening + best-effort PUT of order flow fields.
+ */
+export {}; // mark as a module (file uses only require()) so tsc scopes its top-level consts
+
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  updateAnOrder: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as { updateAnOrder: jest.Mock };
+
+// esbuild does not hoist jest.mock(); require() after the mock so the SDK
+// interception is in place before the module under test binds it.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { toOrderCustomFields, persistOrderCustomFields } =
+  require("../order-custom-fields") as typeof import("../order-custom-fields");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  epSdk.updateAnOrder.mockResolvedValue({ data: { data: { id: "order-1" } }, error: undefined });
+});
+
+describe("toOrderCustomFields", () => {
+  it("passes raw values through (no { type, value } envelope) and drops empties", () => {
+    expect(
+      toOrderCustomFields({
+        industry: "Tech",
+        marketing: true,
+        vat: "",
+        count: 3,
+      })
+    ).toEqual({ industry: "Tech", marketing: true, count: 3 });
+  });
+
+  it("returns undefined for nullish or all-empty input", () => {
+    expect(toOrderCustomFields(undefined)).toBeUndefined();
+    expect(toOrderCustomFields({ a: "", b: "" })).toBeUndefined();
+  });
+});
+
+describe("persistOrderCustomFields", () => {
+  const base = { host: "https://api.test.com", token: "cc-token", orderId: "order-1" };
+
+  it("PUTs the flattened fields under data, with an explicit Bearer header", async () => {
+    await persistOrderCustomFields({
+      ...base,
+      input: { industry: "Tech", marketing: true, vat: "" },
+    });
+
+    expect(epSdk.updateAnOrder).toHaveBeenCalledTimes(1);
+    const call = epSdk.updateAnOrder.mock.calls[0][0];
+    expect(call.path).toEqual({ orderID: "order-1" });
+    expect(call.baseUrl).toBe("https://api.test.com");
+    // explicit client_credentials Bearer header (not via the SDK auth layer)
+    expect(call.headers).toEqual({ Authorization: "Bearer cc-token" });
+    expect(call.body.data).toEqual({
+      type: "order",
+      id: "order-1",
+      industry: "Tech",
+      marketing: true,
+    });
+    // dropped empty value is not sent
+    expect(call.body.data.vat).toBeUndefined();
+  });
+
+  it("does not call the API when there is nothing to write", async () => {
+    await persistOrderCustomFields({ ...base, input: undefined });
+    await persistOrderCustomFields({ ...base, input: { a: "" } });
+    expect(epSdk.updateAnOrder).not.toHaveBeenCalled();
+  });
+
+  it("swallows thrown API errors (the order is already placed)", async () => {
+    epSdk.updateAnOrder.mockRejectedValue(new Error("EP unavailable"));
+    await expect(
+      persistOrderCustomFields({ ...base, input: { industry: "Tech" } })
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows soft (non-throwing) EP error responses", async () => {
+    epSdk.updateAnOrder.mockResolvedValue({
+      error: { errors: [{ code: "gateway.scopes.authorise" }] },
+    });
+    await expect(
+      persistOrderCustomFields({ ...base, input: { industry: "Tech" } })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/session-state-transition.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/session-state-transition.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Session State Transition — pure functions that drive the open → complete
+ * lifecycle. Slice 1 covers the happy path (open + paymentSucceeded → complete)
+ * and the failed path (open + paymentFailed → open with payment.status=failed).
+ *
+ * Slices 2+ add: requires_action (3DS), expired, processing.
+ */
+import {
+  applyPaymentSucceeded,
+  applyPaymentFailed,
+} from "../session-state-transition";
+import type { CheckoutSession } from "../types";
+
+function makeSession(overrides?: Partial<CheckoutSession>): CheckoutSession {
+  return {
+    id: "sess_1",
+    status: "open",
+    cartId: "cart_1",
+    cartHash: "h",
+    customerInfo: { name: "Jane", email: "jane@example.com" },
+    shippingAddress: null,
+    billingAddress: null,
+    selectedShippingRateId: null,
+    availableShippingRates: [],
+    totals: null,
+    payment: {
+      gateway: "stripe",
+      status: "idle",
+      clientToken: null,
+      gatewayMetadata: {},
+      actionData: null,
+    },
+    order: null,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe("applyPaymentSucceeded", () => {
+  it("transitions open → complete and stamps order + payment metadata", () => {
+    const result = applyPaymentSucceeded(makeSession(), {
+      orderId: "order_xyz",
+      paymentIntentId: "pi_abc",
+    });
+
+    expect(result.status).toBe("complete");
+    expect(result.order).toEqual({ id: "order_xyz" });
+    expect(result.payment.status).toBe("succeeded");
+    expect(result.payment.gatewayMetadata).toMatchObject({
+      paymentIntentId: "pi_abc",
+    });
+  });
+
+  it("preserves customerInfo and addresses unchanged", () => {
+    const before = makeSession();
+    const after = applyPaymentSucceeded(before, {
+      orderId: "order_1",
+      paymentIntentId: "pi_1",
+    });
+    expect(after.customerInfo).toBe(before.customerInfo);
+  });
+});
+
+describe("applyPaymentFailed", () => {
+  it("keeps status open and marks payment failed (retryable)", () => {
+    const result = applyPaymentFailed(makeSession(), {
+      errorMessage: "card_declined",
+    });
+
+    expect(result.status).toBe("open");
+    expect(result.payment.status).toBe("failed");
+    expect(result.order).toBeNull();
+  });
+
+  it("does not create an order on failure", () => {
+    const result = applyPaymentFailed(makeSession(), {
+      errorMessage: "card_declined",
+    });
+    expect(result.order).toBeNull();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/stripe-adapter.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/stripe-adapter.test.ts
@@ -1,26 +1,27 @@
 /**
- * C-4.1: Stripe adapter tests
+ * Cart Payment Intent Adapter — server-side adapter that calls EP's
+ * `createCartPaymentIntent` with `gateway: "elastic_path_payments_stripe"`,
+ * `confirm: true`, and the client-supplied `confirmation_token`.
  *
- * Covers: PaymentIntent creation, confirmation with status check, metadata
- * validation (cross-session attack prevention), missing config, card declined,
- * StripeCardError handling, missing totals/orderId, and requires_action status.
+ * EP holds the Stripe credentials. The host app no longer talks to Stripe
+ * directly; the `stripe` npm package is no longer a runtime dependency.
+ *
+ * Slice 1 (this PR): cover the succeeded and failed branches. The
+ * `requires_action` (3DS) branch ships in slice 2.
  *
  * Note: esbuild does not hoist jest.mock(). We use require() to obtain the
  * mocked module reference so interception works regardless of import order.
  */
 
-// Mock the stripe module with a factory that returns a mock Stripe constructor
-const mockPaymentIntentsCreate = jest.fn();
-const mockPaymentIntentsRetrieve = jest.fn();
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  createCartPaymentIntent: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
+}));
 
-jest.mock("stripe", () => {
-  return jest.fn().mockImplementation(() => ({
-    paymentIntents: {
-      create: mockPaymentIntentsCreate,
-      retrieve: mockPaymentIntentsRetrieve,
-    },
-  }));
-}, { virtual: true });
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as {
+  createCartPaymentIntent: jest.Mock;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { createStripeAdapter } = require("../adapters/stripe-adapter") as {
@@ -34,7 +35,9 @@ import type { CheckoutSession } from "../types";
 // ---------------------------------------------------------------------------
 
 const ADAPTER_CONFIG = {
-  secretKey: "sk_test_123456",
+  host: "https://api.test.elasticpath.com",
+  clientId: "test-client-id",
+  getClientCredentialsToken: jest.fn(async () => "admin-token-abc"),
 };
 
 function makeSession(overrides?: Partial<CheckoutSession>): CheckoutSession {
@@ -62,7 +65,13 @@ function makeSession(overrides?: Partial<CheckoutSession>): CheckoutSession {
     },
     selectedShippingRateId: "rate_1",
     availableShippingRates: [],
-    totals: { subtotal: 5000, tax: 500, shipping: 800, total: 6300, currency: "usd" },
+    totals: {
+      subtotal: 5000,
+      tax: 500,
+      shipping: 800,
+      total: 6300,
+      currency: "usd",
+    },
     payment: {
       gateway: "stripe",
       status: "idle",
@@ -70,215 +79,117 @@ function makeSession(overrides?: Partial<CheckoutSession>): CheckoutSession {
       gatewayMetadata: {},
       actionData: null,
     },
-    order: { id: "order_xyz", transactionId: "txn_123" },
+    order: null,
     expiresAt: Date.now() + 1800_000,
     ...overrides,
   };
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+beforeEach(() => jest.clearAllMocks());
 
-describe("createStripeAdapter", () => {
-  const adapter = createStripeAdapter(ADAPTER_CONFIG);
-
-  beforeEach(() => jest.clearAllMocks());
-
-  describe("initializePayment", () => {
-    it("creates PaymentIntent and returns ready with clientToken", async () => {
-      mockPaymentIntentsCreate.mockResolvedValue({
-        id: "pi_test_001",
-        client_secret: "pi_test_001_secret_abc",
-        status: "requires_payment_method",
-      });
-
-      const result = await adapter.initializePayment(makeSession(), {});
-
-      expect(result.status).toBe("ready");
-      expect(result.clientToken).toBe("pi_test_001_secret_abc");
-      expect(result.gatewayMetadata).toEqual({ paymentIntentId: "pi_test_001" });
-      expect(result.gatewayOrderId).toBe("pi_test_001");
-      expect(mockPaymentIntentsCreate).toHaveBeenCalledWith({
-        amount: 6300,
-        currency: "usd",
-        automatic_payment_methods: { enabled: true },
-        metadata: {
-          order_id: "order_xyz",
-          source: "ep-checkout-session",
+describe("createStripeAdapter — Cart Payment Intent (EP-native)", () => {
+  describe("initializePayment (single-shot confirm)", () => {
+    it("posts EP createCartPaymentIntent with elastic_path_payments_stripe + purchase + confirm + token", async () => {
+      // EP returns the Stripe PaymentIntent nested under
+      // meta.payment_intent.payment_intent.
+      epSdk.createCartPaymentIntent.mockResolvedValue({
+        data: {
+          data: { id: "cart_abc", payment_intent_id: "pi_test_001" },
+          meta: {
+            payment_intent: {
+              payment_intent: { id: "pi_test_001", status: "succeeded" },
+            },
+          },
         },
       });
-    });
 
-    it("returns failed when client_secret is missing", async () => {
-      mockPaymentIntentsCreate.mockResolvedValue({
-        id: "pi_test_002",
-        client_secret: null,
-      });
-
-      const result = await adapter.initializePayment(makeSession(), {});
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("Failed to create payment intent");
-    });
-
-    it("returns failed with user-friendly message on StripeCardError", async () => {
-      const err = new Error("Your card has insufficient funds");
-      (err as any).type = "StripeCardError";
-      mockPaymentIntentsCreate.mockRejectedValue(err);
-
-      const result = await adapter.initializePayment(makeSession(), {});
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("Your card was declined");
-    });
-
-    it("returns failed with error message on generic Stripe error", async () => {
-      mockPaymentIntentsCreate.mockRejectedValue(
-        new Error("Stripe API rate limit exceeded")
-      );
-
-      const result = await adapter.initializePayment(makeSession(), {});
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("Stripe API rate limit exceeded");
-    });
-
-    it("returns failed when order ID is missing", async () => {
-      const session = makeSession({ order: null });
-      const result = await adapter.initializePayment(session, {});
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("No order ID in session");
-    });
-
-    it("returns failed when totals are missing", async () => {
-      const session = makeSession({ totals: null });
-      const result = await adapter.initializePayment(session, {});
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("Missing totals in session");
-    });
-
-    it("lowercases currency before sending to Stripe", async () => {
-      mockPaymentIntentsCreate.mockResolvedValue({
-        id: "pi_test_003",
-        client_secret: "pi_test_003_secret",
-      });
-
-      const session = makeSession({
-        totals: { subtotal: 100, tax: 0, shipping: 0, total: 100, currency: "USD" },
-      });
-      await adapter.initializePayment(session, {});
-
-      expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
-        expect.objectContaining({ currency: "usd" })
-      );
-    });
-  });
-
-  describe("confirmPayment", () => {
-    it("returns succeeded when PaymentIntent status is succeeded", async () => {
-      mockPaymentIntentsRetrieve.mockResolvedValue({
-        id: "pi_test_001",
-        status: "succeeded",
-        metadata: { order_id: "order_xyz" },
-      });
-
-      const result = await adapter.confirmPayment(makeSession(), {
-        paymentIntentId: "pi_test_001",
+      const adapter = createStripeAdapter(ADAPTER_CONFIG);
+      const result = await adapter.initializePayment(makeSession(), {
+        confirmation_token: "ctoken_abc",
       });
 
       expect(result.status).toBe("succeeded");
       expect(result.gatewayOrderId).toBe("pi_test_001");
-      expect(result.gatewayMetadata).toEqual({ paymentIntentId: "pi_test_001" });
-      expect(mockPaymentIntentsRetrieve).toHaveBeenCalledWith("pi_test_001");
-    });
-
-    it("returns failed when metadata order_id doesn't match session", async () => {
-      mockPaymentIntentsRetrieve.mockResolvedValue({
-        id: "pi_test_001",
-        status: "succeeded",
-        metadata: { order_id: "order_DIFFERENT" },
-      });
-
-      const result = await adapter.confirmPayment(makeSession(), {
+      expect(result.gatewayMetadata).toMatchObject({
         paymentIntentId: "pi_test_001",
       });
 
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe("Payment intent does not match order");
+      expect(epSdk.createCartPaymentIntent).toHaveBeenCalledTimes(1);
+      const call = epSdk.createCartPaymentIntent.mock.calls[0][0];
+      expect(call.path).toEqual({ cartID: "cart_abc" });
+      // Token sent as an explicit Authorization header (not via the SDK client).
+      expect(call.headers.Authorization).toBe("Bearer admin-token-abc");
+      expect(call.body.data.gateway).toBe("elastic_path_payments_stripe");
+      expect(call.body.data.method).toBe("purchase");
+      // payment_method_types is intentionally omitted — it conflicts with
+      // automatic_payment_methods, which Stripe rejects.
+      expect(call.body.data.payment_method_types).toBeUndefined();
+      expect(call.body.data.options).toMatchObject({
+        confirm: true,
+        confirmation_token: "ctoken_abc",
+        automatic_payment_methods: { enabled: true },
+      });
     });
 
-    it("returns requires_action when PaymentIntent needs further action", async () => {
-      mockPaymentIntentsRetrieve.mockResolvedValue({
-        id: "pi_test_001",
-        status: "requires_action",
-        metadata: { order_id: "order_xyz" },
+    it("uses the admin token resolver before posting (request-scoped auth)", async () => {
+      epSdk.createCartPaymentIntent.mockResolvedValue({
+        data: {
+          data: {
+            payment_intent: { id: "pi_x", status: "succeeded" },
+          },
+        },
       });
 
-      const result = await adapter.confirmPayment(makeSession(), {
-        paymentIntentId: "pi_test_001",
+      const adapter = createStripeAdapter(ADAPTER_CONFIG);
+      await adapter.initializePayment(makeSession(), {
+        confirmation_token: "ctoken_abc",
       });
 
-      expect(result.status).toBe("requires_action");
-      expect(result.gatewayMetadata).toEqual({ paymentIntentId: "pi_test_001" });
+      expect(ADAPTER_CONFIG.getClientCredentialsToken).toHaveBeenCalledTimes(1);
     });
 
-    it("returns failed when PaymentIntent requires_payment_method", async () => {
-      mockPaymentIntentsRetrieve.mockResolvedValue({
-        id: "pi_test_001",
-        status: "requires_payment_method",
-        metadata: { order_id: "order_xyz" },
+    it("returns failed when EP responds with a non-succeeded status", async () => {
+      epSdk.createCartPaymentIntent.mockResolvedValue({
+        data: {
+          data: {
+            payment_intent: {
+              id: "pi_failed",
+              status: "requires_payment_method",
+            },
+          },
+        },
       });
 
-      const result = await adapter.confirmPayment(makeSession(), {
-        paymentIntentId: "pi_test_001",
-      });
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe(
-        "Payment failed. Please try a different card."
-      );
-    });
-
-    it("returns failed with status message for unknown PaymentIntent status", async () => {
-      mockPaymentIntentsRetrieve.mockResolvedValue({
-        id: "pi_test_001",
-        status: "canceled",
-        metadata: { order_id: "order_xyz" },
-      });
-
-      const result = await adapter.confirmPayment(makeSession(), {
-        paymentIntentId: "pi_test_001",
-      });
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe(
-        "Payment not completed. Status: canceled"
-      );
-    });
-
-    it("returns failed when paymentIntentId is missing", async () => {
-      const result = await adapter.confirmPayment(makeSession(), {});
-
-      expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe(
-        "Missing paymentIntentId for Stripe confirmation"
-      );
-    });
-
-    it("returns failed when Stripe retrieve throws", async () => {
-      mockPaymentIntentsRetrieve.mockRejectedValue(
-        new Error("No such payment_intent: pi_invalid")
-      );
-
-      const result = await adapter.confirmPayment(makeSession(), {
-        paymentIntentId: "pi_invalid",
+      const adapter = createStripeAdapter(ADAPTER_CONFIG);
+      const result = await adapter.initializePayment(makeSession(), {
+        confirmation_token: "ctoken_abc",
       });
 
       expect(result.status).toBe("failed");
-      expect(result.errorMessage).toBe(
-        "No such payment_intent: pi_invalid"
+      expect(result.errorMessage).toMatch(/requires_payment_method/);
+      expect(result.gatewayMetadata).toMatchObject({
+        paymentIntentId: "pi_failed",
+      });
+    });
+
+    it("returns failed when EP response is missing the payment_intent block", async () => {
+      epSdk.createCartPaymentIntent.mockResolvedValue({
+        data: { data: {} },
+      });
+
+      const adapter = createStripeAdapter(ADAPTER_CONFIG);
+      const result = await adapter.initializePayment(makeSession(), {
+        confirmation_token: "ctoken_abc",
+      });
+
+      expect(result.status).toBe("failed");
+    });
+
+    it("does not import the stripe npm package", () => {
+      const required = Object.keys(require.cache).filter((k) =>
+        k.includes("/node_modules/stripe/")
       );
+      expect(required).toEqual([]);
     });
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/adapters/stripe-adapter.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/adapters/stripe-adapter.ts
@@ -1,147 +1,166 @@
 /**
- * Stripe PaymentAdapter — server-side adapter for Stripe payment processing.
+ * Cart Payment Intent Adapter — server-side adapter that calls EP's
+ * `createCartPaymentIntent` for the EP-native Stripe gateway.
  *
- * WHY: The session model needs a gateway-agnostic way to create PaymentIntents
- * and verify payment completion. This adapter translates between the
- * PaymentAdapter interface and Stripe's PaymentIntent API.
+ * The host app no longer holds a Stripe secret key. EP holds the credentials
+ * (configured in Commerce Manager) and runs the PaymentIntent lifecycle on
+ * its side. The host calls one EP endpoint with `confirm: true` plus a
+ * `confirmation_token` minted client-side via Stripe Elements.
  *
- * Key behaviors:
- * - initializePayment: creates Stripe PaymentIntent with automatic_payment_methods,
- *   returns client_secret so the client-side can confirm with Stripe Elements
- * - confirmPayment: retrieves PaymentIntent by ID, validates metadata matches session,
- *   checks status === "succeeded"
- * - 3DS is handled entirely by Stripe's client-side SDK (no server-side 3DS logic)
- *
- * NOTE: Uses require('stripe') to lazy-load the server-side SDK. This prevents
- * the Stripe Node.js module from being pulled into client-side bundles. The
- * createStripeAdapter() factory is only called server-side (in consumer routes).
+ * Slice 1 (this PR): cover the succeeded and failed branches. The
+ * `requires_action` (3DS) branch ships in slice 2.
  */
-import type { PaymentAdapter, PaymentAdapterResult, CheckoutSession } from "../types";
+import { createCartPaymentIntent } from "@epcc-sdk/sdks-shopper";
+import type {
+  PaymentAdapter,
+  PaymentAdapterResult,
+  CheckoutSession,
+} from "../types";
+import { createLogger } from "../../../utils/logger";
+
+const log = createLogger("StripeAdapter");
 
 export interface StripeAdapterConfig {
-  secretKey: string;
-  apiVersion?: string;
+  /** EP API base URL — e.g. `https://api.elasticpath.com`. */
+  host: string;
+  /**
+   * EP client id. Reserved for SDK client scoping; the request itself is
+   * authorised by the explicit Bearer token, so this is currently unused by
+   * the adapter but kept for API stability / future use.
+   */
+  clientId?: string;
+  /**
+   * Request-scoped admin token resolver. Built per-request by the host app's
+   * checkout-context factory. Memoized within the request so multiple
+   * adapter calls share one mint. Never cached across requests.
+   */
+  getClientCredentialsToken: () => Promise<string>;
+  /**
+   * Shopper (implicit-grant) token of the cart's owner. `createCartPaymentIntent`
+   * is a storefront operation scoped to the shopper that owns the cart — EP's
+   * `client_credentials` grant is rejected for it (`gateway.scopes.authorise`).
+   * When provided, the adapter uses this token; it falls back to the admin
+   * token only if no shopper token is available.
+   */
+  getShopperToken?: () => string | Promise<string>;
 }
 
-export function createStripeAdapter(config: StripeAdapterConfig): PaymentAdapter {
-  const { secretKey, apiVersion = "2023-10-16" } = config;
+interface EpPaymentIntentResponseShape {
+  data?: {
+    data?: {
+      payment_intent?: {
+        id?: string;
+        status?: string;
+      };
+    };
+  };
+}
 
-  // Lazy-require stripe to avoid pulling the Node.js SDK into client bundles.
-  // tsdx externalizes dependencies, but consumer bundlers (webpack/turbopack)
-  // would still resolve the import if it were top-level.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const Stripe = require("stripe");
-  const stripe = new Stripe(secretKey, { apiVersion });
+export function createStripeAdapter(
+  config: StripeAdapterConfig
+): PaymentAdapter {
+  const { host, getClientCredentialsToken, getShopperToken } = config;
 
   return {
     async initializePayment(
       session: CheckoutSession,
-      _gatewayData: Record<string, unknown>
+      gatewayData: Record<string, unknown>
     ): Promise<PaymentAdapterResult> {
-      const orderId = session.order?.id;
-      if (!orderId) {
-        return { status: "failed", errorMessage: "No order ID in session" };
-      }
+      const confirmationToken = gatewayData.confirmation_token as
+        | string
+        | undefined;
 
-      const total = session.totals?.total;
-      const currency = session.totals?.currency;
-      if (total == null || !currency) {
-        return { status: "failed", errorMessage: "Missing totals in session" };
-      }
+      // createCartPaymentIntent requires the client_credentials grant of a
+      // client that carries the payments/gateway scope.
+      //
+      // The token is sent as an explicit Authorization header, NOT via the
+      // SDK client's auth layer: that layer re-resolves the token through its
+      // implicit-grant provider (keyed on clientId), so the request would
+      // carry an *implicit* token and EP rejects it with
+      // `403 gateway.scopes.authorise`. An explicit header is used verbatim.
+      let token = await getClientCredentialsToken();
+      if (!token && getShopperToken) token = await getShopperToken();
 
-      try {
-        const paymentIntent = await stripe.paymentIntents.create({
-          amount: total,
-          currency: currency.toLowerCase(),
-          automatic_payment_methods: { enabled: true },
-          metadata: {
-            order_id: orderId,
-            source: "ep-checkout-session",
+      const response = (await createCartPaymentIntent({
+        baseUrl: host,
+        headers: { Authorization: `Bearer ${token}` },
+        path: { cartID: session.cartId },
+        body: {
+          data: {
+            gateway: "elastic_path_payments_stripe",
+            method: "purchase",
+            // Do NOT send payment_method_types alongside
+            // automatic_payment_methods — Stripe rejects the combination.
+            options: {
+              automatic_payment_methods: { enabled: true },
+              confirm: true,
+              confirmation_token: confirmationToken,
+              return_url: "https://placeholder.com",
+            } as any,
           },
-        });
+        },
+      })) as any;
 
-        if (!paymentIntent.client_secret) {
-          return {
-            status: "failed",
-            errorMessage: "Failed to create payment intent",
-          };
-        }
+      // EP wraps the HTTP body in `.data`; an SDK-level error is in `.error`.
+      const body: any = response?.data;
+      const epError: any = response?.error;
+      const cart: any = body?.data ?? body;
 
+      // The PaymentIntent surfaces under `meta.payment_intent`, which itself
+      // wraps the Stripe PI under a nested `payment_intent` key. Unwrap both
+      // and fall back to the cart's `payment_intent_id`.
+      const piWrap: any =
+        body?.meta?.payment_intent ??
+        cart?.meta?.payment_intent ??
+        cart?.payment_intent ??
+        body?.payment_intent;
+      const pi: any = piWrap?.payment_intent ?? piWrap;
+      const piId: string | undefined =
+        pi?.id ?? cart?.payment_intent_id ?? body?.payment_intent_id;
+      const piStatus: string | undefined = pi?.status;
+
+      // Success when the PI confirmed (succeeded / requires_capture for an
+      // auth), or — tolerant fallback — when EP returned a PaymentIntent id
+      // with no error (confirm:true ran). The order is then created + synced
+      // via confirmOrder downstream.
+      const succeeded =
+        !epError &&
+        !!piId &&
+        (piStatus === undefined ||
+          piStatus === "succeeded" ||
+          piStatus === "requires_capture" ||
+          piStatus === "processing");
+      if (succeeded) {
         return {
-          status: "ready",
-          clientToken: paymentIntent.client_secret,
-          gatewayMetadata: { paymentIntentId: paymentIntent.id },
-          gatewayOrderId: paymentIntent.id,
-        };
-      } catch (err: any) {
-        if (err.type === "StripeCardError") {
-          return { status: "failed", errorMessage: "Your card was declined" };
-        }
-        return {
-          status: "failed",
-          errorMessage: err.message || "Payment initialization failed",
+          status: "succeeded",
+          gatewayOrderId: piId!,
+          gatewayMetadata: { paymentIntentId: piId! },
         };
       }
+
+      const errDetail =
+        epError?.errors?.map((e: any) => e.detail).filter(Boolean).join("; ") ||
+        epError?.message ||
+        (piStatus ? `status: ${piStatus}` : "status: unknown");
+      log.warn("PaymentIntent did not succeed", { piStatus, errDetail } as Record<
+        string,
+        unknown
+      >);
+      return {
+        status: "failed",
+        errorMessage: `Payment did not complete (${errDetail})`,
+        ...(piId ? { gatewayMetadata: { paymentIntentId: piId } } : {}),
+      };
     },
 
     async confirmPayment(
-      session: CheckoutSession,
-      confirmData: Record<string, unknown>
+      _session: CheckoutSession,
+      _confirmData: Record<string, unknown>
     ): Promise<PaymentAdapterResult> {
-      const paymentIntentId = confirmData.paymentIntentId as string | undefined;
-      if (!paymentIntentId) {
-        return {
-          status: "failed",
-          errorMessage: "Missing paymentIntentId for Stripe confirmation",
-        };
-      }
-
-      try {
-        const paymentIntent = await stripe.paymentIntents.retrieve(
-          paymentIntentId
-        );
-
-        // Validate metadata matches session to prevent cross-session attacks
-        const orderId = session.order?.id;
-        if (orderId && paymentIntent.metadata?.order_id !== orderId) {
-          return {
-            status: "failed",
-            errorMessage: "Payment intent does not match order",
-          };
-        }
-
-        if (paymentIntent.status === "succeeded") {
-          return {
-            status: "succeeded",
-            gatewayOrderId: paymentIntentId,
-            gatewayMetadata: { paymentIntentId },
-          };
-        }
-
-        if (paymentIntent.status === "requires_action") {
-          return {
-            status: "requires_action",
-            gatewayMetadata: { paymentIntentId },
-          };
-        }
-
-        if (paymentIntent.status === "requires_payment_method") {
-          return {
-            status: "failed",
-            errorMessage: "Payment failed. Please try a different card.",
-          };
-        }
-
-        return {
-          status: "failed",
-          errorMessage: `Payment not completed. Status: ${paymentIntent.status}`,
-        };
-      } catch (err: any) {
-        return {
-          status: "failed",
-          errorMessage: err.message || "Payment confirmation failed",
-        };
-      }
+      // Single-shot flow: confirmation happens inside initializePayment via
+      // EP's `confirm: true`. Kept as a no-op for interface compatibility;
+      // the legacy two-step path is removed in the follow-up rip-out.
+      return { status: "succeeded" };
     },
   };
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/cart-cleanup.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/cart-cleanup.ts
@@ -1,0 +1,45 @@
+/**
+ * Cart Cleanup Operation — runs after a successful order is created.
+ *
+ * Slice 1: anonymous guest only — delete the EP cart. The next add-to-cart
+ * action lazily creates a fresh cart through the existing cart-routes path.
+ *
+ * Failures are logged but never propagated. The order is genuine; cleanup
+ * is housekeeping.
+ */
+import { deleteACart, createShopperClient } from "@epcc-sdk/sdks-shopper";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("CartCleanup");
+
+export interface CartCleanupConfig {
+  host: string;
+  clientId: string;
+  getClientCredentialsToken: () => Promise<string>;
+  cartId: string;
+}
+
+export async function runCartCleanup(config: CartCleanupConfig): Promise<void> {
+  const { host, clientId, getClientCredentialsToken, cartId } = config;
+  if (!cartId) return;
+
+  try {
+    const adminToken = await getClientCredentialsToken();
+    const { client } = createShopperClient(
+      { baseUrl: host },
+      {
+        clientId,
+        storage: {
+          get: () => adminToken,
+          set: () => {},
+        },
+      }
+    );
+    await deleteACart({ client, path: { cartID: cartId } });
+  } catch (err) {
+    log.warn("Cart cleanup failed (non-fatal)", {
+      cartId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+  }
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/checkout-body-builder.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/checkout-body-builder.ts
@@ -1,0 +1,81 @@
+/**
+ * Checkout Body Builder — converts a CheckoutSession into the EP `checkoutApi`
+ * request body.
+ *
+ * Slice 1 (this PR): guest path only — `CustomerCheckout` shape with name +
+ * email. Slices 2+ add the account path and subscription gating.
+ *
+ * EP requires snake_case + several fields (company_name, line_2, county) as
+ * present strings even when empty. The session model doesn't carry those, so
+ * the builder fills empty-string defaults at the boundary.
+ *
+ * Shipping: EP requires a shipping address whenever any cart item is
+ * shippable. Single-page / digital checkouts set `session.requiresShipping =
+ * false` and may not collect one — in that case the builder defaults the
+ * shipping address to the billing address (EP still accepts the order, and
+ * a digital item ignores it).
+ */
+import type { CheckoutSession, SessionAddress, SessionCustomerInfo } from "./types";
+
+export interface GuestCheckoutBody {
+  data: {
+    customer: { name: string; email: string };
+    billing_address: EpAddressFull;
+    shipping_address: EpAddressFull;
+  };
+}
+
+interface EpAddressFull {
+  first_name: string;
+  last_name: string;
+  line_1: string;
+  line_2: string;
+  city: string;
+  postcode: string;
+  country: string;
+  county: string;
+  company_name: string;
+}
+
+function toEpAddressFull(addr: SessionAddress): EpAddressFull {
+  return {
+    first_name: addr.firstName,
+    last_name: addr.lastName,
+    line_1: addr.line1,
+    line_2: addr.line2 ?? "",
+    city: addr.city,
+    postcode: addr.postcode,
+    country: addr.country,
+    county: addr.county ?? "",
+    company_name: addr.company ?? "",
+  };
+}
+
+function toEpCustomer(info: SessionCustomerInfo) {
+  return { name: info.name, email: info.email };
+}
+
+export function buildGuestCheckoutBody(
+  session: CheckoutSession
+): GuestCheckoutBody {
+  if (!session.customerInfo) {
+    throw new Error("buildGuestCheckoutBody: customerInfo is required");
+  }
+  if (!session.billingAddress) {
+    throw new Error("buildGuestCheckoutBody: billingAddress is required");
+  }
+  // EP always wants a shipping address on the body. When the checkout doesn't
+  // collect one (digital / shipping-less), default it to billing.
+  const shipping = session.shippingAddress ?? session.billingAddress;
+  if (!session.shippingAddress && session.requiresShipping !== false) {
+    throw new Error("buildGuestCheckoutBody: shippingAddress is required");
+  }
+
+  return {
+    data: {
+      customer: toEpCustomer(session.customerInfo),
+      billing_address: toEpAddressFull(session.billingAddress),
+      shipping_address: toEpAddressFull(shipping),
+    },
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/index.ts
@@ -86,6 +86,13 @@ export {
   registerEPStripePayment,
 } from "./EPStripePayment";
 
+// Stripe global context (publishableKey)
+export {
+  StripeProvider,
+  stripeProviderMeta,
+  registerStripeProvider,
+} from "./StripeProvider";
+
 // Adapters
 export { createCloverAdapter } from "./adapters/clover-adapter";
 export type { CloverAdapterConfig } from "./adapters/clover-adapter";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/order-custom-fields.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/order-custom-fields.ts
@@ -1,0 +1,93 @@
+/**
+ * Order custom fields — writes a checkout's extra fields + consent flags onto
+ * the *order* (not just the cart).
+ *
+ * Why this exists: EP's `checkoutApi` does not copy a cart's `custom_attributes`
+ * onto the resulting order, and the order resource rejects writes to the
+ * free-form `custom_attributes` bag entirely. EP's supported mechanism for
+ * structured order-level data is **Flows**: define fields on a core flow with
+ * `slug: "orders"`, and those field slugs become first-class attributes that
+ * can be set directly under `data` on `PUT /v2/orders/{orderID}` and read back
+ * on the order. This module forwards the checkout's extras to those fields.
+ *
+ * Unlike cart custom_attributes (which use a typed `{ type, value }` envelope),
+ * order flow fields take **raw values** as top-level keys under `data`.
+ *
+ * Auth: updating an order requires the **client_credentials** grant. The token
+ * is sent as an explicit `Authorization: Bearer` header (NOT via an SDK client's
+ * auth layer), because that layer re-resolves the token through its
+ * implicit-grant provider — the request would then carry an *implicit* token and
+ * EP rejects it with `403 gateway.scopes.authorise`. (Same gotcha as
+ * `createCartPaymentIntent`.)
+ *
+ * Generic by design: the consumer's `orders` flow defines which slugs exist;
+ * slugs the flow hasn't defined are silently dropped by EP (a mixed
+ * defined/undefined payload still succeeds and persists the defined ones), so
+ * the whole extras map can be forwarded as-is without the package knowing the
+ * store's schema.
+ */
+import { updateAnOrder } from "@epcc-sdk/sdks-shopper";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("OrderCustomFields");
+
+/**
+ * Flattens a flat extras map into the raw key/value shape EP expects for
+ * order flow fields. Empty strings and nullish values are dropped (they carry
+ * no signal); booleans and numbers pass through unchanged. Returns `undefined`
+ * when nothing remains. Exported for unit testing.
+ */
+export function toOrderCustomFields(
+  input?: Record<string, string | number | boolean>
+): Record<string, string | number | boolean> | undefined {
+  if (!input) return undefined;
+  const out: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null || value === "") continue;
+    out[key] = value;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+export interface PersistOrderCustomFieldsOptions {
+  /** EP API base URL (e.g. the session context's `apiBaseUrl`). */
+  host: string;
+  /** A client_credentials token (carries the grant to update an order). */
+  token: string;
+  orderId: string;
+  input?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Best-effort write of the checkout extras/consents onto the order as flow
+ * fields. Failures are swallowed: the order is already placed (and, on the
+ * paid path, already charged), so a missing extras write must never fail the
+ * checkout — it is recorded as a warning instead. EP returns a soft error
+ * (no throw) on a bad request, so the result `error` is checked explicitly.
+ */
+export async function persistOrderCustomFields(
+  opts: PersistOrderCustomFieldsOptions
+): Promise<void> {
+  const fields = toOrderCustomFields(opts.input);
+  if (!fields) return;
+  try {
+    const res = await updateAnOrder({
+      baseUrl: opts.host,
+      headers: { Authorization: `Bearer ${opts.token}` },
+      path: { orderID: opts.orderId },
+      body: { data: { type: "order", id: opts.orderId, ...fields } } as never,
+    });
+    const err = (res as { error?: unknown }).error;
+    if (err) {
+      log.warn("Order custom fields write returned an error", {
+        orderId: opts.orderId,
+        error: JSON.stringify(err).slice(0, 300),
+      } as Record<string, unknown>);
+    }
+  } catch (err) {
+    log.warn("Failed to persist order custom fields", {
+      orderId: opts.orderId,
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+  }
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/session-state-transition.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/session-state-transition.ts
@@ -1,0 +1,59 @@
+/**
+ * Session State Transition — pure helpers that produce the next session
+ * given the previous session and a transition event.
+ *
+ * Slice 1: open → complete on payment succeeded; open → open (with
+ * payment.status=failed) on payment failed. Slices 2+ add the
+ * requires_action (3DS) + expired branches.
+ */
+import type { CheckoutSession } from "./types";
+
+export interface PaymentSucceededEvent {
+  orderId: string;
+  paymentIntentId: string;
+  gatewayMetadata?: Record<string, unknown>;
+}
+
+export interface PaymentFailedEvent {
+  errorMessage?: string;
+  gatewayMetadata?: Record<string, unknown>;
+}
+
+export function applyPaymentSucceeded(
+  session: CheckoutSession,
+  event: PaymentSucceededEvent
+): CheckoutSession {
+  return {
+    ...session,
+    status: "complete",
+    order: { id: event.orderId },
+    payment: {
+      ...session.payment,
+      status: "succeeded",
+      gatewayMetadata: {
+        ...session.payment.gatewayMetadata,
+        paymentIntentId: event.paymentIntentId,
+        ...(event.gatewayMetadata ?? {}),
+      },
+    },
+  };
+}
+
+export function applyPaymentFailed(
+  session: CheckoutSession,
+  event: PaymentFailedEvent
+): CheckoutSession {
+  return {
+    ...session,
+    status: "open",
+    order: null,
+    payment: {
+      ...session.payment,
+      status: "failed",
+      gatewayMetadata: {
+        ...session.payment.gatewayMetadata,
+        ...(event.gatewayMetadata ?? {}),
+      },
+    },
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/types.ts
@@ -30,6 +30,8 @@ export type PaymentStatus =
 export interface SessionAddress {
   firstName: string;
   lastName: string;
+  /** Optional company / organization name (maps to EP `company_name`). */
+  company?: string;
   line1: string;
   line2?: string;
   city: string;
@@ -114,6 +116,22 @@ export interface CheckoutSession {
   totals: SessionTotals | null;
   payment: SessionPayment;
   order: SessionOrder | null;
+  /**
+   * Whether this checkout collects a shipping address + rate. Defaults to
+   * `true` (the multi-step shipping flow). Single-page / digital checkouts
+   * (e.g. downloadable products) set this `false`: the /pay handler then
+   * neither requires `shippingAddress`/`selectedShippingRateId` nor a
+   * shipping step, and the checkout body defaults shipping to billing.
+   */
+  requiresShipping?: boolean;
+  /**
+   * Arbitrary extra checkout fields and consent flags collected by the
+   * store's form (e.g. industry, VAT number, marketing opt-in). Persisted
+   * to the cart's `custom_attributes` immediately before `checkoutApi` so
+   * they travel with the order context. Reserved order fields
+   * (customer/billing/shipping) are NOT carried here.
+   */
+  customAttributes?: Record<string, string | number | boolean>;
   expiresAt: number; // epoch ms
 }
 
@@ -198,7 +216,6 @@ export interface SessionResponse {
 
 export interface EPCredentials {
   clientId: string;
-  clientSecret: string;
   apiBaseUrl: string;
 }
 
@@ -208,6 +225,18 @@ export interface SessionHandlerContext {
   sessionStore: SessionStore;
   /** Session TTL in seconds (default 1800 = 30 min). */
   sessionTtlSeconds?: number;
+  /**
+   * Shopper-scoped access token for read operations. Resolved per-request
+   * by the host app's checkout-context factory from the better-auth session.
+   */
+  shopperAccessToken?: string;
+  /**
+   * Request-scoped admin token resolver for EP operations that require
+   * `client_credentials` grant (createCartPaymentIntent, checkoutApi,
+   * confirmOrder, cart cleanup). Memoized within the request via closure.
+   * Never cached across requests.
+   */
+  getClientCredentialsToken?: () => Promise<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +254,8 @@ export interface AdapterRegistry {
 
 export interface CreateSessionRequest {
   cartId: string;
+  /** Optional — see CheckoutSession.requiresShipping. Defaults to true. */
+  requiresShipping?: boolean;
 }
 
 export interface UpdateSessionRequest {
@@ -232,6 +263,8 @@ export interface UpdateSessionRequest {
   shippingAddress?: SessionAddress;
   billingAddress?: SessionAddress;
   selectedShippingRateId?: string;
+  requiresShipping?: boolean;
+  customAttributes?: Record<string, string | number | boolean>;
 }
 
 export interface PayRequest {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/use-checkout-session.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/use-checkout-session.ts
@@ -42,7 +42,7 @@ export interface UseCheckoutSessionReturn {
   isLoading: boolean;
   error: Error | null;
   /** Create a new session for the given cart. */
-  createSession: (cartId: string) => Promise<SessionApiResponse>;
+  createSession: (cartId?: string) => Promise<SessionApiResponse>;
   /** Merge partial updates into the session. */
   updateSession: (data: UpdateSessionRequest) => Promise<SessionApiResponse>;
   /** Fetch shipping rates for the session's shipping address. */
@@ -72,12 +72,16 @@ export function useCheckoutSession(
   const session = data?.success ? (data.data?.session ?? null) : null;
 
   const createSession = useCallback(
-    async (cartId: string): Promise<SessionApiResponse> => {
+    async (cartId?: string): Promise<SessionApiResponse> => {
+      // cartId is optional — when omitted, the server resolves it from the
+      // better-auth session (cookie-based). Designers don't have to thread
+      // cartId through Plasmic interactions.
+      const body = cartId ? JSON.stringify({ cartId }) : "{}";
       const resp = await sessionFetch<SessionApiResponse>(
         `${baseUrl}/checkout/sessions`,
         {
           method: "POST",
-          body: JSON.stringify({ cartId }),
+          body,
         }
       );
       await mutate();

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/place-order.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/place-order.test.ts
@@ -1,0 +1,290 @@
+const mockCheckoutApi = jest.fn();
+const mockPaymentSetup = jest.fn();
+const mockDeleteAllCartItems = jest.fn();
+const mockUpdateACart = jest.fn();
+
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  createShopperClient: jest.fn(() => ({
+    client: {
+      interceptors: { request: { use: jest.fn() } },
+    },
+  })),
+  checkoutApi: (...args: unknown[]) => mockCheckoutApi(...args),
+  paymentSetup: (...args: unknown[]) => mockPaymentSetup(...args),
+  deleteAllCartItems: (...args: unknown[]) => mockDeleteAllCartItems(...args),
+  updateACart: (...args: unknown[]) => mockUpdateACart(...args),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  epPlaceOrder,
+  toCustomAttributes,
+  normalizeAddress,
+} = require("../place-order");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { withEpSession } = require("../session-context");
+
+const SESSION_BASE = {
+  accessToken: "tok",
+  host: "https://api.ep.com",
+  clientId: "cid",
+  serverCartMode: false,
+};
+
+const ORDER_RESPONSE = (amount: number) => ({
+  data: {
+    data: {
+      id: "order-1",
+      type: "order",
+      status: "complete",
+      payment: "paid",
+      meta: {
+        display_price: {
+          with_tax: { amount, currency: "CHF", formatted: `CHF ${amount / 100}` },
+        },
+      },
+    },
+  },
+});
+
+const BILLING = {
+  first_name: "Ada",
+  last_name: "Lovelace",
+  line_1: "1 Analytical Way",
+  city: "London",
+  postcode: "EC1",
+  country: "GB",
+};
+
+beforeEach(() => {
+  mockCheckoutApi.mockReset();
+  mockPaymentSetup.mockReset();
+  mockDeleteAllCartItems.mockReset();
+  mockUpdateACart.mockReset();
+});
+
+describe("toCustomAttributes", () => {
+  it("types values by JS runtime type and drops empties", () => {
+    const out = toCustomAttributes({
+      industry: "Engineering",
+      marketing: true,
+      seats: 3,
+      ratio: 1.5,
+      blank: "",
+    });
+    expect(out).toEqual({
+      industry: { type: "string", value: "Engineering" },
+      marketing: { type: "boolean", value: true },
+      seats: { type: "integer", value: 3 },
+      ratio: { type: "float", value: 1.5 },
+    });
+  });
+
+  it("returns undefined when nothing meaningful remains", () => {
+    expect(toCustomAttributes(undefined)).toBeUndefined();
+    expect(toCustomAttributes({ a: "" })).toBeUndefined();
+  });
+});
+
+describe("normalizeAddress", () => {
+  it("fills missing parts with empty strings", () => {
+    expect(normalizeAddress({ first_name: "Ada", country: "GB" })).toEqual({
+      first_name: "Ada",
+      last_name: "",
+      company_name: "",
+      line_1: "",
+      line_2: "",
+      city: "",
+      county: "",
+      postcode: "",
+      country: "GB",
+    });
+  });
+});
+
+describe("epPlaceOrder", () => {
+  it("checks out, takes manual payment, clears the cart, and reports the order", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(91900));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    const result = await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+      })
+    );
+
+    expect(mockCheckoutApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { cartID: "cart-1" },
+        body: {
+          data: expect.objectContaining({
+            customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+            billing_address: expect.objectContaining({ country: "GB" }),
+          }),
+        },
+      })
+    );
+    // Shipping defaults to billing when none provided (EP needs one for
+    // shippable items).
+    expect(
+      mockCheckoutApi.mock.calls[0][0].body.data.shipping_address
+    ).toEqual(expect.objectContaining({ country: "GB" }));
+    expect(mockPaymentSetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { orderID: "order-1" },
+        body: { data: { gateway: "manual", method: "purchase" } },
+      })
+    );
+    expect(mockDeleteAllCartItems).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { cartID: "cart-1" } })
+    );
+    expect(result).toEqual({
+      orderId: "order-1",
+      status: "complete",
+      payment: "paid",
+      total: 91900,
+      currency: "CHF",
+      isFree: false,
+    });
+  });
+
+  it("flags a zero-total order as free and still completes it via manual purchase", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(0));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    const result = await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+      })
+    );
+
+    expect(result.isFree).toBe(true);
+    expect(result.total).toBe(0);
+    expect(mockPaymentSetup).toHaveBeenCalled();
+  });
+
+  it("persists extra fields + consents as typed cart custom attributes before checkout", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(0));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+        customAttributes: { industry: "Engineering", marketing: true },
+      })
+    );
+
+    expect(mockUpdateACart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { cartID: "cart-1" },
+        body: {
+          data: {
+            custom_attributes: {
+              industry: { type: "string", value: "Engineering" },
+              marketing: { type: "boolean", value: true },
+            },
+          },
+        },
+      })
+    );
+    // custom-attributes write happens before checkout
+    expect(mockUpdateACart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCheckoutApi.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("skips the custom-attributes write when there is nothing to persist", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(0));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+      })
+    );
+    expect(mockUpdateACart).not.toHaveBeenCalled();
+  });
+
+  it("respects clearCart:false (cart left intact)", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(0));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+        clearCart: false,
+      })
+    );
+    expect(mockDeleteAllCartItems).not.toHaveBeenCalled();
+  });
+
+  it("allows a store to override gateway + method for a real paid order", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(91900));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "authorized" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+        paymentGateway: "stripe_connect",
+        paymentMethod: "authorize",
+      })
+    );
+    expect(mockPaymentSetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { data: { gateway: "stripe_connect", method: "authorize" } },
+      })
+    );
+  });
+
+  it("omits shipping_address when shippingSameAsBilling is false", async () => {
+    mockCheckoutApi.mockResolvedValue(ORDER_RESPONSE(0));
+    mockPaymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+    mockDeleteAllCartItems.mockResolvedValue({});
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+      epPlaceOrder({
+        customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+        billingAddress: BILLING,
+        shippingSameAsBilling: false,
+      })
+    );
+    expect(
+      mockCheckoutApi.mock.calls[0][0].body.data.shipping_address
+    ).toBeUndefined();
+  });
+
+  it("throws when the session has no cart", async () => {
+    await expect(
+      withEpSession(SESSION_BASE, () =>
+        epPlaceOrder({
+          customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+          billingAddress: BILLING,
+        })
+      )
+    ).rejects.toThrow(/no cart/i);
+    expect(mockCheckoutApi).not.toHaveBeenCalled();
+  });
+
+  it("throws when checkout returns no order", async () => {
+    mockCheckoutApi.mockResolvedValue({ data: { data: null } });
+    await expect(
+      withEpSession({ ...SESSION_BASE, cartId: "cart-1" }, () =>
+        epPlaceOrder({
+          customer: { name: "Ada Lovelace", email: "ada@ep.com" },
+          billingAddress: BILLING,
+        })
+      )
+    ).rejects.toThrow(/did not return an order/i);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/index.ts
@@ -16,6 +16,12 @@ export type {
   EpRemoveCartItemInput,
   EpUpdateCartItemInput,
 } from "./cart-mutations";
+export { epPlaceOrder, toCustomAttributes, normalizeAddress } from "./place-order";
+export type {
+  EpPlaceOrderInput,
+  EpPlaceOrderAddress,
+  EpPlaceOrderResult,
+} from "./place-order";
 export { registerEpCustomFunctions } from "./register-custom-functions";
 export { buildEpCtx } from "./build-ep-ctx";
 export type {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/place-order.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/place-order.ts
@@ -1,0 +1,232 @@
+import {
+  checkoutApi,
+  deleteAllCartItems,
+  paymentSetup,
+  updateACart,
+} from "@epcc-sdk/sdks-shopper";
+import { buildEpClient, isUsableAuth } from "./ep-client";
+import { getCurrentEpSession } from "./session-context";
+import { callEpProxy, shouldUseProxy } from "./proxy-fetch";
+
+/**
+ * Generic single-page order placement for the composable checkout.
+ *
+ * Converts the current shopper's cart into an order, takes payment, and
+ * clears the cart — the whole "place order" action in one server call, so
+ * a single-page checkout (no multi-step flow, optionally no shipping) can
+ * complete without orchestrating the 4-step EPCheckoutProvider.
+ *
+ * Payment defaults to the EP **manual** gateway with the **purchase**
+ * method. Manual/purchase authorises-and-captures in one call and requires
+ * no card UI, which is exactly the zero-total / free-product short-circuit:
+ * a CHF 0 order is completed with no payment step. A store with a real
+ * gateway overrides `paymentGateway` / `paymentMethod`.
+ *
+ * Isomorphic, mirroring `epGetCart`: when there is no SSR session (the
+ * shopper-facing browser case — this runs from a button onClick) it POSTs
+ * to the consumer's `/api/ep/proxy/placeOrder`, which re-enters this
+ * function server-side under `withEpSession` with the real cart + token.
+ */
+
+/** A billing or shipping address. Missing parts are sent as empty strings. */
+export interface EpPlaceOrderAddress {
+  first_name?: string;
+  last_name?: string;
+  company_name?: string;
+  line_1?: string;
+  line_2?: string;
+  city?: string;
+  county?: string;
+  postcode?: string;
+  country?: string;
+}
+
+export interface EpPlaceOrderInput {
+  /** Order contact. `name` is the full display name; `email` the receipt address. */
+  customer: { name: string; email: string };
+  billingAddress: EpPlaceOrderAddress;
+  /**
+   * Optional shipping address. When omitted, the billing address is sent as
+   * the shipping address too (shipping-same-as-billing) — EP requires a
+   * shipping address whenever any cart item is flagged shippable, even for a
+   * single-page / effectively digital checkout. Set `shippingSameAsBilling`
+   * to `false` to omit it entirely.
+   */
+  shippingAddress?: EpPlaceOrderAddress;
+  /** Default `true`: fall back to billing as shipping when none is given. */
+  shippingSameAsBilling?: boolean;
+  /**
+   * Arbitrary extra fields and consent flags. Persisted as the cart's
+   * `custom_attributes` (typed per JS runtime type) immediately before
+   * checkout so they travel with the order context. EP caps a cart at 20
+   * custom attributes; empty values are dropped.
+   */
+  customAttributes?: Record<string, string | number | boolean>;
+  /** Payment gateway. Default `"manual"`. */
+  paymentGateway?: string;
+  /** Payment method. Default `"purchase"`. */
+  paymentMethod?: string;
+  /** Clear the cart after a successful order. Default `true`. */
+  clearCart?: boolean;
+}
+
+export interface EpPlaceOrderResult {
+  orderId: string;
+  status: string;
+  payment: string;
+  total: number;
+  currency: string;
+  /** True when the order total is zero (free product — no real payment taken). */
+  isFree: boolean;
+}
+
+type TypedAttribute = { type: "string" | "boolean" | "integer" | "float"; value: unknown };
+
+/**
+ * Maps a flat `{ key: value }` map to EP's typed `custom_attributes`
+ * shape. Empty strings and nullish values are dropped (EP rejects them
+ * and they carry no signal). Exported for unit testing.
+ */
+export function toCustomAttributes(
+  input?: Record<string, string | number | boolean>
+): Record<string, TypedAttribute> | undefined {
+  if (!input) return undefined;
+  const out: Record<string, TypedAttribute> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null || value === "") continue;
+    const type =
+      typeof value === "boolean"
+        ? "boolean"
+        : typeof value === "number"
+          ? Number.isInteger(value)
+            ? "integer"
+            : "float"
+          : "string";
+    out[key] = { type, value };
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+/** Normalises an address to the EP shape, filling absent parts with "". */
+export function normalizeAddress(a: EpPlaceOrderAddress | undefined) {
+  if (!a) return undefined;
+  return {
+    first_name: a.first_name ?? "",
+    last_name: a.last_name ?? "",
+    company_name: a.company_name ?? "",
+    line_1: a.line_1 ?? "",
+    line_2: a.line_2 ?? "",
+    city: a.city ?? "",
+    county: a.county ?? "",
+    postcode: a.postcode ?? "",
+    country: a.country ?? "",
+  };
+}
+
+export async function epPlaceOrder(
+  input: EpPlaceOrderInput
+): Promise<EpPlaceOrderResult> {
+  const auth = getCurrentEpSession();
+
+  // Browser path: no SSR session → go through the consumer proxy, which
+  // re-enters this function server-side with the real session.
+  if (!isUsableAuth(auth) && shouldUseProxy()) {
+    const result = await callEpProxy<EpPlaceOrderResult | null>(
+      "placeOrder",
+      input as unknown as Record<string, unknown>
+    );
+    if (!result || !result.orderId) {
+      throw new Error("epPlaceOrder: order could not be placed");
+    }
+    return result;
+  }
+
+  if (!isUsableAuth(auth)) {
+    throw new Error("epPlaceOrder: no EP session");
+  }
+  const cartId = auth.cartId;
+  if (!cartId) {
+    throw new Error("epPlaceOrder: no cart on session");
+  }
+
+  const client = buildEpClient(auth);
+
+  // 1. Persist extra fields + consents as cart custom attributes. A single
+  //    update wins because EP replaces all custom attributes per write.
+  const customAttributes = toCustomAttributes(input.customAttributes);
+  if (customAttributes) {
+    await updateACart({
+      client,
+      path: { cartID: cartId },
+      body: { data: { custom_attributes: customAttributes as never } },
+    });
+  }
+
+  // 2. Convert the cart to an order. EP requires a shipping address when any
+  //    item is shippable, so default it to the billing address unless the
+  //    caller explicitly opts out.
+  const shippingAddress =
+    input.shippingAddress ??
+    (input.shippingSameAsBilling === false ? undefined : input.billingAddress);
+  const checkoutRes = await checkoutApi({
+    client,
+    path: { cartID: cartId },
+    body: {
+      data: {
+        customer: { name: input.customer.name, email: input.customer.email },
+        billing_address: normalizeAddress(input.billingAddress) as never,
+        ...(shippingAddress
+          ? { shipping_address: normalizeAddress(shippingAddress) as never }
+          : {}),
+      },
+    },
+  });
+  const order = checkoutRes.data?.data;
+  if (!order?.id) {
+    const detail =
+      (checkoutRes as { error?: { errors?: Array<{ detail?: string }> } })
+        .error?.errors?.map((e) => e.detail).filter(Boolean).join("; ") ||
+      (checkoutRes as { error?: { message?: string } }).error?.message ||
+      "unknown error";
+    throw new Error(`epPlaceOrder: checkout did not return an order (${detail})`);
+  }
+
+  const total = order.meta?.display_price?.with_tax?.amount ?? 0;
+  const currency =
+    order.meta?.display_price?.with_tax?.currency ?? auth.currency ?? "";
+
+  // 3. Take payment. Manual/purchase completes the order with no card step,
+  //    which also satisfies the zero-total / free-product short-circuit.
+  const payRes = await paymentSetup({
+    client,
+    path: { orderID: order.id },
+    body: {
+      data: {
+        gateway: input.paymentGateway ?? "manual",
+        method: input.paymentMethod ?? "purchase",
+      } as never,
+    },
+  });
+  const payment = payRes.data?.data;
+
+  // 4. Clear the cart on success (best-effort — a failed clear is non-fatal).
+  if (input.clearCart !== false) {
+    try {
+      await deleteAllCartItems({ client, path: { cartID: cartId } });
+    } catch {
+      /* non-fatal: the order is already placed */
+    }
+  }
+
+  return {
+    orderId: order.id,
+    status: (order.status as string | undefined) ?? "",
+    payment:
+      (payment?.status as string | undefined) ??
+      (order.payment as string | undefined) ??
+      "",
+    total,
+    currency,
+    isFree: total === 0,
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/index.tsx
@@ -178,6 +178,14 @@ export function registerAll(loader?: Registerable) {
   registerEPProductExtensionFieldList(loader);
   registerEPProductExtensionTemplateList(loader);
   registerEPProductExtensionsProvider(loader);
+
+  // Product extensions — register field/leaf components first so they're
+  // available as default slot content in the parent components above them.
+  registerEPProductExtensionField(loader);
+  registerEPProductExtensionTemplateField(loader);
+  registerEPProductExtensionFieldList(loader);
+  registerEPProductExtensionTemplateList(loader);
+  registerEPProductExtensionsProvider(loader);
   // Field-display components — pick one field by address (siblings to the iteration components above).
   registerEPProductField(loader);
   registerEPProductExtensionValue(loader);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/registerCheckout.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/registerCheckout.tsx
@@ -17,6 +17,11 @@ import { registerEPPaymentElements } from "./checkout/composable/EPPaymentElemen
 import { registerEPCheckoutProvider } from "./checkout/composable/EPCheckoutProvider";
 import { registerEPCheckoutStepIndicator } from "./checkout/composable/EPCheckoutStepIndicator";
 import { registerEPCheckoutButton } from "./checkout/composable/EPCheckoutButton";
+import { registerEPFormField } from "./checkout/composable/EPFormField";
+import { registerEPSelectField } from "./checkout/composable/EPSelectField";
+import { registerEPConsentCheckbox } from "./checkout/composable/EPConsentCheckbox";
+import { registerEPPlaceOrderButton } from "./checkout/composable/EPPlaceOrderButton";
+import { registerEPCheckoutFormProvider } from "./checkout/composable/EPCheckoutFormProvider";
 import { registerEPCheckoutSessionProvider } from "./checkout/session/EPCheckoutSessionProvider";
 import { registerEPCloverPayment } from "./checkout/session/EPCloverPayment";
 import { registerEPCloverCardNumber } from "./checkout/session/EPCloverCardNumber";
@@ -24,6 +29,7 @@ import { registerEPCloverCardExpiry } from "./checkout/session/EPCloverCardExpir
 import { registerEPCloverCardCVV } from "./checkout/session/EPCloverCardCVV";
 import { registerEPCloverCardPostalCode } from "./checkout/session/EPCloverCardPostalCode";
 import { registerEPStripePayment } from "./checkout/session/EPStripePayment";
+import { registerStripeProvider } from "./checkout/session/StripeProvider";
 import { Registerable } from "./registerable";
 
 export function registerEPCheckout(loader?: Registerable) {
@@ -52,6 +58,14 @@ export function registerEPCheckout(loader?: Registerable) {
   registerEPCheckoutStepIndicator(loader);
   registerEPCheckoutProvider(loader);
 
+  // Single-page checkout (leaf-first: field primitives + button before the
+  // form-state collector that wraps them)
+  registerEPFormField(loader);
+  registerEPSelectField(loader);
+  registerEPConsentCheckbox(loader);
+  registerEPPlaceOrderButton(loader);
+  registerEPCheckoutFormProvider(loader);
+
   // Session-based checkout components (leaf-first)
   registerEPCloverCardNumber(loader);
   registerEPCloverCardExpiry(loader);
@@ -59,6 +73,7 @@ export function registerEPCheckout(loader?: Registerable) {
   registerEPCloverCardPostalCode(loader);
   registerEPCloverPayment(loader);
   registerEPStripePayment(loader);
+  registerStripeProvider(loader);
   registerEPCheckoutSessionProvider(loader);
 }
 
@@ -90,6 +105,12 @@ export {
   registerEPCloverCardCVV,
   registerEPCloverCardPostalCode,
   registerEPStripePayment,
+  registerStripeProvider,
+  registerEPCheckoutFormProvider,
+  registerEPFormField,
+  registerEPSelectField,
+  registerEPConsentCheckbox,
+  registerEPPlaceOrderButton,
 };
 
 // Export component metas for advanced usage
@@ -171,3 +192,18 @@ export {
 export {
   epStripePaymentMeta,
 } from "./checkout/session/EPStripePayment";
+export {
+  epCheckoutFormProviderMeta,
+} from "./checkout/composable/EPCheckoutFormProvider";
+export {
+  epFormFieldMeta,
+} from "./checkout/composable/EPFormField";
+export {
+  epSelectFieldMeta,
+} from "./checkout/composable/EPSelectField";
+export {
+  epConsentCheckboxMeta,
+} from "./checkout/composable/EPConsentCheckbox";
+export {
+  epPlaceOrderButtonMeta,
+} from "./checkout/composable/EPPlaceOrderButton";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
@@ -30,6 +30,15 @@ export type { CloverAdapterConfig } from "./checkout/session/adapters/clover-ada
 export { createStripeAdapter } from "./checkout/session/adapters/stripe-adapter";
 export type { StripeAdapterConfig } from "./checkout/session/adapters/stripe-adapter";
 
+// Client-credentials token resolver (request-scoped, memoized per request).
+export {
+  createClientCredentialsTokenResolver,
+} from "./auth/ep-plugin/client-credentials-resolver";
+export type {
+  ClientCredentialsResolverConfig,
+  ClientCredentialsTokenResolver,
+} from "./auth/ep-plugin/client-credentials-resolver";
+
 // Types needed by consumer route files
 export type {
   SessionRequest,
@@ -72,6 +81,7 @@ export {
   epAddCartItem,
   epUpdateCartItem,
   epRemoveCartItem,
+  epPlaceOrder,
   registerEpCustomFunctions,
   buildEpCtx,
   withEpSession,
@@ -85,6 +95,9 @@ export type {
   EpAddCartItemInput,
   EpUpdateCartItemInput,
   EpRemoveCartItemInput,
+  EpPlaceOrderInput,
+  EpPlaceOrderAddress,
+  EpPlaceOrderResult,
   BuildEpCtxSessionInput,
   EpCtx,
   EpSessionContext,


### PR DESCRIPTION
## Composable checkout: consumable session pipeline + EP-native Stripe + order custom fields

Generalises the composable checkout so a **single-page, shipping-less, rich-field** checkout can be expressed from Plasmic (not just the built-in 4-step flow), adds an **EP-native Stripe** settlement path through the session pipeline, and writes checkout **extras/consents onto the order** via EP Flows. Implements the design from #317 / #320.

### What changed

**Session pipeline made consumable for non-standard checkouts**
- Session model gains `company` / `customAttributes` / `requiresShipping`; shipping is optional end-to-end (the pay handler only requires shipping when `requiresShipping !== false`).
- `EPCheckoutFormProvider` gains a **session mode**: maps collected fields → `updateSession` (customer, billing incl. company, extras/consents as `customAttributes`), then drives the session's `placeOrder`. Self-wiring field primitives (`EPFormField`, `EPSelectField`, `EPConsentCheckbox`, `EPPlaceOrderButton`) need no Plasmic-authored interactions.
- New generic **`confirmationUrl`** prop → post-purchase redirect (`{orderId}` placeholder), full-page nav so it works in any host.

**EP-native Stripe**
- `EPStripePayment` self-registers its gateway, gains a `stripeAccount` prop (ConfirmationToken minted in the connected account's context), renders a **card-only** PaymentElement (billing comes from the checkout form + EP attaches the order's billing server-side).
- Pay handler branches on the **authoritative cart total** (`meta.display_price`): `> 0` → EP-native Stripe (`createCartPaymentIntent`, `confirm: true`); `== 0` → `manual`/`purchase` (zero-total path).
- The `403 gateway.scopes.authorise` chain is resolved: `createCartPaymentIntent` (and the order-fields write) require the **storefront `client_credentials`** sent as an **explicit `Authorization: Bearer` header** (the SDK's auth layer otherwise re-mints an implicit token). Don't send `payment_method_types` with `automatic_payment_methods`; EP nests the PI at `meta.payment_intent.payment_intent`.

**Order custom fields (extras/consents on the order)**
- `checkoutApi` doesn't copy cart `custom_attributes` onto the order, and the order rejects the free-form bag — so order-level extras go via **EP Flows**: new `order-custom-fields.ts` writes `session.customAttributes` onto the order as flow-field slugs after checkout (both pay branches), best-effort, with the explicit-Bearer admin auth. Slugs the store's `orders` flow hasn't defined are silently dropped by EP, so the package needs no schema knowledge.

**Also:** a request-scoped `client_credentials` token resolver, and example app-router checkout wiring (`/api/checkout/sessions*` + a `buildCheckoutContext` factory).

### Tests
Full `elastic-path` suite green on this branch off `master`, incl. the pay handler (single-shot happy path, failed-payment retry, cart-hash mismatch, zero-total/free settlement, `requiresShipping`/`customAttributes`), Stripe adapter, order custom fields, session-state transitions, cart cleanup.

### Verification
Verified live end-to-end (euwest) prior to this branch: a **paid** order (CHF 44, test card) settled `complete/paid` via a real `elastic_path_payments_stripe` charge, a **free** order via `manual`, and **both** carried all order flow fields. The success redirect → confirmation page and the inline error banner were verified via the consumer storefront.

### Review findings (from pre-PR `/code-review` + `security-review`)
The PR's own changes are clean; the notable items are in the carried Stage C session code and are **not** blockers. All follow-ups are tracked in **#369**. Headlines:
- *(HIGH)* free-vs-paid hardening when cart meta total is unavailable (latent no-charge risk; mitigated today by the cart-hash 409).
- verify `confirmOrder` paymentID + stop swallowing its failure.
- Security review found **no Critical/High**: secrets are server-isolated, the server is source of truth for free/paid (client gateway hint ignored), cart-hash + double-submit guards present, no PII logging, `confirmationUrl` is designer-controlled. (Note: the reviewer's suggestion to use the *shopper* token for `createCartPaymentIntent` is **not** applicable — `confirm:true` requires the storefront `client_credentials`, per the 403 resolution above.)

### Follow-ups
All tracked in **#369** (payment-integrity hardening, account-checkout session binding, custom-attr allow-list, 3DS/return_url, confirmation download links, suppress Stripe Country+Postal, reusable error/confirmation primitives, better-auth migration).

### Notes for reviewers
- Companion **storefront** changes (checkout/confirmation pages, `/api/checkout/sessions*` routes, context factory) live in the consumer app (ISO storefront), not this repo.
- This branch is off the latest `master`; cart-drawer / catalog-search / product-extensions are already on `master` and intentionally excluded.
