### PR TITLE
fix(cm-cors): apply cmCors to teams and project-meta routes

### DIFF
--- a/platform/wab/src/wab/server/AppServer.ts
+++ b/platform/wab/src/wab/server/AppServer.ts
@@ -725,6 +725,8 @@ function addOptionsRoutes(app: express.Application) {
   app.options("/api/v1/workspaces", cmCorsPreflight());
   app.options("/api/v1/workspaces/*", cmCorsPreflight());
   app.options("/api/v1/personal-workspace", cmCorsPreflight());
+  app.options("/api/v1/teams", cmCorsPreflight());
+  app.options("/api/v1/teams/*", cmCorsPreflight());
 
   // Data sources CORS preflight handlers for Commerce Manager
   app.options("/api/v1/data-source/sources", cmCorsPreflight());
@@ -1587,6 +1589,7 @@ export function addMainAppServerRoutes(
   );
   app.get(
     "/api/v1/projects/:projectId/meta",
+    cmCors,
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
     getProjectMeta
   );
@@ -1696,6 +1699,7 @@ export function addMainAppServerRoutes(
   );
   app.get(
     "/api/v1/teams/:teamId",
+    cmCors,
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
     teamRoutes.getTeamById
   );
@@ -1710,7 +1714,7 @@ export function addMainAppServerRoutes(
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),
     teamRoutes.getTeamWorkspaces
   );
-  app.put("/api/v1/teams/:teamId", withNext(teamRoutes.updateTeam));
+  app.put("/api/v1/teams/:teamId", cmCors, withNext(teamRoutes.updateTeam));
   app.delete(
     "/api/v1/teams/:teamId",
     safeCast<RequestHandler>(authRoutes.teamApiUserAuth),

--- a/platform/wab/src/wab/server/__tests__/ep-fork-integrity.spec.ts
+++ b/platform/wab/src/wab/server/__tests__/ep-fork-integrity.spec.ts
@@ -144,6 +144,20 @@ describe("EP Fork Integrity", () => {
       expect(appServer).toContain("cmCors");
       expect(appServer).toContain("customEPCCCookieAuth");
     });
+
+    // CM reads/writes these for the Visual Builder config surfaces; without
+    // cmCors they fall back to wildcard CORS and break credentialed requests.
+    it("applies cmCors to the CM-called teams and project-meta routes", () => {
+      const appServer = readFile(
+        "platform/wab/src/wab/server/AppServer.ts"
+      );
+      expect(appServer).toContain('app.options("/api/v1/teams"');
+      expect(appServer).toContain('app.options("/api/v1/teams/*"');
+      expect(appServer).toMatch(/"\/api\/v1\/teams\/:teamId",\s*cmCors/);
+      expect(appServer).toMatch(
+        /"\/api\/v1\/projects\/:projectId\/meta",\s*cmCors/
+      );
+    });
   });
 
   describe("EP grant-revoke email bypass", () => {


### PR DESCRIPTION
## Problem
Commerce Manager reads/writes the visual builder `uiConfig` via `GET`/`PUT /api/v1/teams/:teamId` (org scope) and `GET /api/v1/projects/:projectId/meta` (project scope). These routes were registered **without** the `cmCors` middleware, so they fell back to wildcard CORS (`Access-Control-Allow-Origin: *`), which the browser rejects for credentialed requests. Result in-region (e.g. euwest): "CORS request did not succeed" and the CM Visual Builder config page can't load or save.

Other CM→Plasmic calls (`projects`, `workspaces`, `hosts`, `auth`, …) work because they already carry `cmCors`; `teams` was simply never wired up — CM's config surface is its first-ever caller.

## Fix
- Add `cmCors` to `GET`/`PUT /api/v1/teams/:teamId` and to `GET /api/v1/projects/:projectId/meta`, plus `/api/v1/teams` and `/api/v1/teams/*` preflights — mirroring the existing `projects`/`workspaces` registrations (`cmCors` first, before `teamApiUserAuth`).
- The project-meta `PUT` and all `workspaces` routes already had `cmCors` (no change).
- Extend `ep-fork-integrity.spec.ts` to assert `teams` + `project-meta` carry `cmCors` so this can't regress.

## Test
`ep-fork-integrity.spec.ts` + `cm-cors.spec.ts` pass (35 tests).