### PR TITLE
chore(plasmic-mcp): build, verify, and release the .mcpb from CI

### DIFF
--- a/.github/workflows/plasmic-mcp.yml
+++ b/.github/workflows/plasmic-mcp.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'packages/plasmic-mcp/**'
       - '.github/workflows/plasmic-mcp.yml'
+    tags:
+      - 'plasmic-mcp-v*'
   pull_request:
     branches: [master]
     paths:
@@ -17,6 +19,10 @@ jobs:
   test-and-build:
     name: Test & Build
     runs-on: ubuntu-latest
+
+    # Needed only by the release step, which runs on plasmic-mcp-v* tags.
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -45,6 +51,20 @@ jobs:
           rm -f src/wab/shared/model/classes-metas.ts
           make
 
+      - name: Verify manifest version matches package.json
+        working-directory: packages/plasmic-mcp
+        # Claude Desktop reads manifest.json, npm ships it too. If it drifts
+        # behind package.json every build claims the same version and there is
+        # no way to tell which code a user has installed.
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          MANIFEST=$(node -p "require('./manifest.json').version")
+          echo "package.json=$PKG manifest.json=$MANIFEST"
+          if [ "$PKG" != "$MANIFEST" ]; then
+            echo "::error::manifest.json version ($MANIFEST) != package.json ($PKG). Update manifest.json."
+            exit 1
+          fi
+
       - name: TypeScript type-check
         working-directory: packages/plasmic-mcp
         run: npx tsc --noEmit
@@ -72,12 +92,64 @@ jobs:
             echo "::warning::Bundle size ${SIZE_KB}KB exceeds 2MB target"
           fi
 
