### PR TITLE
fix(ep-commerce): payment-integrity hardening for the composable checkout

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay-single-shot.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/pay-single-shot.test.ts
@@ -267,8 +267,13 @@ describe("handlePay — single-shot guest happy path", () => {
 
 describe("handlePay — zero-total (free) order", () => {
   beforeEach(() => {
+    // A genuinely free cart reports an authoritative zero via
+    // meta.display_price — the only signal that routes to free settlement.
     epSdk.getACart.mockResolvedValue({
-      data: { included: { items: FREE_ITEMS } },
+      data: {
+        included: { items: FREE_ITEMS },
+        data: { meta: { display_price: { with_tax: { amount: 0, currency: "CHF" } } } },
+      },
     });
   });
 
@@ -305,7 +310,9 @@ describe("handlePay — zero-total (free) order", () => {
       makeSession({
         cartHash: hashCart(FREE_ITEMS),
         customAttributes: { language: "English", marketing: false },
-      })
+      }),
+      undefined,
+      { allowedCustomAttributeKeys: "*" }
     );
     await handlePay(createMockReq({}), ctx);
 
@@ -393,7 +400,8 @@ describe("handlePay — generalised fields", () => {
       makeSession({
         customAttributes: { industry: "Tech", marketingOptIn: true, vat: "" },
       }),
-      adapter
+      adapter,
+      { allowedCustomAttributeKeys: "*" }
     );
     await handlePay(
       createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),
@@ -414,7 +422,8 @@ describe("handlePay — generalised fields", () => {
       makeSession({
         customAttributes: { industry: "Tech", marketingOptIn: true, vat: "" },
       }),
-      adapter
+      adapter,
+      { allowedCustomAttributeKeys: "*" }
     );
     await handlePay(
       createMockReq({ gateway: "stripe", confirmation_token: "ctoken_xyz" }),

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/security-regression.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/__tests__/security-regression.test.ts
@@ -1,0 +1,823 @@
+/**
+ * Checkout-session security regression suite (#325).
+ *
+ * This file is the designated *home + harness* for the checkout pipeline's
+ * security invariants. Two kinds of assertion live here:
+ *
+ *   1. Always-true boundary guards (purely additive, no production change):
+ *      - admin / client-credentials and shopper tokens never reflect into a
+ *        session response, across every checkout-session route — including
+ *        #368's new branches (the order-custom-fields write and the
+ *        free-order settlement path);
+ *      - no PII (customAttributes values, customer contact details) is ever
+ *        written to the logs.
+ *
+ *   2. Integrity assertions that land *red alongside their fix* (TDD):
+ *      - free-vs-paid server authority (#369 HIGH): a paid cart must never
+ *        settle for free when its authoritative total is unavailable.
+ *      Session-ownership / order-fields allow-list land here as their
+ *      production fixes arrive.
+ *
+ * esbuild does not hoist jest.mock(); we require() the handlers so SDK
+ * interception works regardless of import order (matches the sibling
+ * pay-single-shot suite).
+ */
+
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  getACart: jest.fn(),
+  checkoutApi: jest.fn(),
+  confirmOrder: jest.fn(),
+  confirmPayment: jest.fn(),
+  paymentSetup: jest.fn(),
+  updateACart: jest.fn(),
+  updateAnOrder: jest.fn(),
+  deleteACart: jest.fn(),
+  getShippingOptions: jest.fn(),
+  getByContextAllProducts: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as {
+  getACart: jest.Mock;
+  checkoutApi: jest.Mock;
+  confirmOrder: jest.Mock;
+  confirmPayment: jest.Mock;
+  paymentSetup: jest.Mock;
+  updateACart: jest.Mock;
+  updateAnOrder: jest.Mock;
+  deleteACart: jest.Mock;
+  getShippingOptions: jest.Mock;
+  getByContextAllProducts: jest.Mock;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handlePay } = require("../pay") as {
+  handlePay: typeof import("../pay").handlePay;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handleConfirm } = require("../confirm") as {
+  handleConfirm: typeof import("../confirm").handleConfirm;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handleCreateSession } = require("../create-session") as {
+  handleCreateSession: typeof import("../create-session").handleCreateSession;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handleGetSession } = require("../get-session") as {
+  handleGetSession: typeof import("../get-session").handleGetSession;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handleUpdateSession } = require("../update-session") as {
+  handleUpdateSession: typeof import("../update-session").handleUpdateSession;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handleCalculateShipping } = require("../calculate-shipping") as {
+  handleCalculateShipping: typeof import("../calculate-shipping").handleCalculateShipping;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { resetLogConfig } = require("../../../../utils/logger") as {
+  resetLogConfig: typeof import("../../../../utils/logger").resetLogConfig;
+};
+
+import type {
+  SessionHandlerContext,
+  SessionRequest,
+  CheckoutSession,
+  PaymentAdapter,
+  PaymentAdapterResult,
+  AdapterRegistry,
+  SessionStore,
+} from "../../../../checkout/session/types";
+import { hashCart } from "../../../../checkout/session/cart-hash";
+
+// ---------------------------------------------------------------------------
+// Sentinels — distinctive strings that must NEVER surface in a response body
+// or in the logs. Picked so an accidental leak is unambiguous in a diff.
+// ---------------------------------------------------------------------------
+
+const ADMIN_TOKEN = "ADMIN-CC-TOKEN-must-never-leak-9f3a";
+const SHOPPER_TOKEN = "SHOPPER-TOKEN-must-never-leak-7b21";
+const PII_PHONE = "SECRET-PHONE-+41-00-000-0000";
+const PII_VAT = "SECRET-VAT-CHE-999999999";
+const PII_EMAIL = "secret.shopper@example-pii.test";
+const PII_NAME = "Pii Sentinel-Surname";
+
+const PRICED_ITEMS = [
+  { id: "item-1", quantity: 2, unit_price: { amount: 1500 } },
+  { id: "item-2", quantity: 1, unit_price: { amount: 2400 } },
+];
+
+/** A cart response whose `meta.display_price` carries an authoritative total. */
+function cartResponseWithTotal(
+  amount: number,
+  items: Array<Record<string, unknown>> = PRICED_ITEMS
+) {
+  return {
+    data: {
+      included: { items },
+      data: {
+        meta: { display_price: { with_tax: { amount, currency: "CHF" } } },
+      },
+    },
+  };
+}
+
+function makeSession(overrides: Partial<CheckoutSession> = {}): CheckoutSession {
+  return {
+    id: "sess-sec",
+    status: "open",
+    cartId: "cart-abc",
+    cartHash: hashCart(PRICED_ITEMS),
+    customerInfo: { name: "Jane Doe", email: "jane@example.com" },
+    shippingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "12345",
+    },
+    billingAddress: {
+      firstName: "Jane",
+      lastName: "Doe",
+      line1: "123 Main St",
+      city: "Springfield",
+      country: "US",
+      postcode: "12345",
+    },
+    selectedShippingRateId: "rate-standard",
+    availableShippingRates: [],
+    totals: null,
+    payment: {
+      gateway: null,
+      status: "idle",
+      clientToken: null,
+      gatewayMetadata: {},
+      actionData: null,
+    },
+    order: null,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function createMockStore(session: CheckoutSession | null = null): SessionStore {
+  return {
+    get: jest.fn().mockResolvedValue(session),
+    set: jest
+      .fn()
+      .mockResolvedValue({ headers: { "Set-Cookie": "ep_cs=test; Path=/" } }),
+    delete: jest
+      .fn()
+      .mockResolvedValue({ headers: { "Set-Cookie": "ep_cs=; Max-Age=0" } }),
+  };
+}
+
+function createMockAdapter(
+  initResult: PaymentAdapterResult = {
+    status: "succeeded",
+    gatewayOrderId: "pi_abc",
+    gatewayMetadata: { paymentIntentId: "pi_abc" },
+  },
+  confirmResult: PaymentAdapterResult = { status: "succeeded" }
+): PaymentAdapter {
+  return {
+    initializePayment: jest.fn().mockResolvedValue(initResult),
+    confirmPayment: jest.fn().mockResolvedValue(confirmResult),
+  };
+}
+
+function createMockRegistry(adapter?: PaymentAdapter): AdapterRegistry {
+  return {
+    register: jest.fn(),
+    getAdapter: jest.fn().mockReturnValue(adapter),
+  };
+}
+
+function createMockCtx(
+  session: CheckoutSession | null,
+  adapter?: PaymentAdapter,
+  overrides: Partial<SessionHandlerContext> = {}
+): SessionHandlerContext {
+  return {
+    epCredentials: {
+      clientId: "test-id",
+      apiBaseUrl: "https://api.test.com",
+    },
+    adapterRegistry: createMockRegistry(adapter),
+    sessionStore: createMockStore(session),
+    shopperAccessToken: SHOPPER_TOKEN,
+    getClientCredentialsToken: jest.fn(async () => ADMIN_TOKEN),
+    ...overrides,
+  };
+}
+
+function createMockReq(body: Record<string, unknown> = {}): SessionRequest {
+  return { body, headers: {}, cookies: {} };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: a priced cart with an authoritative non-zero total.
+  epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+  epSdk.checkoutApi.mockResolvedValue({ data: { data: { id: "order-1" } } });
+  epSdk.confirmOrder.mockResolvedValue({ data: { data: { id: "order-1" } } });
+  epSdk.confirmPayment.mockResolvedValue({ data: { data: { id: "txn-1" } } });
+  epSdk.paymentSetup.mockResolvedValue({ data: { data: { status: "paid" } } });
+  epSdk.updateACart.mockResolvedValue({ data: { data: {} } });
+  epSdk.updateAnOrder.mockResolvedValue({ data: { data: { id: "order-1" } } });
+  epSdk.deleteACart.mockResolvedValue({ data: undefined });
+  epSdk.getShippingOptions.mockResolvedValue({ data: { data: [] } });
+  epSdk.getByContextAllProducts.mockResolvedValue({ data: { data: [] } });
+});
+
+// ===========================================================================
+// 1. Free-vs-paid server authority (#369 HIGH) — RED alongside its fix.
+// ===========================================================================
+
+describe("free-vs-paid server authority (#369)", () => {
+  it("refuses to free-settle a paid cart when the authoritative total is unavailable", async () => {
+    // The latent bug: a parse failure present at BOTH session-create and pay
+    // hashes identically (no 409 guard fires), and the cart response carries
+    // no `meta.display_price` total. The old code summed the unparseable items
+    // to 0 and routed to the manual free-settlement gateway — a cart that
+    // actually costs money settling with NO charge.
+    //
+    // Server is the sole authority on free-vs-paid: with no authoritative
+    // zero, the handler MUST NOT free-settle.
+    const UNPARSEABLE_ITEMS = [{ id: "item-x", quantity: 1 }]; // no price fields
+    epSdk.getACart.mockResolvedValue({
+      // NOTE: no data.meta.display_price → cartMetaTotal is null.
+      data: { included: { items: UNPARSEABLE_ITEMS } },
+    });
+    const ctx = createMockCtx(
+      makeSession({ cartHash: hashCart(UNPARSEABLE_ITEMS) })
+    );
+    // A free checkout sends no gateway / confirmation_token.
+    const res = await handlePay(createMockReq({}), ctx);
+
+    // Money teeth: the manual free-settlement path must NOT run, and no order
+    // may be created for free.
+    expect(epSdk.paymentSetup).not.toHaveBeenCalled();
+    expect(epSdk.checkoutApi).not.toHaveBeenCalled();
+
+    // The cart must NOT complete as a free order; the handler fails closed.
+    const body = res.body as any;
+    expect(body?.data?.session?.status).not.toBe("complete");
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("still settles a genuinely free cart (authoritative meta total 0) via the manual gateway", async () => {
+    // Must-not-break: a real CHF 0 cart has `meta.display_price` present and
+    // exactly 0 → it still settles for free with no card.
+    const FREE_ITEMS = [{ id: "free-1", quantity: 1 }];
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(0, FREE_ITEMS));
+    const ctx = createMockCtx(makeSession({ cartHash: hashCart(FREE_ITEMS) }));
+
+    const res = await handlePay(createMockReq({}), ctx);
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    expect(epSdk.paymentSetup).toHaveBeenCalledTimes(1);
+    expect(epSdk.paymentSetup.mock.calls[0][0].body.data).toEqual({
+      gateway: "manual",
+      method: "purchase",
+    });
+  });
+
+  it("charges a paid cart (authoritative non-zero total) via the gateway adapter, not free settlement", async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(makeSession(), adapter);
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    expect(adapter.initializePayment).toHaveBeenCalledTimes(1);
+    // Paid path — NOT the manual free-settlement gateway.
+    expect(epSdk.paymentSetup).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// 1b. Order-fields allow-list (#369) — RED alongside its fix.
+//     customAttributes are the client-supplied non-reserved form fields. They
+//     are written to the cart's custom_attributes AND forwarded to the order's
+//     flow fields, where EP persists any slug its flow defines. Without a gate
+//     a client can forge/overwrite ANY defined order-flow slug (consent flags,
+//     internal/audit fields the form never exposes) just by sending it. The
+//     server-side allow-list is the gate: fail closed (no list → nothing
+//     persists), strict when a list is set, explicit "*" to opt into open.
+// ===========================================================================
+
+describe("order-fields allow-list (#369)", () => {
+  it("drops a forged custom-attribute key not on the allow-list (cart + order writes)", async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(
+      // industry is a legitimate form field; kyc_verified is a forged
+      // order-flow slug the form never exposes.
+      makeSession({ customAttributes: { industry: "Tech", kyc_verified: true } }),
+      adapter,
+      { allowedCustomAttributeKeys: ["industry"] }
+    );
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+    expect(res.status).toBe(200);
+
+    // Cart custom_attributes write carries only the allow-listed key.
+    const cartAttrs =
+      epSdk.updateACart.mock.calls[0][0].body.data.custom_attributes;
+    expect(cartAttrs.industry).toBeDefined();
+    expect(cartAttrs.kyc_verified).toBeUndefined();
+
+    // Order flow-field write carries only the allow-listed key.
+    const orderData = epSdk.updateAnOrder.mock.calls[0][0].body.data;
+    expect(orderData.industry).toBe("Tech");
+    expect(orderData.kyc_verified).toBeUndefined();
+  });
+
+  it("fails closed: with no allow-list configured, no custom attributes are persisted", async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(
+      makeSession({ customAttributes: { industry: "Tech" } }),
+      adapter
+      // no allowedCustomAttributeKeys → fail closed
+    );
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+    // The order still completes; the extras are simply dropped.
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    // Nothing to persist → neither write fires.
+    expect(epSdk.updateACart).not.toHaveBeenCalled();
+    expect(epSdk.updateAnOrder).not.toHaveBeenCalled();
+  });
+
+  it('the "*" sentinel opts into persisting arbitrary keys (deliberate permissive mode)', async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(
+      makeSession({ customAttributes: { anything: "goes", another: 1 } }),
+      adapter,
+      { allowedCustomAttributeKeys: "*" }
+    );
+
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const orderData = epSdk.updateAnOrder.mock.calls[0][0].body.data;
+    expect(orderData.anything).toBe("goes");
+    expect(orderData.another).toBe(1);
+  });
+
+  it("enforces the allow-list at the update-session boundary (forged key never enters the session)", async () => {
+    const ctx = createMockCtx(makeSession({ customAttributes: {} }), undefined, {
+      allowedCustomAttributeKeys: ["industry"],
+    });
+    const res = await handleUpdateSession(
+      createMockReq({ customAttributes: { industry: "Tech", kyc_verified: true } }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    const stored = (res.body as any).data.session.customAttributes;
+    expect(stored).toEqual({ industry: "Tech" }); // forged key dropped on entry
+    // And the persisted session matches (no forged key in stored state).
+    const persisted = (ctx.sessionStore.set as jest.Mock).mock.calls[0][1];
+    expect(persisted.customAttributes.kyc_verified).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// 1c. confirmOrder reconciliation (#369) — RED alongside its fix.
+//     After a paid order is created, confirmOrder syncs the gateway payment
+//     status onto the EP order. The customer is ALREADY charged at this point,
+//     so a failure must not lose their order — but it must NOT be swallowed
+//     either: a charged-but-unreconciled order has to be flagged durably so it
+//     can be reconciled, not silently reported as a clean success.
+// ===========================================================================
+
+describe("confirmOrder reconciliation (#369)", () => {
+  it("flags needsReconciliation (not a silent success) when confirmOrder fails", async () => {
+    epSdk.confirmOrder.mockRejectedValue(new Error("EP confirmOrder 500"));
+    const adapter = createMockAdapter({
+      status: "succeeded",
+      gatewayOrderId: "pi_abc",
+      gatewayMetadata: { paymentIntentId: "pi_abc" },
+    });
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(makeSession(), adapter);
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const body = res.body as any;
+    // The order is genuine + paid → still completes.
+    expect(res.status).toBe(200);
+    expect(body.data.session.status).toBe("complete");
+    expect(body.data.session.order?.id).toBe("order-1");
+    // ...but the reconciliation gap is surfaced, not swallowed.
+    expect(body.reconciliationPending).toBe(true);
+    expect(body.data.session.payment.gatewayMetadata.needsReconciliation).toBe(
+      true
+    );
+  });
+
+  it("does not call confirmOrder with an undefined paymentID; flags reconciliation instead", async () => {
+    // Adapter succeeded but returned no gateway order id / payment intent id.
+    const adapter = createMockAdapter({ status: "succeeded" });
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(makeSession(), adapter);
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const body = res.body as any;
+    expect(res.status).toBe(200);
+    expect(body.data.session.status).toBe("complete");
+    // We must not fire a meaningless confirmOrder with paymentID=undefined.
+    expect(epSdk.confirmOrder).not.toHaveBeenCalled();
+    // The missing payment id is itself a reconciliation gap.
+    expect(body.reconciliationPending).toBe(true);
+    expect(body.data.session.payment.gatewayMetadata.needsReconciliation).toBe(
+      true
+    );
+  });
+
+  it("clean confirmOrder → no reconciliation flag (no false positives)", async () => {
+    const adapter = createMockAdapter({
+      status: "succeeded",
+      gatewayOrderId: "pi_ok",
+      gatewayMetadata: { paymentIntentId: "pi_ok" },
+    });
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(makeSession(), adapter);
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const body = res.body as any;
+    expect(res.status).toBe(200);
+    expect(epSdk.confirmOrder).toHaveBeenCalledTimes(1);
+    expect(epSdk.confirmOrder.mock.calls[0][0].path.paymentID).toBe("pi_ok");
+    expect(body.reconciliationPending).toBeUndefined();
+    expect(
+      body.data.session.payment.gatewayMetadata.needsReconciliation
+    ).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// 1d. Server-authoritative requiresShipping (#369) — RED alongside its fix.
+//     EP requires a shipping address on every checkout (the body builder
+//     defaults it to billing), so a client setting requiresShipping:false on a
+//     PHYSICAL cart would ship to billing silently. The server infers the
+//     requirement from the cart's physical items; the client flag may only ADD
+//     it, never suppress it.
+// ===========================================================================
+
+describe("server-authoritative requiresShipping (#369)", () => {
+  /** Cart whose single line points at the given product id. */
+  function physicalCartFetch(productId: string, commodityType: string) {
+    const items = [{ id: "li-1", quantity: 1, product_id: productId }];
+    epSdk.getACart.mockResolvedValue({
+      data: {
+        included: { items },
+        data: {
+          meta: { display_price: { with_tax: { amount: 5400, currency: "CHF" } } },
+        },
+      },
+    });
+    epSdk.getByContextAllProducts.mockResolvedValue({
+      data: { data: [{ id: productId, attributes: { commodity_type: commodityType } }] },
+    });
+    return hashCart(items);
+  }
+
+  it("forces shipping for a physical cart even when the client suppressed it", async () => {
+    const cartHash = physicalCartFetch("prod-phys", "physical");
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({
+        cartHash,
+        requiresShipping: false, // client tries to suppress
+        shippingAddress: null,
+        selectedShippingRateId: null,
+      }),
+      adapter
+    );
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(res.status).toBe(400);
+    expect((res.body as any).error.code).toBe("MISSING_FIELDS");
+    expect((res.body as any).error.message).toContain("shippingAddress");
+    // No payment attempted, no order created.
+    expect(adapter.initializePayment).not.toHaveBeenCalled();
+    expect(epSdk.checkoutApi).not.toHaveBeenCalled();
+  });
+
+  it("honours suppression for a digital-only cart", async () => {
+    const cartHash = physicalCartFetch("prod-dig", "digital");
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(
+      makeSession({
+        cartHash,
+        requiresShipping: false,
+        shippingAddress: null,
+        selectedShippingRateId: null,
+      }),
+      adapter
+    );
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+    expect(adapter.initializePayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds for a physical cart when a real shipping address + rate were provided", async () => {
+    const cartHash = physicalCartFetch("prod-phys", "physical");
+    const adapter = createMockAdapter();
+    // requiresShipping:false but a genuine shipping address + rate are present
+    // (makeSession defaults them) → the requirement is satisfied.
+    const ctx = createMockCtx(
+      makeSession({ cartHash, requiresShipping: false }),
+      adapter
+    );
+
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).data.session.status).toBe("complete");
+  });
+
+  it("does not look up products when shipping isn't suppressed (no extra call)", async () => {
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const adapter = createMockAdapter();
+    const ctx = createMockCtx(makeSession(), adapter); // requiresShipping undefined
+
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    expect(epSdk.getByContextAllProducts).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// 2. Token-leak boundary — admin / shopper tokens must never reflect into a
+//    response. Covers every checkout-session route, including #368's new
+//    branches (the order-custom-fields write, which carries the admin token in
+//    an explicit Bearer header, and the free-order settlement path).
+// ===========================================================================
+
+/** The serialised response (status + body + headers) must contain neither the
+ * admin client-credentials token nor the shopper token. The legitimate
+ * Set-Cookie header carries the encrypted session, which never holds a token. */
+function expectNoTokenLeak(res: { status: number; body: unknown; headers?: unknown }) {
+  const serialised = JSON.stringify({
+    status: res.status,
+    body: res.body,
+    headers: res.headers ?? null,
+  });
+  expect(serialised).not.toContain(ADMIN_TOKEN);
+  expect(serialised).not.toContain(SHOPPER_TOKEN);
+}
+
+describe("token-leak boundary — no admin/shopper token in any response", () => {
+  // customAttributes ensure the order-custom-fields write (admin Bearer token)
+  // actually runs on the pay paths — exercising the #368 branches, not just
+  // skipping them.
+  const EXTRAS = { industry: "Tech", marketingOptIn: true } as const;
+
+  it("paid pay() — admin token (checkoutApi/confirmOrder/order-fields) never reflected", async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(makeSession({ customAttributes: { ...EXTRAS } }), adapter, {
+      allowedCustomAttributeKeys: "*",
+    });
+    const res = await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+    expect(res.status).toBe(200);
+    // The admin token DID travel to the outbound order-fields write...
+    expect(epSdk.updateAnOrder).toHaveBeenCalledTimes(1);
+    expect(epSdk.updateAnOrder.mock.calls[0][0].headers.Authorization).toBe(
+      `Bearer ${ADMIN_TOKEN}`
+    );
+    // ...but it must NOT come back in the response.
+    expectNoTokenLeak(res);
+  });
+
+  it("free pay() — settleFreeOrder + order-fields write never reflect the admin token", async () => {
+    const FREE_ITEMS = [{ id: "free-1", quantity: 1 }];
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(0, FREE_ITEMS));
+    const ctx = createMockCtx(
+      makeSession({ cartHash: hashCart(FREE_ITEMS), customAttributes: { ...EXTRAS } }),
+      undefined,
+      { allowedCustomAttributeKeys: "*" }
+    );
+    const res = await handlePay(createMockReq({}), ctx);
+    expect(res.status).toBe(200);
+    expect(epSdk.paymentSetup).toHaveBeenCalledTimes(1);
+    expect(epSdk.updateAnOrder.mock.calls[0][0].headers.Authorization).toBe(
+      `Bearer ${ADMIN_TOKEN}`
+    );
+    expectNoTokenLeak(res);
+  });
+
+  it("confirm() never reflects a token", async () => {
+    const adapter = createMockAdapter(undefined, { status: "succeeded" });
+    const ctx = createMockCtx(
+      makeSession({
+        status: "processing",
+        payment: {
+          gateway: "stripe",
+          status: "requires_action",
+          clientToken: null,
+          gatewayMetadata: {},
+          actionData: null,
+        },
+        order: { id: "order-1", transactionId: "txn-1" },
+      }),
+      adapter
+    );
+    const res = await handleConfirm(createMockReq({}), ctx);
+    expect(res.status).toBe(200);
+    expectNoTokenLeak(res);
+  });
+
+  it("create-session() never reflects the cart-read token", async () => {
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(null);
+    const res = await handleCreateSession(createMockReq({ cartId: "cart-abc" }), ctx);
+    expect(res.status).toBe(201);
+    expectNoTokenLeak(res);
+  });
+
+  it("update-session() never reflects a token", async () => {
+    const ctx = createMockCtx(makeSession());
+    const res = await handleUpdateSession(
+      createMockReq({ customAttributes: { ...EXTRAS } }),
+      ctx
+    );
+    expect(res.status).toBe(200);
+    expectNoTokenLeak(res);
+  });
+
+  it("calculate-shipping() never reflects a token", async () => {
+    epSdk.getShippingOptions.mockResolvedValue({ data: { data: [] } });
+    const ctx = createMockCtx(makeSession());
+    const res = await handleCalculateShipping(createMockReq({}), ctx);
+    expect(res.status).toBe(200);
+    expectNoTokenLeak(res);
+  });
+
+  it("get-session() never reflects a token", async () => {
+    const ctx = createMockCtx(makeSession());
+    const res = await handleGetSession(createMockReq({}), ctx);
+    expect(res.status).toBe(200);
+    expectNoTokenLeak(res);
+  });
+});
+
+// ===========================================================================
+// 3. No-PII logging — the logger must never emit a customer's contact details
+//    or any customAttributes *value* (phone, VAT, consent text). The logger
+//    only logs cartId/orderId/sessionId/error.message/field-keys today; this
+//    guards against a regression that dumps the session or the extras map.
+// ===========================================================================
+
+describe("no-PII logging across the pipeline", () => {
+  const PII_ATTRS = {
+    phone: PII_PHONE,
+    vatNumber: PII_VAT,
+    marketingOptIn: true,
+  } as const;
+  const PII_CUSTOMER = { name: PII_NAME, email: PII_EMAIL };
+
+  const consoleSpies: jest.SpyInstance[] = [];
+
+  beforeEach(() => {
+    // The logger is SILENT unless EP_DEBUG is set; force it fully on so a leak
+    // would actually be emitted (a silent logger trivially "passes").
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: () => "*",
+    };
+    resetLogConfig();
+    for (const method of ["debug", "info", "warn", "error"] as const) {
+      consoleSpies.push(jest.spyOn(console, method).mockImplementation(() => {}));
+    }
+  });
+
+  afterEach(() => {
+    consoleSpies.forEach((s) => s.mockRestore());
+    consoleSpies.length = 0;
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    resetLogConfig();
+  });
+
+  /** Every argument passed to any console method during the test, serialised. */
+  function allLogOutput(): string {
+    return consoleSpies
+      .flatMap((spy) => spy.mock.calls as unknown[][])
+      .map((args) =>
+        args.map((a: unknown) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")
+      )
+      .join("\n");
+  }
+
+  function expectNoPII(logged: string) {
+    expect(logged).not.toContain(PII_PHONE);
+    expect(logged).not.toContain(PII_VAT);
+    expect(logged).not.toContain(PII_EMAIL);
+    expect(logged).not.toContain(PII_NAME);
+  }
+
+  it("paid pay() with PII extras logs no field values (success info path)", async () => {
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(
+      makeSession({ customAttributes: { ...PII_ATTRS }, customerInfo: PII_CUSTOMER }),
+      adapter,
+      { allowedCustomAttributeKeys: "*" }
+    );
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const logged = allLogOutput();
+    expect(logged.length).toBeGreaterThan(0); // logging really is on
+    expectNoPII(logged);
+  });
+
+  it("pay() warn paths (cart-attr + order-field write failures) log no PII", async () => {
+    // Force the best-effort writes to fail so their warn branches fire.
+    epSdk.updateACart.mockRejectedValue(new Error("EP cart write rejected"));
+    epSdk.updateAnOrder.mockRejectedValue(new Error("EP order write rejected"));
+    const adapter = createMockAdapter();
+    epSdk.getACart.mockResolvedValue(cartResponseWithTotal(5400));
+    const ctx = createMockCtx(
+      makeSession({ customAttributes: { ...PII_ATTRS }, customerInfo: PII_CUSTOMER }),
+      adapter,
+      { allowedCustomAttributeKeys: "*" }
+    );
+    await handlePay(
+      createMockReq({ gateway: "stripe", confirmation_token: "ctok" }),
+      ctx
+    );
+
+    const logged = allLogOutput();
+    expect(logged).toContain("custom attributes"); // a warn branch did fire
+    expectNoPII(logged);
+  });
+
+  it("update-session() logs field keys, never customAttributes values", async () => {
+    const ctx = createMockCtx(makeSession(), undefined, {
+      allowedCustomAttributeKeys: "*",
+    });
+    await handleUpdateSession(
+      createMockReq({ customAttributes: { ...PII_ATTRS }, customerInfo: PII_CUSTOMER }),
+      ctx
+    );
+
+    const logged = allLogOutput();
+    expect(logged).toContain("customAttributes"); // the top-level KEY is logged
+    expectNoPII(logged); // ...but none of the VALUES are
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/pay.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/pay.ts
@@ -38,6 +38,11 @@ import { hashCart } from "../../../checkout/session/cart-hash";
 import { buildGuestCheckoutBody } from "../../../checkout/session/checkout-body-builder";
 import { runCartCleanup } from "../../../checkout/session/cart-cleanup";
 import { persistOrderCustomFields } from "../../../checkout/session/order-custom-fields";
+import { filterAllowedCustomAttributes } from "../../../checkout/session/custom-attributes-allowlist";
+import {
+  resolveRequiresShipping,
+  cartHasPhysicalItem,
+} from "../../../checkout/session/cart-shipping";
 import {
   applyPaymentSucceeded,
   applyPaymentFailed,
@@ -55,26 +60,6 @@ const FREE_ORDER_METHOD = "purchase";
 function toClientSession(s: CheckoutSession): ClientCheckoutSession {
   const { cartHash, ...rest } = s;
   return rest;
-}
-
-/** Order total in EP minor units, summed across cart items. Prefers each
- * item's line `value.amount`; falls back to `unit_price.amount * quantity`.
- * Used to decide the free (== 0) vs paid (> 0) settlement path. */
-function cartItemsTotal(
-  items: Array<{
-    quantity?: number;
-    unit_price?: { amount?: number };
-    value?: { amount?: number };
-  }>
-): number {
-  return items.reduce((sum, it) => {
-    const line =
-      it.value?.amount ??
-      (it.unit_price?.amount != null
-        ? it.unit_price.amount * (it.quantity ?? 1)
-        : 0);
-    return sum + line;
-  }, 0);
 }
 
 /** Persist the session's extra fields + consent flags as cart custom
@@ -301,29 +286,31 @@ export async function handlePay(
     };
   }
 
-  // 2b. Validate required checkout fields. Shipping address + rate are only
-  //     required when the checkout collects shipping (requiresShipping !==
-  //     false) — digital / single-page checkouts skip them.
-  const requiresShipping = session.requiresShipping !== false;
-  const missingFields: string[] = [];
-  if (!session.customerInfo) missingFields.push("customerInfo");
-  if (!session.billingAddress) missingFields.push("billingAddress");
-  if (requiresShipping && !session.shippingAddress)
-    missingFields.push("shippingAddress");
-  if (requiresShipping && !session.selectedShippingRateId)
-    missingFields.push("selectedShippingRateId");
+  // 2b. Required-field validation is deferred to step 3a (after the cart
+  //     fetch), because whether shipping is required is server-authoritative —
+  //     inferred from the cart's physical items, not just the client flag — so
+  //     all missing fields (contact + shipping) are reported in one response.
 
-  if (missingFields.length > 0) {
-    return {
-      status: 400,
-      body: {
-        success: false,
-        error: {
-          message: `Missing required fields: ${missingFields.join(", ")}`,
-          code: "MISSING_FIELDS",
-        },
-      },
-    };
+  // 2c. Re-apply the customAttributes allow-list before any persistence
+  //     (defence in depth — updateSession already gated these on the way in).
+  //     Every downstream write (cart custom_attributes, order flow fields, on
+  //     both the paid and free branches) reads session.customAttributes, so
+  //     filtering once here gates them all. Fail closed: with no allow-list
+  //     configured, nothing persists.
+  {
+    const { allowed, dropped } = filterAllowedCustomAttributes(
+      session.customAttributes,
+      ctx.allowedCustomAttributeKeys
+    );
+    if (dropped.length > 0) {
+      // Keys only — never the values (they may be PII).
+      log.warn("Dropped customAttribute keys not on the allow-list", {
+        sessionId: session.id,
+        dropped: dropped.join(","),
+        allowListConfigured: ctx.allowedCustomAttributeKeys !== undefined,
+      } as Record<string, unknown>);
+    }
+    session = { ...session, customAttributes: allowed };
   }
 
   // 3. Re-fetch cart and compare hash
@@ -331,6 +318,7 @@ export async function handlePay(
   let freshCartItems: Array<{
     id: string;
     quantity: number;
+    product_id?: string;
     unit_price?: { amount?: number };
     value?: { amount?: number };
   }> = [];
@@ -398,6 +386,52 @@ export async function handlePay(
     }
   }
 
+  // 3a. Required-field validation + server-authoritative shipping requirement.
+  //     EP requires a shipping address on every checkout (the body builder
+  //     defaults it to billing), so a client could set requiresShipping:false
+  //     on a PHYSICAL cart and have the goods silently ship to billing. The
+  //     client flag may only ADD a requirement: if the cart has any physical
+  //     item, shipping is required regardless. We only pay for the product
+  //     lookup when the client tried to suppress shipping — the normal path
+  //     needs no extra call.
+  let cartHasPhysical = false;
+  if (session.requiresShipping === false) {
+    cartHasPhysical = await cartHasPhysicalItem({
+      host: ctx.epCredentials.apiBaseUrl,
+      clientId: ctx.epCredentials.clientId,
+      shopperAccessToken: ctx.shopperAccessToken,
+      productIds: freshCartItems.map((it) => it.product_id ?? "").filter(Boolean),
+    });
+    if (cartHasPhysical) {
+      log.warn("Physical cart overrode client requiresShipping:false", {
+        sessionId: session.id,
+      } as Record<string, unknown>);
+    }
+  }
+  const requiresShipping = resolveRequiresShipping(
+    session.requiresShipping,
+    cartHasPhysical
+  );
+  const missingFields: string[] = [];
+  if (!session.customerInfo) missingFields.push("customerInfo");
+  if (!session.billingAddress) missingFields.push("billingAddress");
+  if (requiresShipping && !session.shippingAddress)
+    missingFields.push("shippingAddress");
+  if (requiresShipping && !session.selectedShippingRateId)
+    missingFields.push("selectedShippingRateId");
+  if (missingFields.length > 0) {
+    return {
+      status: 400,
+      body: {
+        success: false,
+        error: {
+          message: `Missing required fields: ${missingFields.join(", ")}`,
+          code: "MISSING_FIELDS",
+        },
+      },
+    };
+  }
+
   // 3b. Admin client + persist the session's extra fields/consents as cart
   //     custom attributes (best-effort) before any checkout.
   const adminClient = await buildAdminEpClient(ctx);
@@ -407,11 +441,18 @@ export async function handlePay(
   //     reject a 0 charge, so EP best practice is to settle a free order with
   //     the manual gateway — no card, no PaymentIntent. Run it before any
   //     gateway/adapter requirement so a free checkout needs no payment UI.
-  // Prefer the authoritative cart-meta total; fall back to summing items only
-  // when meta is unavailable. A truly free cart has meta total 0.
-  const orderTotal =
-    cartMetaTotal !== null ? cartMetaTotal : cartItemsTotal(freshCartItems);
-  if (orderTotal === 0) {
+  //
+  //     The server is the SOLE authority on free-vs-paid. Settle for free ONLY
+  //     on the cart's authoritative `meta.display_price` total being present
+  //     AND exactly zero — i.e. an authoritative zero, never an *absence*. The
+  //     parsed-items sum is deliberately NOT consulted here (see the note
+  //     above the cart re-fetch): a paid cart whose items don't parse would
+  //     sum to 0 and route to free settlement, completing with no charge. When
+  //     the authoritative total is unavailable (cartMetaTotal === null) we fail
+  //     closed: we refuse to free-settle and fall through to the paid path,
+  //     which requires a gateway + a confirmed PaymentIntent. An unprovable-
+  //     free cart can therefore never settle for free.
+  if (cartMetaTotal === 0) {
     return await settleFreeOrder(req, ctx, session, adminClient, ttl);
   }
 
@@ -565,24 +606,39 @@ export async function handlePay(
     input: session.customAttributes,
   });
 
-  // 5b. confirmOrder — syncs the EP-side payment intent status to the order.
-  try {
-    await confirmOrder({
-      client: adminClient,
-      path: {
-        orderID: orderId,
+  // 5b. confirmOrder — syncs the gateway payment status onto the EP order. The
+  //     customer is ALREADY charged at this point, so a failure here must not
+  //     roll back the order — but it must not be swallowed either: it leaves a
+  //     charged-but-unreconciled order that has to be flagged for follow-up
+  //     (durable marker on the session + a response flag), not silently
+  //     reported as a clean success. We also require a real paymentID — firing
+  //     confirmOrder with `undefined` can never reconcile anything.
+  const paymentIntentId =
+    (adapterResult.gatewayOrderId as string | undefined) ??
+    (adapterResult.gatewayMetadata?.paymentIntentId as string | undefined);
+  let reconciliationError: string | null = null;
+  if (!paymentIntentId) {
+    reconciliationError = "missing gateway payment intent id";
+    log.error("Cannot reconcile order — no gateway payment intent id", {
+      orderId,
+    } as Record<string, unknown>);
+  } else {
+    try {
+      await confirmOrder({
+        client: adminClient,
         // The EP API requires the paymentID on this path. The PI id from the
         // adapter result is what EP returned as the cart's payment intent.
-        paymentID: (adapterResult.gatewayOrderId ??
-          (adapterResult.gatewayMetadata?.paymentIntentId as string)) as string,
-      } as any,
-      body: { data: {} } as any,
-    });
-  } catch (err) {
-    log.warn("confirmOrder failed (non-fatal — order is genuine)", {
-      orderId,
-      error: err instanceof Error ? err.message : String(err),
-    } as Record<string, unknown>);
+        path: { orderID: orderId, paymentID: paymentIntentId } as any,
+        body: { data: {} } as any,
+      });
+    } catch (err) {
+      reconciliationError = err instanceof Error ? err.message : String(err);
+      log.error("confirmOrder failed — order charged but unreconciled", {
+        orderId,
+        paymentIntentId,
+        error: reconciliationError,
+      } as Record<string, unknown>);
+    }
   }
 
   // 5c. Cart cleanup — best-effort housekeeping
@@ -595,15 +651,18 @@ export async function handlePay(
     });
   }
 
-  // 5d. Mark complete and persist
+  // 5d. Mark complete and persist. When confirmOrder couldn't reconcile, carry
+  //     a durable `needsReconciliation` marker on the session so the
+  //     charged-but-unreconciled order is discoverable later.
   const completeSession = applyPaymentSucceeded(
     { ...session, payment: { ...session.payment, gateway } },
     {
       orderId,
-      paymentIntentId:
-        (adapterResult.gatewayOrderId as string) ??
-        ((adapterResult.gatewayMetadata?.paymentIntentId as string) ?? ""),
-      gatewayMetadata: adapterResult.gatewayMetadata,
+      paymentIntentId: paymentIntentId ?? "",
+      gatewayMetadata: {
+        ...(adapterResult.gatewayMetadata ?? {}),
+        ...(reconciliationError ? { needsReconciliation: true } : {}),
+      },
     }
   );
 
@@ -626,6 +685,7 @@ export async function handlePay(
   log.info("Pay handler completed", {
     sessionId: completeSession.id,
     orderId,
+    reconciliationPending: reconciliationError !== null,
   } as Record<string, unknown>);
 
   return {
@@ -633,6 +693,9 @@ export async function handlePay(
     body: {
       success: true,
       data: { session: toClientSession(completeSession) },
+      // Surface the charged-but-unreconciled state so the client / monitoring
+      // can act on it — the order is genuine and paid, but EP didn't confirm.
+      ...(reconciliationError ? { reconciliationPending: true } : {}),
     },
     headers: setResult.headers,
   };

--- a/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/update-session.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/api/endpoints/checkout-session/update-session.ts
@@ -13,6 +13,7 @@ import type {
   ClientCheckoutSession,
   UpdateSessionRequest,
 } from "../../../checkout/session/types";
+import { filterAllowedCustomAttributes } from "../../../checkout/session/custom-attributes-allowlist";
 import { createLogger } from "../../../utils/logger";
 
 const log = createLogger("UpdateSession");
@@ -69,6 +70,34 @@ export async function handleUpdateSession(
 
   const update = req.body as UpdateSessionRequest;
 
+  // customAttributes are client-supplied. Gate them against the server-side
+  // allow-list at this boundary so forged keys never enter session state.
+  // Fail closed: with no allow-list configured, nothing survives. (Defence in
+  // depth: /pay re-applies the same filter before the privileged EP writes.)
+  let nextCustomAttributes: CheckoutSession["customAttributes"] =
+    session.customAttributes;
+  if (update.customAttributes !== undefined) {
+    const merged = {
+      // Merge (not replace) so partial updates accumulate the extra fields +
+      // consent flags a single-page form collects.
+      ...(session.customAttributes ?? {}),
+      ...update.customAttributes,
+    };
+    const { allowed, dropped } = filterAllowedCustomAttributes(
+      merged,
+      ctx.allowedCustomAttributeKeys
+    );
+    nextCustomAttributes = allowed;
+    if (dropped.length > 0) {
+      // Keys only — never the values (they may be PII).
+      log.warn("Dropped customAttribute keys not on the allow-list", {
+        sessionId: session.id,
+        dropped: dropped.join(","),
+        allowListConfigured: ctx.allowedCustomAttributeKeys !== undefined,
+      } as Record<string, unknown>);
+    }
+  }
+
   const updated: CheckoutSession = {
     ...session,
     ...(update.customerInfo !== undefined && { customerInfo: update.customerInfo }),
@@ -80,13 +109,8 @@ export async function handleUpdateSession(
     ...(update.requiresShipping !== undefined && {
       requiresShipping: update.requiresShipping,
     }),
-    // customAttributes merge (not replace) so partial updates accumulate the
-    // extra fields + consent flags a single-page form collects.
     ...(update.customAttributes !== undefined && {
-      customAttributes: {
-        ...(session.customAttributes ?? {}),
-        ...update.customAttributes,
-      },
+      customAttributes: nextCustomAttributes,
     }),
   };
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/cart-shipping.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/cart-shipping.test.ts
@@ -1,0 +1,103 @@
+jest.mock("@epcc-sdk/sdks-shopper", () => ({
+  getByContextAllProducts: jest.fn(),
+  createShopperClient: jest.fn(() => ({ client: {} })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const epSdk = require("@epcc-sdk/sdks-shopper") as {
+  getByContextAllProducts: jest.Mock;
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { resolveRequiresShipping, cartHasPhysicalItem } = require("../cart-shipping") as {
+  resolveRequiresShipping: typeof import("../cart-shipping").resolveRequiresShipping;
+  cartHasPhysicalItem: typeof import("../cart-shipping").cartHasPhysicalItem;
+};
+
+function productsResponse(commodityTypes: string[]) {
+  return {
+    data: {
+      data: commodityTypes.map((commodity_type, i) => ({
+        id: `prod-${i}`,
+        attributes: { commodity_type },
+      })),
+    },
+  };
+}
+
+const LOOKUP = {
+  host: "https://api.test.com",
+  clientId: "test-id",
+  shopperAccessToken: "shopper-token",
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("resolveRequiresShipping", () => {
+  // The client flag may only ADD a shipping requirement, never suppress one a
+  // physical cart imposes. requiresShipping defaults to true.
+  it("requires shipping when the cart has a physical item, even if the client suppressed it", () => {
+    expect(resolveRequiresShipping(false, true)).toBe(true);
+  });
+
+  it("honours client suppression only for a non-physical cart", () => {
+    expect(resolveRequiresShipping(false, false)).toBe(false);
+  });
+
+  it("defaults to requiring shipping when the client flag is undefined", () => {
+    expect(resolveRequiresShipping(undefined, false)).toBe(true);
+    expect(resolveRequiresShipping(undefined, true)).toBe(true);
+  });
+
+  it("requires shipping when the client flag is true", () => {
+    expect(resolveRequiresShipping(true, false)).toBe(true);
+    expect(resolveRequiresShipping(true, true)).toBe(true);
+  });
+});
+
+describe("cartHasPhysicalItem", () => {
+  it("returns true when any product is a physical commodity", async () => {
+    epSdk.getByContextAllProducts.mockResolvedValue(
+      productsResponse(["digital", "physical"])
+    );
+    expect(
+      await cartHasPhysicalItem({ ...LOOKUP, productIds: ["a", "b"] })
+    ).toBe(true);
+  });
+
+  it("returns false when all products are digital", async () => {
+    epSdk.getByContextAllProducts.mockResolvedValue(
+      productsResponse(["digital", "digital"])
+    );
+    expect(
+      await cartHasPhysicalItem({ ...LOOKUP, productIds: ["a", "b"] })
+    ).toBe(false);
+  });
+
+  it("does not call EP and returns false for an empty product list", async () => {
+    expect(await cartHasPhysicalItem({ ...LOOKUP, productIds: [] })).toBe(false);
+    expect(epSdk.getByContextAllProducts).not.toHaveBeenCalled();
+  });
+
+  it("dedupes ids and queries with an in(id,...) filter", async () => {
+    epSdk.getByContextAllProducts.mockResolvedValue(productsResponse(["digital"]));
+    await cartHasPhysicalItem({ ...LOOKUP, productIds: ["a", "a", "b", ""] });
+    const query = epSdk.getByContextAllProducts.mock.calls[0][0].query;
+    expect(query.filter).toBe("in(id,a,b)");
+  });
+
+  it("fails open (returns false) and does not throw when the lookup errors", async () => {
+    epSdk.getByContextAllProducts.mockRejectedValue(new Error("EP down"));
+    expect(
+      await cartHasPhysicalItem({ ...LOOKUP, productIds: ["a"] })
+    ).toBe(false);
+  });
+
+  it("fails closed (returns true) when the lookup resolves fewer products than requested", async () => {
+    // Healthy response, but one of the two requested products is missing — we
+    // can't prove the cart is all-digital, so require shipping.
+    epSdk.getByContextAllProducts.mockResolvedValue(productsResponse(["digital"]));
+    expect(
+      await cartHasPhysicalItem({ ...LOOKUP, productIds: ["a", "b"] })
+    ).toBe(true);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/custom-attributes-allowlist.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/__tests__/custom-attributes-allowlist.test.ts
@@ -1,0 +1,56 @@
+import { filterAllowedCustomAttributes } from "../custom-attributes-allowlist";
+
+describe("filterAllowedCustomAttributes", () => {
+  const ATTRS = { industry: "Tech", marketingOptIn: true, kyc_verified: true };
+
+  it("fails closed when no allow-list is configured (undefined)", () => {
+    const { allowed, dropped } = filterAllowedCustomAttributes(ATTRS, undefined);
+    expect(allowed).toBeUndefined();
+    expect(dropped.sort()).toEqual(["industry", "kyc_verified", "marketingOptIn"]);
+  });
+
+  it("fails closed for an empty allow-list", () => {
+    const { allowed, dropped } = filterAllowedCustomAttributes(ATTRS, []);
+    expect(allowed).toBeUndefined();
+    expect(dropped).toHaveLength(3);
+  });
+
+  it("keeps only allow-listed keys and reports the rest as dropped", () => {
+    const { allowed, dropped } = filterAllowedCustomAttributes(ATTRS, [
+      "industry",
+      "marketingOptIn",
+    ]);
+    expect(allowed).toEqual({ industry: "Tech", marketingOptIn: true });
+    expect(dropped).toEqual(["kyc_verified"]);
+  });
+
+  it('passes everything through for the "*" sentinel', () => {
+    const { allowed, dropped } = filterAllowedCustomAttributes(ATTRS, "*");
+    expect(allowed).toBe(ATTRS); // same reference — no copy needed
+    expect(dropped).toEqual([]);
+  });
+
+  it("returns undefined allowed (not {}) when every key is dropped", () => {
+    const { allowed } = filterAllowedCustomAttributes(ATTRS, ["not-present"]);
+    expect(allowed).toBeUndefined();
+  });
+
+  it("is a no-op for empty / absent input", () => {
+    expect(filterAllowedCustomAttributes(undefined, ["industry"])).toEqual({
+      allowed: undefined,
+      dropped: [],
+    });
+    expect(filterAllowedCustomAttributes({}, "*")).toEqual({
+      allowed: undefined,
+      dropped: [],
+    });
+  });
+
+  it("preserves boolean/number/string value types for kept keys", () => {
+    const { allowed } = filterAllowedCustomAttributes(
+      { s: "x", n: 7, b: false },
+      ["s", "n", "b"]
+    );
+    expect(allowed).toEqual({ s: "x", n: 7, b: false });
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/cart-shipping.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/cart-shipping.ts
@@ -1,0 +1,96 @@
+/**
+ * Server-authoritative shipping requirement.
+ *
+ * `requiresShipping` is otherwise a client-supplied flag, and EP requires a
+ * shipping address on EVERY checkout (physical and digital alike) — so the
+ * checkout-body builder defaults a missing shipping address to billing. That
+ * combination lets a client set `requiresShipping: false` on a cart containing
+ * a PHYSICAL item and have the goods silently ship to the billing address.
+ *
+ * The server is the authority: it infers whether the cart actually needs
+ * shipping from each line's product `commodity_type`, and the client flag may
+ * only ADD a shipping requirement, never suppress one a physical cart imposes.
+ */
+import { getByContextAllProducts, createShopperClient } from "@epcc-sdk/sdks-shopper";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("CartShipping");
+
+/**
+ * Resolve the effective shipping requirement. The client flag may only ADD a
+ * requirement: a physical cart always requires shipping, and a non-physical
+ * cart honours the client flag (defaulting to required when unset).
+ */
+export function resolveRequiresShipping(
+  clientRequiresShipping: boolean | undefined,
+  cartHasPhysicalItem: boolean
+): boolean {
+  return cartHasPhysicalItem || clientRequiresShipping !== false;
+}
+
+export interface CartPhysicalLookup {
+  /** EP API base URL. */
+  host: string;
+  clientId: string;
+  /** Shopper token resolving the same catalog context the cart was built in. */
+  shopperAccessToken?: string;
+  /** The cart lines' `product_id`s. */
+  productIds: string[];
+}
+
+/**
+ * True when ANY of the cart's products is a physical (shippable) commodity.
+ *
+ * Looks each product up in the shopper catalog context and inspects its
+ * `commodity_type`. Fails OPEN (returns false) on a lookup error: the primary
+ * consumer is digital/shipping-less, so a transient EP outage must not block a
+ * legitimate checkout — the failure is logged, and the clean-lookup path still
+ * catches every real physical cart. Callers should only consult this when the
+ * client tried to suppress shipping (otherwise shipping is already required).
+ */
+export async function cartHasPhysicalItem(
+  opts: CartPhysicalLookup
+): Promise<boolean> {
+  const ids = Array.from(new Set(opts.productIds.filter(Boolean)));
+  if (ids.length === 0) return false;
+
+  try {
+    const { client } = createShopperClient(
+      { baseUrl: opts.host },
+      {
+        clientId: opts.clientId,
+        storage: { get: () => opts.shopperAccessToken ?? "", set: () => {} },
+      }
+    );
+    const res = await getByContextAllProducts({
+      client,
+      query: { filter: `in(id,${ids.join(",")})`, "page[limit]": ids.length },
+    } as never);
+    const products = ((res as { data?: { data?: unknown } }).data?.data ??
+      []) as Array<{ attributes?: { commodity_type?: string } }>;
+    if (products.some((p) => p?.attributes?.commodity_type === "physical")) {
+      return true;
+    }
+    if (products.length < ids.length) {
+      // The lookup succeeded but didn't return every requested product, so we
+      // can't prove the cart is all-digital. Fail CLOSED — require shipping
+      // rather than risk a physical line we couldn't classify. (Note: this is
+      // a healthy-but-incomplete response; a *total* lookup failure still fails
+      // open in the catch below, to keep a digital store available.)
+      log.warn(
+        "Shippability lookup resolved fewer products than requested; requiring shipping",
+        {
+          requested: ids.length,
+          resolved: products.length,
+        } as Record<string, unknown>
+      );
+      return true;
+    }
+    return false;
+  } catch (err) {
+    log.error("Shippability lookup failed — proceeding without it", {
+      error: err instanceof Error ? err.message : String(err),
+    } as Record<string, unknown>);
+    return false;
+  }
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/custom-attributes-allowlist.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/custom-attributes-allowlist.ts
@@ -1,0 +1,68 @@
+/**
+ * Allow-list enforcement for client-supplied checkout custom attributes.
+ *
+ * `customAttributes` are the non-reserved extra fields + consent flags a
+ * checkout form collects. They are written to the cart's `custom_attributes`
+ * and forwarded to the order's flow fields. EP persists any slug its flow
+ * defines, so without a gate a client could set ANY defined order-flow slug —
+ * including consent/audit/system fields the form never exposes — simply by
+ * sending it through `updateSession`. This module is the server-side gate:
+ * only keys the consumer explicitly allow-lists survive.
+ *
+ * Fail closed: with no allow-list configured, NO custom attributes are
+ * accepted. A consumer that intends to accept arbitrary keys must opt in
+ * explicitly with the `"*"` sentinel — so permissive behaviour is a
+ * deliberate, greppable choice, never an accident.
+ *
+ * Enforced at two layers: the `updateSession` boundary (reject forged keys on
+ * entry, keep the session clean) and defensively in the `/pay` handler right
+ * before the privileged admin-token writes (the trust boundary for what
+ * actually reaches EP). A single helper keeps the two in lockstep.
+ */
+import type { CustomAttributeAllowList } from "./types";
+
+export interface FilteredCustomAttributes {
+  /** Keys that passed the allow-list. `undefined` when nothing remains. */
+  allowed: Record<string, string | number | boolean> | undefined;
+  /**
+   * Keys that were rejected — surfaced so the caller can log a keys-only
+   * warning. NEVER log the dropped values (they may be PII).
+   */
+  dropped: string[];
+}
+
+/**
+ * Filter a customAttributes map down to the keys the allow-list permits.
+ *
+ * - empty / absent input → nothing to do
+ * - `"*"` → pass everything through (explicit opt-out)
+ * - a list → keep listed keys, report the rest as dropped
+ * - `undefined` list → fail closed (drop everything, report all as dropped)
+ */
+export function filterAllowedCustomAttributes(
+  attrs: Record<string, string | number | boolean> | undefined,
+  allowList: CustomAttributeAllowList | undefined
+): FilteredCustomAttributes {
+  if (!attrs || Object.keys(attrs).length === 0) {
+    return { allowed: undefined, dropped: [] };
+  }
+  if (allowList === "*") {
+    return { allowed: attrs, dropped: [] };
+  }
+
+  const permitted = new Set(allowList ?? []);
+  const allowed: Record<string, string | number | boolean> = {};
+  const dropped: string[] = [];
+  for (const [key, value] of Object.entries(attrs)) {
+    if (permitted.has(key)) {
+      allowed[key] = value;
+    } else {
+      dropped.push(key);
+    }
+  }
+
+  return {
+    allowed: Object.keys(allowed).length > 0 ? allowed : undefined,
+    dropped,
+  };
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/types.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/checkout/session/types.ts
@@ -135,6 +135,15 @@ export interface CheckoutSession {
   expiresAt: number; // epoch ms
 }
 
+/**
+ * Allow-list of customAttribute keys a checkout may accept from the client.
+ * Either an explicit list of permitted keys, or the `"*"` sentinel to accept
+ * any key. Omitting it entirely fails closed (no custom attributes persist) —
+ * permissive behaviour must be opted into deliberately via `"*"`. See
+ * `filterAllowedCustomAttributes`.
+ */
+export type CustomAttributeAllowList = readonly string[] | "*";
+
 // ---------------------------------------------------------------------------
 // PaymentAdapter — implemented per gateway (Clover, Stripe)
 // ---------------------------------------------------------------------------
@@ -237,6 +246,20 @@ export interface SessionHandlerContext {
    * Never cached across requests.
    */
   getClientCredentialsToken?: () => Promise<string>;
+  /**
+   * Server-side allow-list of customAttribute keys this checkout may accept
+   * from the client (the non-reserved form fields + consent flags). EP
+   * persists any order-flow slug its flow defines, so without this gate a
+   * client could forge/overwrite ANY defined slug — including consent/audit
+   * fields the form never exposes — simply by sending it.
+   *
+   * Fail closed: when omitted, NO custom attributes are persisted. A consumer
+   * that intends to accept arbitrary keys must opt in explicitly with the
+   * `"*"` sentinel, so permissive behaviour is a deliberate, greppable choice.
+   * Reserved customer/billing/shipping fields travel a separate path and are
+   * unaffected.
+   */
+  allowedCustomAttributeKeys?: CustomAttributeAllowList;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Payment-integrity hardening for the composable checkout (#369, #325)

Server-authoritative integrity fixes in the checkout-session pipeline, built **test-first** and housed in a new **security regression suite** — the designated home for checkout integrity, token-leak, and no-PII assertions. Guiding principle throughout: the server is the sole authority; treat absence as a threat and **fail closed**.

### Fixes

- **Free-vs-paid (money bug).** `handlePay` decided free-vs-paid from an `orderTotal` that fell back to *summing parsed cart items* when the authoritative `meta.display_price` total was absent — a paid cart whose items didn't parse summed to `0` and settled via the `manual` gateway with **no charge** (latent: a parse failure present at both session-create and pay hashes identically, so the cart-hash 409 guard never fires). Now settles free **only** on an authoritative `cartMetaTotal === 0`; the summing fallback is removed; an absent total fails closed to the paid path. A genuine zero-total cart (meta present, `=== 0`) still settles free.

- **Order-fields allow-list.** `customAttributes` are written to the cart and forwarded to the order's flow fields, where EP persists any defined slug — so a client could forge/overwrite **any defined order-flow slug** (consent flags, internal/audit fields the form never exposes) via `session.customAttributes`. Added a server-side allow-list (`allowedCustomAttributeKeys: string[] | "*"` on the checkout context), enforced at **two layers** — the `updateSession` boundary and again before the privileged EP writes. **Fail closed** when unset (no extras persist); the `"*"` sentinel is an explicit, greppable permissive opt-out. Dropped keys are logged keys-only (never values).

- **`confirmOrder` reconciliation.** After a paid order is created, `confirmOrder` syncs the gateway payment status onto the EP order. The customer is already charged, yet a failure was swallowed as a `warn` and reported as a clean success — leaving a charged-but-unreconciled order with no trace; it also passed `paymentID` through even when `undefined`. Now verifies a real `paymentID` before calling; on a missing id or failure, logs at `error`, sets a durable `needsReconciliation` marker on the session and a `reconciliationPending` response flag. The order still completes (payment genuinely succeeded), but the gap is discoverable.

- **Server-authoritative `requiresShipping`.** `requiresShipping` was a client flag, and the body builder defaults a missing shipping address to billing — so a client could set `requiresShipping:false` on a **physical** cart and have the goods ship to billing silently. (Verified against a live store: EP requires a shipping address on *every* checkout — digital included — so EP can't be the authority, and shippability isn't on the cart item; `commodity_type` is on the product.) Now infers the requirement from the cart's product `commodity_type` (batched lookup, run **only** when the client suppressed shipping); the client flag may only **add** a requirement, never suppress one a physical cart imposes. Fails **open** on a total lookup error (availability for digital stores), **closed** on a partial resolution.

### Also in the security suite (additive, no behaviour change)
- Token-leak assertions across **all** checkout-session routes, including the order-custom-fields write and the free-order branch (admin/shopper tokens never reflect into a response).
- A no-PII logger-spy assertion (customAttributes values and customer contact details are never logged).

### Tests
Full `elastic-path` jest suite green — **118 suites / 1882 tests**. Production files type-clean.

### Follow-up
A consumer using the managed-form checkout must now declare its `allowedCustomAttributeKeys` (the keys its form collects) or extras silently stop persisting — intended fail-closed behaviour, a small wiring step on the consumer side.

Branch off the merged composable-checkout work (`a0b5846e7`, #368).
