### PR TITLE
fix(ep-commerce): cart drawer/trigger/popover read cart via proxy useEpCart

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawer.tsx
@@ -7,7 +7,7 @@ import registerComponent, {
 } from "@plasmicapp/host/registerComponent";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
-import useCart from "../cart/use-cart";
+import { useEpCart } from "../cart-provider/use-ep-cart";
 import {
   CART_BACKDROP_Z_INDEX,
   CART_OVERLAY_Z_INDEX,
@@ -205,7 +205,7 @@ export function EPCartDrawer(props: EPCartDrawerProps) {
     inline = false,
   } = props;
 
-  const { data: cart, error: cartError } = useCart();
+  const { cart, error: cartError } = useEpCart();
   const { providerRef } = useCommerce();
   const currencyDisplay = providerRef?.current?.currencyDisplay ?? "symbol";
   const inEditor = !!usePlasmicCanvasContext();

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawerTrigger.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartDrawerTrigger.tsx
@@ -6,7 +6,7 @@ import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
 import React from "react";
-import useCart from "../cart/use-cart";
+import { useEpCart } from "../cart-provider/use-ep-cart";
 import { Registerable } from "../registerable";
 import { MOCK_CART_LINE_ITEMS } from "../utils/design-time-data";
 import { useDrawerOpen, setDrawerOpen } from "./CartDrawerContext";
@@ -63,7 +63,7 @@ export function EPCartDrawerTrigger(props: EPCartDrawerTriggerProps) {
     previewState = "auto",
   } = props;
 
-  const { data: cart } = useCart();
+  const { cart } = useEpCart();
   const inEditor = !!usePlasmicCanvasContext();
   const [isOpen] = useDrawerOpen();
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartPopover.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartPopover.tsx
@@ -6,7 +6,7 @@ import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import useCart from "../cart/use-cart";
+import { useEpCart } from "../cart-provider/use-ep-cart";
 import { useCommerce } from "../elastic-path";
 import { Registerable } from "../registerable";
 import { deriveCartData } from "../utils/cart-data";
@@ -171,7 +171,7 @@ export function EPCartPopover(props: EPCartPopoverProps) {
     previewState = "auto",
   } = props;
 
-  const { data: cart, error: cartError } = useCart();
+  const { cart, error: cartError } = useEpCart();
   const { providerRef } = useCommerce();
   const currencyDisplay = providerRef?.current?.currencyDisplay ?? "symbol";
   const inEditor = !!usePlasmicCanvasContext();

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
@@ -17,10 +17,23 @@
 
 // --- Mocks (hoisted by Jest before any other code) ---
 
+// Cart data flows through the proxy-backed `useEpCart` hook (shared "ep-cart"
+// SWR key). Tests still configure `mockUseCart` with the SWR-style
+// `{ data, error }` shape; the mock maps it to useEpCart's
+// `{ cart, isLoading, error, refresh }` return so the ~18 call sites are
+// unchanged.
 const mockUseCart = jest.fn();
-jest.mock("../../cart/use-cart", () => ({
+jest.mock("../../cart-provider/use-ep-cart", () => ({
   __esModule: true,
-  default: mockUseCart,
+  useEpCart: () => {
+    const r = mockUseCart() ?? {};
+    return {
+      cart: r.data ?? null,
+      isLoading: !r.data && !r.error,
+      error: r.error ?? null,
+      refresh: jest.fn(),
+    };
+  },
 }));
 
 const mockUseUpdateItem = jest.fn();


### PR DESCRIPTION
Closes #380.

`EPCartDrawer`, `EPCartDrawerTrigger`, and `EPCartPopover` read the cart via the deprecated `cart/use-cart` hook, which fetches directly from Elastic Path with a browser-side SDK client. In an app-host storefront the client secret never reaches the browser, so that hook can't fetch — these components render permanently empty even when the cart has items.

`EPAddToCartButton` and `EPCartProvider` were migrated to the proxy-backed `useEpCart()` (server route `/api/ep/proxy/getCart`, shared SWR key `"ep-cart"`) in #300; the drawer family was never re-pointed, so the add button mutated one cache while the drawer read a different, non-functional one.

## Change
- Re-point the three components from `../cart/use-cart` to `useEpCart()` (`../cart-provider/use-ep-cart`), destructuring `.cart` (same normalized `Cart` shape as the old hook's `.data`).
- Update the drawer test suite to mock `useEpCart` — 111/111 pass.

## Verification
Built the package and ran an app-host storefront against a real store: Add to Cart → trigger count and drawer contents update (item, price, qty control, total). Previously "Cart (0)" / "Your cart is empty" regardless of state.

## Follow-ups (tracked in #380)
- Add the add→drawer Playwright e2e that was deferred in #300.
- Retire the deprecated `cart/use-cart` once nothing depends on it.