+      - name: Pack .mcpb extension
+        working-directory: packages/plasmic-mcp
+        # build.mjs already ran above, so only the packaging step is needed.
+        run: node build-mcpb.mjs
+
+      - name: Smoke-test packed .mcpb
+        working-directory: packages/plasmic-mcp
+        # Boots the packed server exactly as Claude Desktop does and asserts the
+        # handshake plus full tool surface. Guards against publishing a bundle
+        # whose staged dependency install came up short.
+        run: node smoke-mcpb.mjs dist/visual-builder.mcpb 10
+
+      - name: Report .mcpb size
+        working-directory: packages/plasmic-mcp
+        run: |
+          SIZE=$(stat -c%s dist/visual-builder.mcpb 2>/dev/null || stat -f%z dist/visual-builder.mcpb)
+          VERSION=$(node -p "require('./package.json').version")
+          echo "| .mcpb version | $VERSION |" >> $GITHUB_STEP_SUMMARY
+          echo "| .mcpb size | $((SIZE / 1024 / 1024))MB |" >> $GITHUB_STEP_SUMMARY
+          echo "| .mcpb sha256 | $(sha256sum dist/visual-builder.mcpb | cut -d' ' -f1) |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload .mcpb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-builder-mcpb
+          path: packages/plasmic-mcp/dist/visual-builder.mcpb
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/plasmic-mcp-v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: packages/plasmic-mcp
+        # Private distribution has no auto-update: users reinstall manually, so
+        # the release page is the only place they can find the current build.
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [ "${GITHUB_REF_NAME}" != "plasmic-mcp-v${VERSION}" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match package.json version ${VERSION}"
+            exit 1
+          fi
+          cp dist/visual-builder.mcpb "dist/visual-builder-${VERSION}.mcpb"
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "Plasmic MCP v${VERSION}" \
+            --notes "Claude Desktop extension. Install by double-clicking the \`.mcpb\`, then set your Visual Builder host, email, and API token.
+
+          For Claude Code and Cursor use the npm package instead: \`npx @elasticpath/plasmic-mcp\`.
+
+          sha256: \`$(sha256sum dist/visual-builder.mcpb | cut -d' ' -f1)\`" \
+            "dist/visual-builder-${VERSION}.mcpb"
+
       - name: Test Summary
         if: always()
         run: |
           echo "### Plasmic MCP Results" >> $GITHUB_STEP_SUMMARY
           if [ "${{ job.status }}" == "success" ]; then
-            echo "Type-check, tests, and build all passed." >> $GITHUB_STEP_SUMMARY
+            echo "Type-check, tests, build, and .mcpb smoke test all passed." >> $GITHUB_STEP_SUMMARY
           else
             echo "Some checks failed." >> $GITHUB_STEP_SUMMARY
           fi

--- a/packages/plasmic-mcp/build-mcpb.mjs
+++ b/packages/plasmic-mcp/build-mcpb.mjs
@@ -8,6 +8,11 @@
  * - package.json (for npm install --production)
  *
  * Then packs it into a .mcpb file using @anthropic-ai/mcpb.
+ *
+ * package.json is the single source of truth for the version. Claude Desktop
+ * reads manifest.json, so a manifest version that drifts behind package.json
+ * makes every build claim the same version and leaves no way to tell which
+ * code a user has installed.
  */
 
 import { execSync } from "child_process";
@@ -22,10 +27,27 @@ const staging = path.resolve(__dirname, "dist/mcpb-staging");
 fs.rmSync(staging, { recursive: true, force: true });
 fs.mkdirSync(path.join(staging, "server"), { recursive: true });
 
-// Copy manifest
-fs.copyFileSync(
-  path.resolve(__dirname, "manifest.json"),
-  path.join(staging, "manifest.json")
+// Copy the manifest, taking the version from package.json.
+const pkgVersion = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "package.json"), "utf-8")
+).version;
+const manifest = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "manifest.json"), "utf-8")
+);
+
+if (manifest.version !== pkgVersion) {
+  // npm ships manifest.json too (see the `files` field), so the committed copy
+  // must be corrected as well — the staged override only fixes the .mcpb.
+  console.warn(
+    `⚠ manifest.json version ${manifest.version} != package.json ${pkgVersion}; ` +
+      `using ${pkgVersion}. Update manifest.json to match.`
+  );
+}
+manifest.version = pkgVersion;
+
+fs.writeFileSync(
+  path.join(staging, "manifest.json"),
+  JSON.stringify(manifest, null, 2) + "\n"
 );
 
 // Copy built server bundle (without shebang — Claude Desktop runs it via node directly)
@@ -46,22 +68,6 @@ execSync("npm install --omit=dev --ignore-scripts --no-optional --legacy-peer-de
   stdio: "pipe",
 });
 
-// Remove devDependencies artifacts and unnecessary files to reduce size
-const nmPath = path.join(staging, "node_modules");
-const cleanPatterns = [
-  "**/.github",
-  "**/test",
-  "**/tests",
-  "**/__tests__",
-  "**/docs",
-  "**/example",
-  "**/examples",
-  "**/*.map",
-  "**/*.ts.map",
-  "**/CHANGELOG.md",
-  "**/HISTORY.md",
-];
-
 // Remove package.json from staging (not needed in final bundle)
 fs.unlinkSync(path.join(staging, "package.json"));
 // Remove package-lock.json if created
@@ -78,4 +84,4 @@ execSync(`npx @anthropic-ai/mcpb pack "${staging}" "${output}"`, {
 // Clean staging
 fs.rmSync(staging, { recursive: true, force: true });
 
-console.log(`\n✓ Built ${output}`);
+console.log(`\n✓ Built ${output} (version ${pkgVersion})`);

--- a/packages/plasmic-mcp/manifest.json
+++ b/packages/plasmic-mcp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Visual Builder",
-  "version": "0.1.7",
+  "version": "0.2.2",
   "description": "Edit Visual Builder projects with AI — design, build, and manage pages, components, and design systems.",
   "author": {
     "name": "Elastic Path"

--- a/packages/plasmic-mcp/package.json
+++ b/packages/plasmic-mcp/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node build.mjs",
     "build:mcpb": "node build.mjs && node build-mcpb.mjs",
+    "smoke:mcpb": "node smoke-mcpb.mjs dist/visual-builder.mcpb",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",

--- a/packages/plasmic-mcp/smoke-mcpb.mjs
+++ b/packages/plasmic-mcp/smoke-mcpb.mjs
@@ -1,0 +1,133 @@
+/**
+ * Smoke-test a packed .mcpb before it is published.
+ *
+ * Unpacks the bundle and drives the packed server over stdio the way Claude
+ * Desktop does — bare `node server/index.cjs`, no TTY, nothing resolvable
+ * outside the bundle. Asserts the handshake completes and every tool is
+ * registered.
+ *
+ * This catches the failure that shipping an unverified bundle hides: the
+ * bundle externalises its npm dependencies, so a staging install that missed
+ * a package produces a server that dies on require, or starts but cannot
+ * serve tools. Both look fine from `mcpb pack`.
+ *
+ * No credentials needed — the server starts unauthenticated and still
+ * registers its full tool surface.
+ *
+ * Usage: node smoke-mcpb.mjs dist/visual-builder.mcpb [expectedToolCount]
+ */
+
+import { execSync, spawn } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const mcpbPath = path.resolve(process.argv[2] ?? "dist/visual-builder.mcpb");
+const expectedTools = Number(process.argv[3] ?? 10);
+
+if (!fs.existsSync(mcpbPath)) {
+  console.error(`✗ no bundle at ${mcpbPath}`);
+  process.exit(1);
+}
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpb-smoke-"));
+const fail = (msg) => {
+  console.error(`✗ ${msg}`);
+  fs.rmSync(workDir, { recursive: true, force: true });
+  process.exit(1);
+};
+
+execSync(`unzip -q "${mcpbPath}" -d "${workDir}"`);
+
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(workDir, "manifest.json"), "utf-8")
+);
+const entry = path.join(workDir, "server/index.cjs");
+if (!fs.existsSync(entry)) fail("bundle has no server/index.cjs");
+
+console.log(`smoke-testing ${manifest.name} v${manifest.version}`);
+
+// Deliberately bare: cwd inside the bundle, so anything the server needs must
+// be present in the bundle itself.
+const child = spawn("node", [entry], {
+  cwd: workDir,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+const stderr = [];
+child.stderr.on("data", (d) => stderr.push(d.toString()));
+
+let buf = "";
+let settled = false;
+
+const finish = (ok, msg) => {
+  if (settled) return;
+  settled = true;
+  try {
+    child.kill("SIGKILL");
+  } catch {}
+  if (ok) {
+    console.log(`✓ ${msg}`);
+    fs.rmSync(workDir, { recursive: true, force: true });
+    process.exit(0);
+  }
+  if (stderr.length) console.error(stderr.join("").trim().slice(-2000));
+  fail(msg);
+};
+
+child.on("exit", (code, signal) => {
+  if (!settled) finish(false, `server exited early (code=${code} signal=${signal})`);
+});
+
+child.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  let idx;
+  while ((idx = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, idx);
+    buf = buf.slice(idx + 1);
+    if (!line.trim()) continue;
+
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      // stdout is the JSON-RPC transport; anything else on it corrupts the stream.
+      return finish(false, `non-JSON on stdout: ${line.slice(0, 200)}`);
+    }
+
+    if (msg.id === 0) {
+      if (msg.error) return finish(false, `initialize failed: ${JSON.stringify(msg.error)}`);
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    }
+
+    if (msg.id === 1) {
+      if (msg.error) return finish(false, `tools/list failed: ${JSON.stringify(msg.error)}`);
+      const tools = msg.result?.tools ?? [];
+      if (tools.length < expectedTools) {
+        return finish(
+          false,
+          `expected >=${expectedTools} tools, got ${tools.length}: ${tools.map((t) => t.name).join(",")}`
+        );
+      }
+      return finish(true, `v${manifest.version}: handshake ok, ${tools.length} tools registered`);
+    }
+  }
+});
+
+function send(obj) {
+  child.stdin.write(JSON.stringify(obj) + "\n");
+}
+
+send({
+  jsonrpc: "2.0",
+  id: 0,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-11-25",
+    capabilities: {},
+    clientInfo: { name: "mcpb-smoke", version: "1.0.0" },
+  },
+});
+
+setTimeout(() => finish(false, "timed out waiting for handshake"), 60000);


### PR DESCRIPTION
## Problem

The Claude Desktop `.mcpb` has never had a distribution channel — no releases, no CI packaging, bundles packed by hand. Two gaps kept a stale artifact installed for four months undetected:

1. `manifest.json` carries its own version and had drifted three releases behind `package.json`, so every bundle built since April declared `0.1.7` regardless of contents.
2. Nothing ever booted a packed bundle. The esbuild output externalises all 66 npm deps, so a short staged install passes `mcpb pack` and then dies on `require`.

## Changes

- Derive the manifest version from `package.json` at pack time; guard parity in CI. Bump `manifest.json` `0.1.7` → `0.2.2`.
- Add `smoke-mcpb.mjs` — unpacks the bundle and boots the packed server as Desktop does (bare `node`, cwd inside the bundle), asserting the handshake and full tool surface. No credentials needed.
- CI packs, smoke-tests and uploads the `.mcpb` on every run, and attaches it to a release on `plasmic-mcp-v*` tags.
- Remove a dead `cleanPatterns` block that claimed to trim bundle size and never ran.

## Verification

Build produces `0.2.2`; smoke test passes on a good bundle and **fails** on one with `@modelcontextprotocol/sdk` removed; `manifest.test.ts` 7/7; the artifact loads a real 33-component project in 4.4s.

Release: bump both versions, then `git tag plasmic-mcp-v0.2.3 && git push origin plasmic-mcp-v0.2.3`.