### PR TITLE
Security: production-guards batch — consolidates the six mechanical #279 fixes

### DIFF
--- a/examples/ep-commerce-app-router/.env.local.example
+++ b/examples/ep-commerce-app-router/.env.local.example
@@ -1,8 +1,14 @@
 # EP Commerce credentials (same values as configured in Plasmic Studio EP Provider)
+# The Studio EP Provider global context WINS for shopper auth — these are the
+# fallback. EP_CLIENT_ID must match what Studio has, or checkout's admin calls
+# authenticate as a different client than the shopper session.
 EP_CLIENT_ID=your-ep-client-id
 EP_HOST=https://useast.api.elasticpath.com
 
-# Checkout session encryption key (min 16 characters)
+# Session secret. Doubles as the better-auth JWE key and the checkout-session
+# HMAC key. REQUIRED in production: the package refuses to serve on a missing
+# secret, a known example placeholder, or fewer than 32 characters. Outside
+# production it warns instead.
 CHECKOUT_SESSION_SECRET=your-32-char-secret-key-here
 
 # EP client_credentials secret — REQUIRED for checkout / payments.
@@ -13,3 +19,21 @@ EP_CLIENT_SECRET=your-ep-client-secret
 # Stripe publishable key — exposed to the browser via the StripeProvider
 # global context. NOT a secret; safe to ship in client bundles.
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key
+
+# --- Optional ---
+
+# Public origin of this app. Seeds the trusted-origin list, which drives both
+# proxy CORS and the origin gate. Set it whenever you serve on anything other
+# than http://localhost:3456, or cart mutations get rejected as cross-origin.
+# NEXT_PUBLIC_BASE_URL=https://shop.example.com
+
+# Extra origins permitted to act as the shopper. One list feeds auth, proxy
+# CORS and the origin gate (ADR-0001) — this is how you let Plasmic Studio's
+# cross-origin preview drive the cart.
+# BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3003
+
+# Comma-separated host patterns the EP API may be reached at. Defaults to
+# Elastic Path Composable Commerce regions plus the integration host, with
+# loopback allowed outside production. Elastic Path Self Managed Commerce
+# deployments must list their own host here.
+# EP_HOST_ALLOWLIST=commerce.internal.example

--- a/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
+++ b/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
@@ -46,8 +46,6 @@ export default async function PlasmicLoaderPage({
     ),
   });
 
-  // No cookie writes here: Next forbids them in plain RSC pages, so session
-  // bootstrap belongs to `epAuthMiddleware`, which runs before this page.
 
   // ---------------------------------------------------------------------------
   // Build EP session context + run Studio Server Queries (PRD #262 / #272)

--- a/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
+++ b/examples/ep-commerce-app-router/app/[[...catchall]]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
 import { notFound } from "next/navigation";
 import { cookies } from "next/headers";
-import { epAuth } from "@/lib/ep-auth";
+import { epAuth, EP_HOST_ALLOWLIST } from "@/lib/ep-auth";
 
 export const revalidate = 60;
 
@@ -46,22 +46,8 @@ export default async function PlasmicLoaderPage({
     ),
   });
 
-  // Next 15 forbids cookie writes in plain RSC pages. Swallow — the
-  // `/api/ep/*` handler persists cookies on the next request.
-  try {
-    session.commitCookies({
-      appendHeader(_name: string, value: string) {
-        const [nameVal] = value.split(";");
-        const [cookieName, ...rest] = nameVal.split("=");
-        cookieStore.set(cookieName.trim(), rest.join("=").trim(), {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-          maxAge: 2592000,
-        });
-      },
-    });
-  } catch {}
+  // No cookie writes here: Next forbids them in plain RSC pages, so session
+  // bootstrap belongs to `epAuthMiddleware`, which runs before this page.
 
   // ---------------------------------------------------------------------------
   // Build EP session context + run Studio Server Queries (PRD #262 / #272)
@@ -72,6 +58,7 @@ export default async function PlasmicLoaderPage({
       cartId: session.cart?.id ?? undefined,
       accountId: session.user?.accountId ?? undefined,
     },
+    hostAllowlist: EP_HOST_ALLOWLIST,
   });
 
   const queryCtx = {

--- a/examples/ep-commerce-app-router/app/api/plasmic-registry/route.ts
+++ b/examples/ep-commerce-app-router/app/api/plasmic-registry/route.ts
@@ -7,19 +7,7 @@ import {
 
 // Re-register with captured PLASMIC so host's registration functions
 // populate globalThis registries (the server loader's are noops).
-//
-// `withRegistryCapture` describes a loader with `unknown`-parameter function
-// properties, which the real loader's generic `registerComponent` cannot
-// satisfy under `strictFunctionTypes` — the parameters are checked
-// contravariantly. The capture wrapper only proxies calls and returns the
-// same object, so the shapes agree at runtime. Casting at this boundary
-// keeps the mismatch local; the durable fix is for the registry package to
-// declare those members as methods (bivariant) or with `any` parameters.
-const capturedPlasmic = withRegistryCapture(
-  PLASMIC as unknown as Parameters<typeof withRegistryCapture>[0]
-) as unknown as typeof PLASMIC;
-
-registerAllPackages(capturedPlasmic);
+registerAllPackages(withRegistryCapture(PLASMIC));
 
 export function GET() {
   try {

--- a/examples/ep-commerce-app-router/app/api/plasmic-registry/route.ts
+++ b/examples/ep-commerce-app-router/app/api/plasmic-registry/route.ts
@@ -7,7 +7,19 @@ import {
 
 // Re-register with captured PLASMIC so host's registration functions
 // populate globalThis registries (the server loader's are noops).
-registerAllPackages(withRegistryCapture(PLASMIC));
+//
+// `withRegistryCapture` describes a loader with `unknown`-parameter function
+// properties, which the real loader's generic `registerComponent` cannot
+// satisfy under `strictFunctionTypes` — the parameters are checked
+// contravariantly. The capture wrapper only proxies calls and returns the
+// same object, so the shapes agree at runtime. Casting at this boundary
+// keeps the mismatch local; the durable fix is for the registry package to
+// declare those members as methods (bivariant) or with `any` parameters.
+const capturedPlasmic = withRegistryCapture(
+  PLASMIC as unknown as Parameters<typeof withRegistryCapture>[0]
+) as unknown as typeof PLASMIC;
+
+registerAllPackages(capturedPlasmic);
 
 export function GET() {
   try {

--- a/examples/ep-commerce-app-router/lib/checkout-context.ts
+++ b/examples/ep-commerce-app-router/lib/checkout-context.ts
@@ -21,8 +21,6 @@ import {
 import { cookies } from "next/headers";
 import { epAuth, getEpProviderConfig } from "./ep-auth";
 
-// No fallback: in production this throws rather than encrypting checkout
-// sessions under a value that shipped in public example code.
 const SESSION_SECRET = resolveAuthSecret(process.env.CHECKOUT_SESSION_SECRET, {
   label: "CHECKOUT_SESSION_SECRET",
 });
@@ -48,7 +46,6 @@ export async function buildCheckoutContext(
     process.env.EP_HOST ??
     "https://useast.api.elasticpath.com";
 
-  // The session lives in cookies; passing only headers reads nothing.
   const cookieStore = await cookies();
   const session = await epAuth.api
     .getSession({

--- a/examples/ep-commerce-app-router/lib/checkout-context.ts
+++ b/examples/ep-commerce-app-router/lib/checkout-context.ts
@@ -15,13 +15,16 @@ import {
   createAdapterRegistry,
   createClientCredentialsTokenResolver,
   createStripeAdapter,
+  resolveAuthSecret,
   type SessionHandlerContext,
 } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
 import { epAuth, getEpProviderConfig } from "./ep-auth";
 
-const SESSION_SECRET =
-  process.env.CHECKOUT_SESSION_SECRET ??
-  "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache";
+// No fallback: in production this throws rather than encrypting checkout
+// sessions under a value that shipped in public example code.
+const SESSION_SECRET = resolveAuthSecret(process.env.CHECKOUT_SESSION_SECRET, {
+  label: "CHECKOUT_SESSION_SECRET",
+});
 
 const sessionStore = new CookieSessionStore(SESSION_SECRET);
 

--- a/examples/ep-commerce-app-router/lib/checkout-context.ts
+++ b/examples/ep-commerce-app-router/lib/checkout-context.ts
@@ -48,10 +48,7 @@ export async function buildCheckoutContext(
     process.env.EP_HOST ??
     "https://useast.api.elasticpath.com";
 
-  // Read the better-auth session to pull shopper token + cart id.
-  // `cookies` is where the session actually lives — passing only `headers`
-  // (and a raw Headers object at that) meant this read nothing and
-  // bootstrapped a fresh anonymous session on every checkout request.
+  // The session lives in cookies; passing only headers reads nothing.
   const cookieStore = await cookies();
   const session = await epAuth.api
     .getSession({
@@ -62,10 +59,6 @@ export async function buildCheckoutContext(
     })
     .catch(() => null);
 
-  // Public EpSession shape: `session.session.accessToken` / `session.cart.id`.
-  // The `epAccessToken` / `epCartId` names are the internal better-auth
-  // fields and are never exposed here, so the previous `as any` reads were
-  // always undefined.
   const shopperAccessToken = session?.session?.accessToken ?? "";
   const epCartId = session?.cart?.id ?? null;
 

--- a/examples/ep-commerce-app-router/lib/checkout-context.ts
+++ b/examples/ep-commerce-app-router/lib/checkout-context.ts
@@ -18,6 +18,7 @@ import {
   resolveAuthSecret,
   type SessionHandlerContext,
 } from "@elasticpath/plasmic-ep-commerce-elastic-path/server";
+import { cookies } from "next/headers";
 import { epAuth, getEpProviderConfig } from "./ep-auth";
 
 // No fallback: in production this throws rather than encrypting checkout
@@ -47,14 +48,26 @@ export async function buildCheckoutContext(
     process.env.EP_HOST ??
     "https://useast.api.elasticpath.com";
 
-  // Read the better-auth session to pull shopper token + epCartId.
+  // Read the better-auth session to pull shopper token + cart id.
+  // `cookies` is where the session actually lives — passing only `headers`
+  // (and a raw Headers object at that) meant this read nothing and
+  // bootstrapped a fresh anonymous session on every checkout request.
+  const cookieStore = await cookies();
   const session = await epAuth.api
-    .getSession({ headers: request.headers })
+    .getSession({
+      cookies: Object.fromEntries(
+        cookieStore.getAll().map((c) => [c.name, c.value])
+      ),
+      headers: Object.fromEntries(request.headers.entries()),
+    })
     .catch(() => null);
 
-  const shopperAccessToken =
-    (session?.session as any)?.epAccessToken ?? "";
-  const epCartId = (session?.session as any)?.epCartId ?? null;
+  // Public EpSession shape: `session.session.accessToken` / `session.cart.id`.
+  // The `epAccessToken` / `epCartId` names are the internal better-auth
+  // fields and are never exposed here, so the previous `as any` reads were
+  // always undefined.
+  const shopperAccessToken = session?.session?.accessToken ?? "";
+  const epCartId = session?.cart?.id ?? null;
 
   // Per-request admin-token resolver. Built only when EP_CLIENT_SECRET is
   // present; absence cleanly disables admin-side EP calls (Stripe gateway

--- a/examples/ep-commerce-app-router/lib/ep-auth.ts
+++ b/examples/ep-commerce-app-router/lib/ep-auth.ts
@@ -20,19 +20,10 @@ import { PLASMIC } from "@/plasmic-init";
  *
  * Env vars consulted:
  *   - CHECKOUT_SESSION_SECRET — used as the better-auth JWE secret AND the
- *     checkout-session HMAC secret. Required in production: the package's
- *     production guard refuses to construct without it, so there is
- *     deliberately no fallback value here to copy into a deployment.
+ *     checkout-session HMAC secret. Required in production.
  */
 const SECRET = process.env.CHECKOUT_SESSION_SECRET;
 
-/**
- * Host patterns the EP API may be reached at. Defined once and passed to
- * every host check — `createBetterEpAuth`, `extractEpProviderConfig` and
- * `buildEpCtx` each apply it independently, so setting it in only one place
- * leaves the others on the package default. Elastic Path Self Managed
- * Commerce deployments set EP_HOST_ALLOWLIST to their own host.
- */
 export const EP_HOST_ALLOWLIST = process.env.EP_HOST_ALLOWLIST?.split(",")
   .map((h) => h.trim())
   .filter(Boolean);

--- a/examples/ep-commerce-app-router/lib/ep-auth.ts
+++ b/examples/ep-commerce-app-router/lib/ep-auth.ts
@@ -20,11 +20,22 @@ import { PLASMIC } from "@/plasmic-init";
  *
  * Env vars consulted:
  *   - CHECKOUT_SESSION_SECRET — used as the better-auth JWE secret AND the
- *     checkout-session HMAC secret. Required in production.
+ *     checkout-session HMAC secret. Required in production: the package's
+ *     production guard refuses to construct without it, so there is
+ *     deliberately no fallback value here to copy into a deployment.
  */
-const SECRET =
-  process.env.CHECKOUT_SESSION_SECRET ??
-  "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache";
+const SECRET = process.env.CHECKOUT_SESSION_SECRET;
+
+/**
+ * Host patterns the EP API may be reached at. Defined once and passed to
+ * every host check — `createBetterEpAuth`, `extractEpProviderConfig` and
+ * `buildEpCtx` each apply it independently, so setting it in only one place
+ * leaves the others on the package default. Elastic Path Self Managed
+ * Commerce deployments set EP_HOST_ALLOWLIST to their own host.
+ */
+export const EP_HOST_ALLOWLIST = process.env.EP_HOST_ALLOWLIST?.split(",")
+  .map((h) => h.trim())
+  .filter(Boolean);
 
 export const epAuth = createBetterEpAuth({
   clientId: "bootstrap-placeholder",
@@ -32,15 +43,13 @@ export const epAuth = createBetterEpAuth({
   secret: SECRET,
   baseURL: process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3456",
   basePath: "/api/ep",
+  hostAllowlist: EP_HOST_ALLOWLIST,
   resolveConfig: async () => {
     const config = await getEpProviderConfig();
     if (!config) return null;
     return { clientId: config.clientId, host: config.host };
   },
-  checkout: {
-    sessionSecret:
-      process.env.CHECKOUT_SESSION_SECRET ?? "dev-secret-min-16-chars",
-  },
+  ...(SECRET ? { checkout: { sessionSecret: SECRET } } : {}),
 });
 
 /**
@@ -62,7 +71,9 @@ export function getEpProviderConfig(): Promise<EpProviderBundleConfig | null> {
       const pages = await PLASMIC.fetchPages();
       if (pages.length === 0) return null;
       const data = await PLASMIC.maybeFetchComponentData(pages[0].path);
-      return extractEpProviderConfig(data);
+      return extractEpProviderConfig(data, {
+        hostAllowlist: EP_HOST_ALLOWLIST,
+      });
     })();
   }
   return _configPromise;

--- a/packages/plasmic-mcp-registry/src/capture.ts
+++ b/packages/plasmic-mcp-registry/src/capture.ts
@@ -32,9 +32,8 @@
  * Minimal interface for a PLASMIC-like object that has registration methods.
  * We don't import the full loader types to avoid a dependency on @plasmicapp/loader-*.
  *
- * Methods with `any` params, not properties with `unknown`: property syntax
- * is contravariant under `strictFunctionTypes`, so no real loader satisfied
- * the constraint.
+ * Methods with `any` params: property syntax is contravariant under
+ * strictFunctionTypes, which no real loader satisfies.
  */
 interface PlasmicLike {
   registerComponent(component: any, meta: any): void;

--- a/packages/plasmic-mcp-registry/src/capture.ts
+++ b/packages/plasmic-mcp-registry/src/capture.ts
@@ -31,14 +31,17 @@
 /**
  * Minimal interface for a PLASMIC-like object that has registration methods.
  * We don't import the full loader types to avoid a dependency on @plasmicapp/loader-*.
+ *
+ * Methods with `any` params, not properties with `unknown`: property syntax
+ * is contravariant under `strictFunctionTypes`, so no real loader satisfied
+ * the constraint.
  */
 interface PlasmicLike {
-  registerComponent: (component: unknown, meta: unknown) => void;
-  registerGlobalContext?: (component: unknown, meta: unknown) => void;
-  registerFunction?: (fn: unknown, meta: unknown) => void;
-  registerToken?: (token: unknown) => void;
-  registerTrait?: (trait: string, meta: unknown) => void;
-  [key: string]: unknown;
+  registerComponent(component: any, meta: any): void;
+  registerGlobalContext?(component: any, meta: any): void;
+  registerFunction?(fn: any, meta: any): void;
+  registerToken?(token: any): void;
+  registerTrait?(trait: string, meta: any): void;
 }
 
 interface HostRegistration {

--- a/plasmicpkgs/commerce-providers/elastic-path/CONTEXT.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/CONTEXT.md
@@ -1,0 +1,113 @@
+# Elastic Path Commerce Components for Plasmic
+
+The headless commerce building blocks published as
+`@elasticpath/plasmic-ep-commerce-elastic-path`: Plasmic code components,
+global contexts, and `ep.*` server functions that let designers compose
+Elastic Path Composable Commerce storefronts in Plasmic Studio while the
+server owns auth, data, and money.
+
+## Language
+
+### Component model
+
+**Provider**:
+A code component that publishes data to its descendants via Plasmic's
+`DataProvider` (`$ctx.*`) and exposes mutations as refActions. Providers own
+behaviour and data; they render no chrome of their own.
+_Avoid_: wrapper, container
+
+**refAction**:
+A mutation exposed by a provider that a designer wires to an interaction in
+Plasmic Studio (e.g. `setValue`, `placeOrder`, `goToPage`).
+_Avoid_: callback, handler, action prop
+
+**Headless styling contract**:
+The rule that components ship behaviour, not appearance: `className` lands on
+the visible interactive element, no inline appearance styles, structural CSS
+only via zero-specificity `:where()` selectors, and the editor renders the
+same DOM as the runtime.
+_Avoid_: unstyled components, default theme
+
+**Server Query**:
+A Studio-authored server-side data binding that invokes a registered `ep.*`
+function during SSR and surfaces the result under `$q.*`. The primary
+data-binding path; client-side provider fetching is the alternative.
+_Avoid_: data query, `$queries` (that is the client data-queries namespace)
+
+**EP session scope**:
+The per-request `AsyncLocalStorage` scope established by `withEpSession`
+inside which every `ep.*` function reads auth and cart context. Auth is never
+a function argument. Outside the scope, functions fail soft to `null`/`[]`.
+
+### Checkout
+
+**Managed-form checkout**:
+The self-wiring, arbitrary-schema, single-page checkout form family:
+`EPCheckoutFormProvider` plus `EPFormField`/`EPSelectField`/
+`EPConsentCheckbox`/`EPPlaceOrderButton`. The recommended default. Reserved
+field names map to the order; other fields persist as custom attributes.
+_Avoid_: simple checkout, form provider checkout
+
+**Controlled-field checkout**:
+The refAction-orchestrated, fixed-schema checkout family:
+`EPCustomerInfoFields`/`EPShippingAddressFields`/`EPBillingAddressFields`
+with the 4-step `EPCheckoutProvider`. The breakout for multi-step flows,
+bring-your-own inputs, address suggestions, and shipping-rate selection.
+Either/or per page with managed-form, never mixed.
+_Avoid_: composable checkout (ambiguous — both families are composable)
+
+**Checkout session**:
+The server-authoritative checkout state managed by
+`EPCheckoutSessionProvider` and the `/api/…/checkout/sessions*` routes. Holds
+orchestration and selection state only — never an authoritative amount. The
+managed form auto-detects it (`paymentMode: "auto"`) and submits through it.
+
+### Session & security
+
+**Production guard**:
+A check that makes the package refuse to construct or serve when
+production-grade configuration is missing (real secrets, explicit origin
+allowlists). Keyed on `NODE_ENV === "production"` with no opt-out flag;
+preview deployments are deliberately held to production standards.
+_Avoid_: strict mode, safe mode
+
+**Dev sentinel**:
+A known, public placeholder secret shipped in example code. Fine in
+development (with a warning); rejected outright by the production guard,
+because a copied sentinel in production makes session cookies forgeable.
+_Avoid_: default secret, dummy secret
+
+**Trusted origin**:
+An origin permitted to act as the shopper from the browser. One list
+(better-auth's `trustedOrigins`) feeds every origin check — auth endpoints,
+internal synthetic requests, and the proxy's CORS reflection (ADR-0001).
+There is no separate proxy allowlist.
+_Avoid_: allowedOrigins, CORS whitelist
+
+**Origin gate**:
+The CSRF layer on state-changing routes: safe methods pass; unsafe methods
+pass on `Sec-Fetch-Site: same-origin`/`none`, are checked against trusted
+origins when cross-site, and pass when no browser origin signal exists
+(non-browser client). Same semantics as Go's `CrossOriginProtection`;
+layered with `SameSite=Lax` cookies, not CSRF tokens.
+_Avoid_: CORS check (CORS is response readability; the gate is request rejection)
+
+### Money trust (ADR-0013, iso-storefront)
+
+**Discretionary mutation**:
+A cart write for a cost the shopper elects for themselves (e.g. opt-in gift
+wrap). Shopper-auth is acceptable because manipulation is self-defeating.
+`ep.applyCartAdjustment` is the discretionary member only.
+
+**Authoritative money**:
+A value the merchant's rules determine (mandatory fees, shipping, tax,
+discounts). The client may only trigger and select — never supply the value.
+Server-computed with the `client_credentials` secret and re-asserted by
+`handlePay` at checkout, because the cart is shopper-mutable and no cart line
+is self-guaranteeing.
+_Avoid_: trusted cart line, server-priced line item
+
+**Shipping rate resolver**:
+The config-time `shippingRateResolver` hook on `SessionHandlerContext` that
+sources `availableShippingRates` server-side. The only correct path for real
+shipping charges — never `applyCartAdjustment` with `kind: "shipping"`.

--- a/plasmicpkgs/commerce-providers/elastic-path/README.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/README.md
@@ -15,6 +15,11 @@ export const epAuth = createEpAuth({
   clientId: "your-ep-client-id",
   host: "https://useast.api.elasticpath.com",
 
+  // Session cookie secret. Read it straight from the environment — no `!`
+  // and no fallback: a missing value must fail loudly in production, not
+  // silently become a guessable key.
+  secret: process.env.CHECKOUT_SESSION_SECRET,
+
   // Optional: checkout session encryption
   checkout: { sessionSecret: process.env.CHECKOUT_SESSION_SECRET! },
 
@@ -208,7 +213,29 @@ export default function Page({
 # .env.local — only genuine secrets, no EP credentials
 CHECKOUT_SESSION_SECRET=your-32-char-secret-key-here
 STRIPE_SECRET_KEY=sk_test_...
+
+# Optional: extra origins permitted to act as the shopper. One list feeds
+# auth, the proxy's CORS reflection and the origin gate — add your Studio
+# origin here for cross-origin preview.
+BETTER_AUTH_TRUSTED_ORIGINS=https://studio.example.com
 ```
+
+In production `createEpAuth` refuses to serve when the secret is missing, is
+a known example placeholder, or is under 32 characters. Anything other than
+`NODE_ENV=development` / `test` counts as production, so preview deployments
+are held to the same bar; the check stands down during `next build` so
+build-then-inject-env pipelines still build.
+
+Two options tighten the deployment further:
+
+| Option | Default | Use when |
+| --- | --- | --- |
+| `trustedOrigins` | the app's own origin | another origin must act as the shopper (e.g. Studio preview) |
+| `hostAllowlist` | Elastic Path Composable Commerce regions, the integration host, and loopback outside production | the EP API lives elsewhere — Elastic Path Self Managed Commerce |
+
+`hostAllowlist` is applied independently by `createEpAuth`,
+`extractEpProviderConfig` and `buildEpCtx`, so pass the same list to all
+three rather than only to the factory.
 
 ## Architecture
 

--- a/plasmicpkgs/commerce-providers/elastic-path/build-server.mjs
+++ b/plasmicpkgs/commerce-providers/elastic-path/build-server.mjs
@@ -84,8 +84,8 @@ export type { StripeAdapterConfig } from "./checkout/session/adapters/stripe-ada
 export { createClientCredentialsTokenResolver } from "./auth/ep-plugin/client-credentials-resolver";
 export type { ClientCredentialsResolverConfig, ClientCredentialsTokenResolver } from "./auth/ep-plugin/client-credentials-resolver";
 export type { SessionRequest, SessionResponse, SessionHandlerContext, EPCredentials, AdapterRegistry, SessionStore, PaymentAdapter, CustomAttributeAllowList } from "./checkout/session/types";
-export { createEpAuth, createBetterEpAuth, extractEpProviderConfig, epPlugin, epAuthMiddleware, createCartRoutes, createEpProxyRoutes } from "./auth";
-export type { EpAuth, EpAuthConfig, EpSession, EpProviderBundleConfig, EpPluginOptions, EpProxyRoutes, CreateEpProxyRoutesOptions } from "./auth";
+export { createEpAuth, createBetterEpAuth, extractEpProviderConfig, epPlugin, epAuthMiddleware, createCartRoutes, createEpProxyRoutes, enforceOriginGate, isTrustedOrigin, passesOriginGate, assertProductionSecret, resolveAuthSecret, DEFAULT_HOST_ALLOWLIST, isAllowedEpHost } from "./auth";
+export type { EpAuth, EpAuthConfig, EpSession, EpProviderBundleConfig, ExtractEpProviderConfigOptions, EpPluginOptions, EpProxyRoutes } from "./auth";
 export { epGetProduct, epGetCart, epGetProductList, epGetRelatedProducts, epAddCartItem, epApplyCartAdjustment, epUpdateCartItem, epRemoveCartItem, epPlaceOrder, addCustomCartItem, CART_ADJUSTMENT_KINDS, registerEpCustomFunctions, buildEpCtx, withEpSession, getCurrentEpSession } from "./ep-server-functions";
 export type { EpGetProductInput, EpGetCartInput, EpGetProductListInput, EpGetRelatedProductsInput, EpAddCartItemInput, EpApplyCartAdjustmentInput, EpUpdateCartItemInput, EpRemoveCartItemInput, EpPlaceOrderInput, EpPlaceOrderAddress, EpPlaceOrderResult, AddCustomCartItemInput, CartAdjustmentKind, BuildEpCtxSessionInput, EpCtx, EpSessionContext, EpServerAuth } from "./ep-server-functions";
 `;

--- a/plasmicpkgs/commerce-providers/elastic-path/docs/adr/0001-single-origin-trust-list.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/docs/adr/0001-single-origin-trust-list.md
@@ -1,0 +1,63 @@
+# ADR-0001: One origin trust list — the proxy derives CORS from `trustedOrigins`
+
+## Status
+
+Accepted (2026-08-04)
+
+## Context
+
+Two independent origin allowlists gated browser access:
+
+- better-auth's `trustedOrigins` — validates the `Origin` header on every
+  auth endpoint (including internal synthetic requests such as
+  `persistCartId`'s hop to `/ep/cart`). Secure default: the app's `baseURL`.
+- The proxy route's `allowedOrigins` — a hand-rolled CORS reflection list
+  with an insecure production default (`localhost:3003`), added in PR #289
+  for Plasmic Studio's cross-origin preview panel.
+
+Both lists express the same fact — "this origin may act as the shopper" —
+but were maintained separately. Divergence produced a known silent failure:
+Studio's origin passed the proxy's CORS check, then the mutation's cart-id
+persistence died on a swallowed 403 at the better-auth boundary because
+`trustedOrigins` did not include Studio. It also left a localhost default
+shippable to production (security finding #279 MEDIUM-1).
+
+## Decision
+
+`trustedOrigins` is the single origin trust list. The proxy derives its
+CORS allowlist from the auth instance's resolved `trustedOrigins`; the
+`allowedOrigins` option is removed outright (no deprecation alias — the
+package is pre-1.0 and the removal rides the 0.2.0 hardening release).
+
+"Resolved" means what better-auth itself resolves, not merely what the
+caller passed: the configured list, plus the `baseURL` origin, plus
+`BETTER_AUTH_TRUSTED_ORIGINS`. Exposing only the caller's array would make
+`config.trustedOrigins` a strict subset of what the auth endpoints accept,
+so an origin added by env var would pass better-auth and be rejected by the
+proxy and the origin gate — the same split-brain this ADR removes.
+The proxy's matcher honors the same wildcard-pattern semantics better-auth
+uses (e.g. `https://*.vercel.app`), implemented in-package because
+better-auth's matcher is not public API.
+
+Cross-origin Studio use is therefore one knob: add the Studio origin to
+`trustedOrigins`.
+
+## Consequences
+
+- The insecure proxy default is deleted, not guarded — #279 MEDIUM-1
+  dissolves; production inherits better-auth's secure default (own origin).
+- The proxy/auth allowlist mismatch class (silent cart-id loss from Studio)
+  is structurally impossible: any origin the proxy accepts is an origin
+  better-auth trusts.
+- Coupling accepted: an origin trusted for auth is automatically
+  CORS-readable on the proxy. We judge the two meanings identical; a future
+  need to split them would require reintroducing a second list with an
+  explicit rationale.
+- Wildcard entries in `trustedOrigins` widen both surfaces at once — the
+  deployment-hardening docs must say so.
+- The origin gate keeps Go's `CrossOriginProtection` behaviour of comparing
+  the `Origin` against the request's own `Host` before consulting the list.
+  An explicit `trustedOrigins` replaces the defaults rather than extending
+  them, so without that check a deployment that lists only a Studio origin
+  would reject its own storefront's mutations from any client that omits
+  `Sec-Fetch-Site`.

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/__tests__/extract-ep-provider-config.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/__tests__/extract-ep-provider-config.test.ts
@@ -106,6 +106,74 @@ describe("extractEpProviderConfig", () => {
     expect(config?.clientId).toBe("oVC2dwzwVi0sCbov7voN63H8gami9do0TLm3GaVKAJ");
   });
 
+  describe("host allowlist", () => {
+    const smcModule = EP_PROVIDER_MODULE_CUSTOM_HOST.replace(
+      "https://epcc-integration.global.ssl.fastly.net",
+      "https://commerce.selfmanaged.example"
+    );
+    const bundleWith = (code: string) => ({
+      bundle: {
+        projects: [{ globalContextsProviderFileName: "global__proj.js" }],
+        modules: {
+          server: [{ type: "code", fileName: "global__proj.js", code }],
+        },
+      },
+    });
+
+    let errorSpy: jest.SpyInstance;
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterEach(() => errorSpy.mockRestore());
+
+    it("accepts the Elastic Path regions and the integration host by default", () => {
+      expect(
+        extractEpProviderConfig(bundleWith(EP_PROVIDER_MODULE_PREDEFINED_HOST))
+          ?.host
+      ).toBe("https://useast.api.elasticpath.com");
+      expect(
+        extractEpProviderConfig(bundleWith(EP_PROVIDER_MODULE_CUSTOM_HOST))?.host
+      ).toBe("https://epcc-integration.global.ssl.fastly.net");
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unlisted host and says so, naming the host and the option", () => {
+      expect(extractEpProviderConfig(bundleWith(smcModule))).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("commerce.selfmanaged.example")
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("hostAllowlist")
+      );
+    });
+
+    it("accepts a Self Managed Commerce host once it is allowlisted", () => {
+      expect(
+        extractEpProviderConfig(bundleWith(smcModule), {
+          hostAllowlist: ["commerce.selfmanaged.example"],
+        })?.host
+      ).toBe("https://commerce.selfmanaged.example");
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("honours wildcard entries", () => {
+      expect(
+        extractEpProviderConfig(bundleWith(smcModule), {
+          hostAllowlist: ["*.selfmanaged.example"],
+        })?.host
+      ).toBe("https://commerce.selfmanaged.example");
+    });
+
+    it("logs rather than silently returning null when nothing matches the regex", () => {
+      expect(
+        extractEpProviderConfig(bundleWith("function noop(){}"))
+      ).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no usable EP Provider config")
+      );
+    });
+  });
+
   it("returns null when clientId is an empty string (EP Provider not configured)", () => {
     const unconfigured = `
       function E(r){

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/__tests__/host-allowlist.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/__tests__/host-allowlist.test.ts
@@ -1,0 +1,73 @@
+import { DEFAULT_HOST_ALLOWLIST, isAllowedEpHost } from "../host-allowlist";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+function setNodeEnv(value: string | undefined) {
+  if (value === undefined) delete (process.env as any).NODE_ENV;
+  else (process.env as any).NODE_ENV = value;
+}
+
+afterEach(() => setNodeEnv(originalNodeEnv));
+
+describe("isAllowedEpHost", () => {
+  it("accepts the Elastic Path regions and the integration host", () => {
+    expect(isAllowedEpHost("https://useast.api.elasticpath.com")).toBe(true);
+    expect(isAllowedEpHost("https://euwest.api.elasticpath.com")).toBe(true);
+    expect(isAllowedEpHost("https://elasticpath.com")).toBe(true);
+    expect(
+      isAllowedEpHost("https://epcc-integration.global.ssl.fastly.net")
+    ).toBe(true);
+  });
+
+  it("rejects lookalike domains", () => {
+    expect(isAllowedEpHost("https://elasticpath.com.evil.test")).toBe(false);
+    expect(isAllowedEpHost("https://notelasticpath.com")).toBe(false);
+  });
+
+  it("is case-insensitive on both host and pattern", () => {
+    expect(isAllowedEpHost("https://EUWest.API.ElasticPath.com")).toBe(true);
+    expect(
+      isAllowedEpHost("https://commerce.acme.test", ["*.ACME.test"])
+    ).toBe(true);
+  });
+
+  it("matches a bare host, with or without a port", () => {
+    expect(isAllowedEpHost("epcc.internal", ["epcc.internal"])).toBe(true);
+    expect(isAllowedEpHost("epcc.internal:8080", ["epcc.internal"])).toBe(true);
+    expect(
+      isAllowedEpHost("https://epcc.internal:8080", ["epcc.internal"])
+    ).toBe(true);
+  });
+
+  it("ignores a path on either side", () => {
+    expect(
+      isAllowedEpHost("https://commerce.acme.test/v2", ["commerce.acme.test"])
+    ).toBe(true);
+  });
+
+  it("allows loopback outside production but not in it", () => {
+    setNodeEnv("development");
+    expect(isAllowedEpHost("http://localhost:3456")).toBe(true);
+    expect(isAllowedEpHost("http://127.0.0.1:9999")).toBe(true);
+
+    setNodeEnv("production");
+    expect(isAllowedEpHost("http://localhost:3456")).toBe(false);
+    expect(isAllowedEpHost("http://127.0.0.1:9999")).toBe(false);
+  });
+
+  it("still honours an explicitly allowlisted loopback host in production", () => {
+    setNodeEnv("production");
+    expect(isAllowedEpHost("http://localhost:3456", ["localhost"])).toBe(true);
+  });
+
+  it("does not carry loopback in the published default list", () => {
+    expect(DEFAULT_HOST_ALLOWLIST).not.toContain("localhost");
+    expect(DEFAULT_HOST_ALLOWLIST).not.toContain("127.0.0.1");
+  });
+
+  it("rejects junk", () => {
+    expect(isAllowedEpHost("")).toBe(false);
+    expect(isAllowedEpHost("   ")).toBe(false);
+    expect(isAllowedEpHost("not a host")).toBe(false);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/middleware.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/middleware.test.ts
@@ -115,6 +115,45 @@ describe("epAuthMiddleware (PRD #273)", () => {
     );
   });
 
+  it("recognises the session by cookie name, not by a substring of the header", async () => {
+    // A value that merely mentions the cookie names must not read as a
+    // session — the previous `cookieHeader.includes(...)` check let any
+    // unrelated cookie suppress the bootstrap.
+    const epAuth = buildEpAuth();
+    const middleware = epAuthMiddleware(epAuth);
+
+    const req = new Request("http://localhost:3456/product/abc", {
+      headers: {
+        cookie:
+          "referrer=better-auth.session_token; note=better-auth.session_data",
+      },
+    });
+    const res = await middleware(req);
+
+    const setCookies: string[] = [];
+    res.headers.forEach((value: string, key: string) => {
+      if (key.toLowerCase() === "set-cookie") setCookies.push(value);
+    });
+    expect(setCookies.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("recognises secure-prefixed and chunked session cookies", async () => {
+    const epAuth = buildEpAuth();
+    const middleware = epAuthMiddleware(epAuth);
+
+    const req = new Request("http://localhost:3456/product/abc", {
+      headers: {
+        cookie:
+          "__Secure-better-auth.session_token=tok; " +
+          "__Secure-better-auth.session_data.0=aaa; " +
+          "__Secure-better-auth.session_data.1=bbb",
+      },
+    });
+    await middleware(req);
+
+    expect((globalThis.fetch as any).mock.calls.length).toBe(0);
+  });
+
   it("skips mint on request paths matching the auth handler basePath", async () => {
     // /api/ep/* requests are the auth handler itself — middleware must
     // not bootstrap mid-flight or it'd loop.

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/middleware.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/middleware.test.ts
@@ -116,9 +116,6 @@ describe("epAuthMiddleware (PRD #273)", () => {
   });
 
   it("recognises the session by cookie name, not by a substring of the header", async () => {
-    // A value that merely mentions the cookie names must not read as a
-    // session — the previous `cookieHeader.includes(...)` check let any
-    // unrelated cookie suppress the bootstrap.
     const epAuth = buildEpAuth();
     const middleware = epAuthMiddleware(epAuth);
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/origin-gate.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/origin-gate.test.ts
@@ -151,10 +151,6 @@ describe("passesOriginGate", () => {
   });
 
   it("passes a same-origin request whose own origin is absent from the trust list", () => {
-    // Go's CrossOriginProtection compares Origin against the request's Host
-    // before consulting any allowlist. An explicit `trustedOrigins` replaces
-    // the defaults, so the deployment's own origin can legitimately be
-    // missing from the list while the request is still same-origin.
     const studioOnly = ["https://studio.example.com"];
     expect(
       passesOriginGate(

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/origin-gate.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/origin-gate.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  enforceOriginGate,
+  isTrustedOrigin,
+  matchesOriginPattern,
+  passesOriginGate,
+} from "../origin-gate";
+
+const TRUSTED = ["http://localhost:3456", "https://*.vercel.app"];
+
+function req(
+  method: string,
+  headers: Record<string, string> = {}
+): Request {
+  return new Request("http://localhost:3456/api/ep/cart/items", {
+    method,
+    headers,
+    ...(method === "GET" || method === "HEAD" ? {} : { body: "{}" }),
+  });
+}
+
+describe("matchesOriginPattern", () => {
+  it("matches an exact origin and rejects a near-miss", () => {
+    expect(
+      matchesOriginPattern("http://localhost:3456", "http://localhost:3456")
+    ).toBe(true);
+    expect(
+      matchesOriginPattern("http://localhost:3457", "http://localhost:3456")
+    ).toBe(false);
+    expect(
+      matchesOriginPattern("https://localhost:3456", "http://localhost:3456")
+    ).toBe(false);
+  });
+
+  it("ignores path and trailing content when comparing origins", () => {
+    expect(
+      matchesOriginPattern(
+        "http://localhost:3456/api/ep",
+        "http://localhost:3456"
+      )
+    ).toBe(true);
+  });
+
+  it("honours full-origin wildcard patterns", () => {
+    expect(
+      matchesOriginPattern("https://preview.vercel.app", "https://*.vercel.app")
+    ).toBe(true);
+    expect(
+      matchesOriginPattern("http://preview.vercel.app", "https://*.vercel.app")
+    ).toBe(false);
+    expect(
+      matchesOriginPattern("https://vercel.app.evil.com", "https://*.vercel.app")
+    ).toBe(false);
+  });
+
+  it("matches host-only wildcard patterns against the host", () => {
+    expect(
+      matchesOriginPattern("https://shop.elasticpath.com", "*.elasticpath.com")
+    ).toBe(true);
+    expect(
+      matchesOriginPattern("https://elasticpath.com.evil.io", "*.elasticpath.com")
+    ).toBe(false);
+  });
+
+  it("rejects opaque and unparseable origins", () => {
+    expect(matchesOriginPattern("null", "http://localhost:3456")).toBe(false);
+    expect(matchesOriginPattern("null", "https://*.vercel.app")).toBe(false);
+    expect(matchesOriginPattern("", "http://localhost:3456")).toBe(false);
+  });
+});
+
+describe("isTrustedOrigin", () => {
+  it("is false when the trust list is empty or absent", () => {
+    expect(isTrustedOrigin("http://localhost:3456", [])).toBe(false);
+    expect(isTrustedOrigin("http://localhost:3456", undefined)).toBe(false);
+  });
+
+  it("accepts any matching entry in the list", () => {
+    expect(isTrustedOrigin("https://x.vercel.app", TRUSTED)).toBe(true);
+    expect(isTrustedOrigin("http://evil.test", TRUSTED)).toBe(false);
+  });
+});
+
+describe("passesOriginGate", () => {
+  it("passes safe methods regardless of origin", () => {
+    expect(
+      passesOriginGate(
+        req("GET", { origin: "http://evil.test", "sec-fetch-site": "cross-site" }),
+        TRUSTED
+      )
+    ).toBe(true);
+    expect(passesOriginGate(req("HEAD"), TRUSTED)).toBe(true);
+    expect(
+      passesOriginGate(
+        req("OPTIONS", { origin: "http://evil.test" }),
+        TRUSTED
+      )
+    ).toBe(true);
+  });
+
+  it("passes unsafe methods reported as same-origin or browser-initiated", () => {
+    expect(
+      passesOriginGate(req("POST", { "sec-fetch-site": "same-origin" }), TRUSTED)
+    ).toBe(true);
+    expect(
+      passesOriginGate(req("POST", { "sec-fetch-site": "none" }), TRUSTED)
+    ).toBe(true);
+  });
+
+  it("passes cross-site requests from a trusted origin", () => {
+    expect(
+      passesOriginGate(
+        req("POST", {
+          "sec-fetch-site": "cross-site",
+          origin: "https://preview.vercel.app",
+        }),
+        TRUSTED
+      )
+    ).toBe(true);
+  });
+
+  it("rejects cross-site requests from an untrusted origin", () => {
+    expect(
+      passesOriginGate(
+        req("POST", {
+          "sec-fetch-site": "cross-site",
+          origin: "http://evil.test",
+        }),
+        TRUSTED
+      )
+    ).toBe(false);
+    expect(
+      passesOriginGate(
+        req("DELETE", {
+          "sec-fetch-site": "same-site",
+          origin: "http://evil.test",
+        }),
+        TRUSTED
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a cross-site request that withholds its Origin", () => {
+    expect(
+      passesOriginGate(req("POST", { "sec-fetch-site": "cross-site" }), TRUSTED)
+    ).toBe(false);
+  });
+
+  it("passes non-browser clients that send neither signal", () => {
+    expect(passesOriginGate(req("POST"), TRUSTED)).toBe(true);
+  });
+
+  it("passes a same-origin request whose own origin is absent from the trust list", () => {
+    // Go's CrossOriginProtection compares Origin against the request's Host
+    // before consulting any allowlist. An explicit `trustedOrigins` replaces
+    // the defaults, so the deployment's own origin can legitimately be
+    // missing from the list while the request is still same-origin.
+    const studioOnly = ["https://studio.example.com"];
+    expect(
+      passesOriginGate(
+        req("POST", { origin: "http://localhost:3456" }),
+        studioOnly
+      )
+    ).toBe(true);
+    expect(
+      passesOriginGate(
+        req("POST", {
+          origin: "http://localhost:3456",
+          "sec-fetch-site": "cross-site",
+        }),
+        studioOnly
+      )
+    ).toBe(true);
+  });
+
+  it("still rejects a different origin when the trust list omits it", () => {
+    expect(
+      passesOriginGate(
+        req("POST", { origin: "http://localhost:9999" }),
+        ["https://studio.example.com"]
+      )
+    ).toBe(false);
+  });
+
+  it("checks the Origin when Sec-Fetch-Site is absent", () => {
+    expect(
+      passesOriginGate(req("POST", { origin: "http://localhost:3456" }), TRUSTED)
+    ).toBe(true);
+    expect(
+      passesOriginGate(req("POST", { origin: "http://evil.test" }), TRUSTED)
+    ).toBe(false);
+  });
+});
+
+describe("enforceOriginGate", () => {
+  it("returns null when the request passes", () => {
+    expect(enforceOriginGate(req("GET"), TRUSTED)).toBeNull();
+  });
+
+  it("returns a 403 untrusted_origin JSON response when it rejects", async () => {
+    const res = enforceOriginGate(
+      req("POST", { "sec-fetch-site": "cross-site", origin: "http://evil.test" }),
+      TRUSTED
+    );
+    expect(res?.status).toBe(403);
+    expect(res?.headers.get("Content-Type")).toBe("application/json");
+    expect(await res!.json()).toEqual({ error: "untrusted_origin" });
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/production-guard.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/production-guard.test.ts
@@ -130,7 +130,6 @@ describe("assertNonSentinelSecret", () => {
         label: "checkout.sessionSecret",
       })
     ).toThrow(/public example placeholder/);
-    // Short but unique is the checkout secret's own ≥16 rule, not this guard's.
     expect(() =>
       assertNonSentinelSecret("a-unique-17-chars", {
         label: "checkout.sessionSecret",

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/production-guard.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/production-guard.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEV_FALLBACK_SECRET,
+  DEV_SECRET_SENTINELS,
+  assertNonSentinelSecret,
+  assertProductionSecret,
+  resolveAuthSecret,
+} from "../production-guard";
+
+const GOOD_SECRET = "s".repeat(48);
+const LABEL = { label: "createEpAuth" };
+
+let originalNodeEnv: string | undefined;
+let originalNextPhase: string | undefined;
+
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV;
+  originalNextPhase = process.env.NEXT_PHASE;
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  setEnv("NODE_ENV", originalNodeEnv);
+  setEnv("NEXT_PHASE", originalNextPhase);
+  vi.restoreAllMocks();
+});
+
+function setEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete (process.env as any)[key];
+  else (process.env as any)[key] = value;
+}
+
+function inProduction() {
+  setEnv("NODE_ENV", "production");
+  setEnv("NEXT_PHASE", undefined);
+}
+
+function inDevelopment() {
+  setEnv("NODE_ENV", "development");
+  setEnv("NEXT_PHASE", undefined);
+}
+
+describe("assertProductionSecret in production", () => {
+  beforeEach(inProduction);
+
+  it("accepts a long unique secret", () => {
+    expect(() => assertProductionSecret(GOOD_SECRET, LABEL)).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("throws when no secret is configured", () => {
+    expect(() => assertProductionSecret(undefined, LABEL)).toThrow(
+      /no secret is configured/
+    );
+    expect(() => assertProductionSecret("", LABEL)).toThrow();
+  });
+
+  it.each(DEV_SECRET_SENTINELS)("throws on the sentinel %s", (sentinel) => {
+    expect(() => assertProductionSecret(sentinel, LABEL)).toThrow(
+      /public example placeholder/
+    );
+  });
+
+  it("throws on a secret shorter than 32 characters", () => {
+    expect(() => assertProductionSecret("z".repeat(31), LABEL)).toThrow(
+      /at least 32/
+    );
+    expect(() => assertProductionSecret("z".repeat(32), LABEL)).not.toThrow();
+  });
+
+  it("names the failing call site in the message", () => {
+    expect(() => assertProductionSecret(undefined, LABEL)).toThrow(
+      /^createEpAuth:/
+    );
+  });
+});
+
+describe("assertProductionSecret during a production build", () => {
+  beforeEach(() => {
+    setEnv("NODE_ENV", "production");
+    setEnv("NEXT_PHASE", "phase-production-build");
+  });
+
+  it("warns instead of throwing so build-time env injection still builds", () => {
+    expect(() => assertProductionSecret(undefined, LABEL)).not.toThrow();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no secret is configured")
+    );
+  });
+
+  it("still warns on a sentinel", () => {
+    expect(() =>
+      assertProductionSecret(DEV_SECRET_SENTINELS[0], LABEL)
+    ).not.toThrow();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe("assertProductionSecret under an unrecognised NODE_ENV", () => {
+  it.each(["staging", "preview", "", undefined])(
+    "enforces when NODE_ENV is %p, since only development and test are trusted",
+    (value) => {
+      setEnv("NODE_ENV", value as string | undefined);
+      setEnv("NEXT_PHASE", undefined);
+      expect(() => assertProductionSecret(undefined, LABEL)).toThrow();
+      expect(() =>
+        assertProductionSecret(DEV_SECRET_SENTINELS[0], LABEL)
+      ).toThrow();
+    }
+  );
+
+  it("never hands back the published fallback outside development", () => {
+    setEnv("NODE_ENV", "staging");
+    setEnv("NEXT_PHASE", undefined);
+    expect(() => resolveAuthSecret(undefined, LABEL)).toThrow();
+  });
+
+  it("treats the test environment as development", () => {
+    setEnv("NODE_ENV", "test");
+    setEnv("NEXT_PHASE", undefined);
+    expect(() => assertProductionSecret(undefined, LABEL)).not.toThrow();
+  });
+});
+
+describe("assertNonSentinelSecret", () => {
+  it("rejects a sentinel checkout secret in production but ignores length", () => {
+    inProduction();
+    expect(() =>
+      assertNonSentinelSecret("dev-secret-min-16-chars", {
+        label: "checkout.sessionSecret",
+      })
+    ).toThrow(/public example placeholder/);
+    // Short but unique is the checkout secret's own ≥16 rule, not this guard's.
+    expect(() =>
+      assertNonSentinelSecret("a-unique-17-chars", {
+        label: "checkout.sessionSecret",
+      })
+    ).not.toThrow();
+  });
+
+  it("warns instead of throwing in development", () => {
+    inDevelopment();
+    expect(() =>
+      assertNonSentinelSecret("dev-secret-min-16-chars", {
+        label: "checkout.sessionSecret",
+      })
+    ).not.toThrow();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe("assertProductionSecret outside production", () => {
+  beforeEach(inDevelopment);
+
+  it("warns rather than throwing on every finding", () => {
+    expect(() => assertProductionSecret(undefined, LABEL)).not.toThrow();
+    expect(() =>
+      assertProductionSecret(DEV_SECRET_SENTINELS[0], LABEL)
+    ).not.toThrow();
+    expect(() => assertProductionSecret("short", LABEL)).not.toThrow();
+    expect(console.warn).toHaveBeenCalledTimes(3);
+  });
+
+  it("stays silent for a well-formed secret", () => {
+    assertProductionSecret(GOOD_SECRET, LABEL);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAuthSecret", () => {
+  it("returns the configured secret unchanged", () => {
+    inDevelopment();
+    expect(resolveAuthSecret(GOOD_SECRET, LABEL)).toBe(GOOD_SECRET);
+  });
+
+  it("substitutes the dev fallback when nothing is configured", () => {
+    inDevelopment();
+    expect(resolveAuthSecret(undefined, LABEL)).toBe(DEV_FALLBACK_SECRET);
+  });
+
+  it("propagates the production throw", () => {
+    inProduction();
+    expect(() => resolveAuthSecret(undefined, LABEL)).toThrow();
+  });
+
+  it("keeps the dev fallback out of production by listing it as a sentinel", () => {
+    inProduction();
+    expect(() => resolveAuthSecret(DEV_FALLBACK_SECRET, LABEL)).toThrow(
+      /public example placeholder/
+    );
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
@@ -132,7 +132,7 @@ describe("createEpProxyRoutes", () => {
       }
     );
     const proxyResp = await proxy.handle(proxyReq, {
-      params: { fn: "addCartItem" },
+      params: Promise.resolve({ fn: "addCartItem" }),
     });
 
     expect(proxyResp.status).toBe(200);
@@ -184,7 +184,7 @@ describe("createEpProxyRoutes", () => {
       }
     );
     const proxyResp = await proxy.handle(proxyReq, {
-      params: { fn: "addCartItem" },
+      params: Promise.resolve({ fn: "addCartItem" }),
     });
 
     expect(proxyResp.status).toBe(200);
@@ -303,7 +303,7 @@ describe("createEpProxyRoutes origin gate", () => {
         },
         body: JSON.stringify({ productId: "p", quantity: 1 }),
       }),
-      { params: { fn: "addCartItem" } }
+      { params: Promise.resolve({ fn: "addCartItem" }) }
     );
 
     expect(res.status).toBe(403);
@@ -342,7 +342,7 @@ describe("createEpProxyRoutes error sanitization", () => {
         },
         body: JSON.stringify({ productId: "p", quantity: 1 }),
       }),
-      { params: { fn: "addCartItem" } }
+      { params: Promise.resolve({ fn: "addCartItem" }) }
     );
   }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
@@ -208,7 +208,6 @@ describe("createEpProxyRoutes CORS", () => {
   }
 
   it("reflects an origin that better-auth already trusts", () => {
-    // baseURL http://localhost:3000 implies both loopback spellings.
     const auth = buildAuth();
     expect(
       preflight(auth, "http://localhost:3000").headers.get(
@@ -244,8 +243,6 @@ describe("createEpProxyRoutes CORS", () => {
   });
 
   it("keeps the baseURL origin reflectable even when trustedOrigins is overridden", () => {
-    // better-auth re-adds the baseURL origin to its own effective list, so
-    // the exposed list has to as well or ADR-0001's one-list claim breaks.
     const auth = buildAuth(["http://localhost:3003"]);
     expect(auth.config.trustedOrigins).toContain("http://localhost:3000");
     expect(

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/proxy-routes.test.ts
@@ -58,12 +58,13 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function buildAuth() {
+function buildAuth(trustedOrigins?: string[]) {
   return createEpAuth({
     clientId: EP_CLIENT_ID,
     host: EP_HOST,
     secret: SECRET,
     baseURL: "http://localhost:3000",
+    ...(trustedOrigins ? { trustedOrigins } : {}),
   });
 }
 
@@ -193,5 +194,181 @@ describe("createEpProxyRoutes", () => {
       if (k.toLowerCase() === "set-cookie") setCookies.push(v);
     });
     expect(setCookies.join(";")).not.toContain("session_data=");
+  });
+});
+
+describe("createEpProxyRoutes CORS", () => {
+  function preflight(auth: any, origin: string) {
+    return createEpProxyRoutes(auth).options(
+      new Request("http://localhost:3000/api/ep/proxy/getCart", {
+        method: "OPTIONS",
+        headers: { Origin: origin },
+      })
+    );
+  }
+
+  it("reflects an origin that better-auth already trusts", () => {
+    // baseURL http://localhost:3000 implies both loopback spellings.
+    const auth = buildAuth();
+    expect(
+      preflight(auth, "http://localhost:3000").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBe("http://localhost:3000");
+    expect(
+      preflight(auth, "http://127.0.0.1:3000").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBe("http://127.0.0.1:3000");
+  });
+
+  it("no longer reflects the old hardcoded Studio default", () => {
+    expect(
+      preflight(buildAuth(), "http://localhost:3003").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBeNull();
+  });
+
+  it("reflects a Studio origin once it is added to trustedOrigins", () => {
+    const auth = buildAuth([
+      "http://localhost:3000",
+      "http://localhost:3003",
+    ]);
+    const res = preflight(auth, "http://localhost:3003");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:3003"
+    );
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("keeps the baseURL origin reflectable even when trustedOrigins is overridden", () => {
+    // better-auth re-adds the baseURL origin to its own effective list, so
+    // the exposed list has to as well or ADR-0001's one-list claim breaks.
+    const auth = buildAuth(["http://localhost:3003"]);
+    expect(auth.config.trustedOrigins).toContain("http://localhost:3000");
+    expect(
+      preflight(auth, "http://localhost:3000").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBe("http://localhost:3000");
+  });
+
+  it("picks up BETTER_AUTH_TRUSTED_ORIGINS the way better-auth does", () => {
+    const prior = process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS =
+      "https://studio.elasticpathdev.com, https://second.example.com";
+    try {
+      const auth = buildAuth();
+      expect(
+        preflight(auth, "https://studio.elasticpathdev.com").headers.get(
+          "Access-Control-Allow-Origin"
+        )
+      ).toBe("https://studio.elasticpathdev.com");
+      expect(auth.config.trustedOrigins).toContain(
+        "https://second.example.com"
+      );
+    } finally {
+      if (prior === undefined) delete process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+      else process.env.BETTER_AUTH_TRUSTED_ORIGINS = prior;
+    }
+  });
+
+  it("honours wildcard trustedOrigins entries", () => {
+    const auth = buildAuth(["http://localhost:3000", "https://*.vercel.app"]);
+    expect(
+      preflight(auth, "https://preview-42.vercel.app").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBe("https://preview-42.vercel.app");
+    expect(
+      preflight(auth, "https://vercel.app.evil.test").headers.get(
+        "Access-Control-Allow-Origin"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("createEpProxyRoutes origin gate", () => {
+  it("rejects a cross-site mutation from an untrusted origin", async () => {
+    const proxy = createEpProxyRoutes(buildAuth() as any);
+    const res = await proxy.handle(
+      new Request("http://localhost:3000/api/ep/proxy/addCartItem", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://evil.test",
+          "Sec-Fetch-Site": "cross-site",
+        },
+        body: JSON.stringify({ productId: "p", quantity: 1 }),
+      }),
+      { params: { fn: "addCartItem" } }
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "untrusted_origin" });
+    expect(cartMutations.epAddCartItem as any).not.toHaveBeenCalled();
+  });
+});
+
+describe("createEpProxyRoutes error sanitization", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    (process.env as any).NODE_ENV = originalNodeEnv;
+  });
+
+  async function dispatchFailure(): Promise<Response> {
+    const auth = buildAuth();
+    const anonResp = await (auth.handler.api as any).epAnonymous({
+      body: {},
+      headers: new Headers(),
+      asResponse: true,
+    });
+    (cartMutations.epAddCartItem as any).mockRejectedValue(
+      new Error("EP 500 at https://internal.ep.svc/v2/carts — token tok-secret")
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const proxy = createEpProxyRoutes(auth as any);
+    return proxy.handle(
+      new Request("http://localhost:3000/api/ep/proxy/addCartItem", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          cookie: cookiesFromResponse(anonResp),
+        },
+        body: JSON.stringify({ productId: "p", quantity: 1 }),
+      }),
+      { params: { fn: "addCartItem" } }
+    );
+  }
+
+  it("withholds the message in production and logs it instead", async () => {
+    (process.env as any).NODE_ENV = "production";
+    const res = await dispatchFailure();
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("dispatch_failed");
+    expect(body.message).toBeUndefined();
+    expect(body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(body.correlationId),
+      expect.any(Error)
+    );
+  });
+
+  it("keeps the message outside production", async () => {
+    (process.env as any).NODE_ENV = "development";
+    const body = await (await dispatchFailure()).json();
+
+    expect(body.error).toBe("dispatch_failed");
+    expect(body.message).toContain("EP 500");
+    expect(body.correlationId).toBeTruthy();
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/trusted-origins-parity.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/trusted-origins-parity.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ADR-0001 makes `epAuth.config.trustedOrigins` the one origin trust list:
+ * the proxy's CORS reflection and the origin gate both read it. That only
+ * holds if the list agrees with what better-auth itself accepts.
+ *
+ * A superset is the dangerous direction — the proxy would set CORS headers
+ * and the gate would pass a request that better-auth then rejects mid-flight,
+ * which is the silent cart-id-persistence 403 the ADR exists to remove. So
+ * rather than re-asserting our own resolution, this asks better-auth.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEpAuth } from "../create-ep-auth-better";
+
+const EP_HOST = "https://api.test.elasticpath.com";
+let originalFetch: typeof fetch;
+let originalEnvOrigins: string | undefined;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalEnvOrigins = process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+  globalThis.fetch = vi.fn(async (url: any) => {
+    if (String(url) === `${EP_HOST}/oauth/access_token`) {
+      return new Response(
+        JSON.stringify({
+          access_token: "tok",
+          token_type: "Bearer",
+          expires: Math.floor(Date.now() / 1000) + 3600,
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalEnvOrigins === undefined) {
+    delete process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+  } else {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = originalEnvOrigins;
+  }
+  vi.restoreAllMocks();
+});
+
+/**
+ * better-auth's own resolved trust list, straight off its context.
+ *
+ * Deliberately not probed through the request handler: better-auth sets
+ * `skipOriginCheck` to true whenever `isTest()` (create-context.mjs), so
+ * under Vitest its handler accepts every origin and any assertion made that
+ * way would pass vacuously.
+ */
+async function betterAuthTrustedOrigins(auth: any): Promise<string[]> {
+  const ctx = await auth.handler.$context;
+  return ctx.trustedOrigins;
+}
+
+describe("config.trustedOrigins parity with better-auth", () => {
+  it("matches better-auth's resolved list exactly", async () => {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS =
+      "https://studio.elasticpathdev.com";
+    const auth = createEpAuth({
+      clientId: "cid",
+      host: EP_HOST,
+      secret: "z".repeat(48),
+      baseURL: "http://localhost:3456",
+      // Deliberately omits the baseURL origin: an explicit list replaces the
+      // defaults, but better-auth re-adds its own origin regardless.
+      trustedOrigins: ["http://localhost:3003"],
+    });
+
+    const theirs = new Set(await betterAuthTrustedOrigins(auth));
+    const ours = new Set(auth.config.trustedOrigins);
+
+    // Advertising an origin better-auth rejects is the split-brain ADR-0001
+    // removes: the proxy would send CORS headers and the gate would pass a
+    // request that then 403s at the auth boundary.
+    expect(
+      [...ours].filter((o) => !theirs.has(o)),
+      "origins we advertise that better-auth does not trust"
+    ).toEqual([]);
+    // The reverse gap is milder but still breaks the single-list promise.
+    expect(
+      [...theirs].filter((o) => !ours.has(o)),
+      "origins better-auth trusts that we do not advertise"
+    ).toEqual([]);
+  });
+
+  it("carries the baseURL origin and the env-var origins into the list", async () => {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS =
+      "https://studio.elasticpathdev.com, https://second.example.com";
+    const auth = createEpAuth({
+      clientId: "cid",
+      host: EP_HOST,
+      secret: "z".repeat(48),
+      baseURL: "http://localhost:3456",
+      trustedOrigins: ["http://localhost:3003"],
+    });
+
+    expect(auth.config.trustedOrigins).toEqual(
+      expect.arrayContaining([
+        "http://localhost:3003",
+        "http://localhost:3456",
+        "https://studio.elasticpathdev.com",
+        "https://second.example.com",
+      ])
+    );
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/trusted-origins-parity.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/__tests__/trusted-origins-parity.test.ts
@@ -1,13 +1,3 @@
-/**
- * ADR-0001 makes `epAuth.config.trustedOrigins` the one origin trust list:
- * the proxy's CORS reflection and the origin gate both read it. That only
- * holds if the list agrees with what better-auth itself accepts.
- *
- * A superset is the dangerous direction — the proxy would set CORS headers
- * and the gate would pass a request that better-auth then rejects mid-flight,
- * which is the silent cart-id-persistence 403 the ADR exists to remove. So
- * rather than re-asserting our own resolution, this asks better-auth.
- */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEpAuth } from "../create-ep-auth-better";
 
@@ -44,14 +34,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/**
- * better-auth's own resolved trust list, straight off its context.
- *
- * Deliberately not probed through the request handler: better-auth sets
- * `skipOriginCheck` to true whenever `isTest()` (create-context.mjs), so
- * under Vitest its handler accepts every origin and any assertion made that
- * way would pass vacuously.
- */
+// Read off the context, not the handler: better-auth disables origin
+// checks under isTest(), so a handler probe would pass vacuously.
 async function betterAuthTrustedOrigins(auth: any): Promise<string[]> {
   const ctx = await auth.handler.$context;
   return ctx.trustedOrigins;
@@ -66,22 +50,16 @@ describe("config.trustedOrigins parity with better-auth", () => {
       host: EP_HOST,
       secret: "z".repeat(48),
       baseURL: "http://localhost:3456",
-      // Deliberately omits the baseURL origin: an explicit list replaces the
-      // defaults, but better-auth re-adds its own origin regardless.
       trustedOrigins: ["http://localhost:3003"],
     });
 
     const theirs = new Set(await betterAuthTrustedOrigins(auth));
     const ours = new Set(auth.config.trustedOrigins);
 
-    // Advertising an origin better-auth rejects is the split-brain ADR-0001
-    // removes: the proxy would send CORS headers and the gate would pass a
-    // request that then 403s at the auth boundary.
     expect(
       [...ours].filter((o) => !theirs.has(o)),
       "origins we advertise that better-auth does not trust"
     ).toEqual([]);
-    // The reverse gap is milder but still breaks the single-list promise.
     expect(
       [...theirs].filter((o) => !ours.has(o)),
       "origins better-auth trusts that we do not advertise"

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/create-ep-auth-better.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/create-ep-auth-better.ts
@@ -25,11 +25,22 @@
 import { betterAuth } from "better-auth";
 import { nextCookies } from "better-auth/next-js";
 import { epPlugin } from "./ep-plugin";
+import { DEFAULT_HOST_ALLOWLIST } from "../host-allowlist";
+import {
+  assertNonSentinelSecret,
+  resolveAuthSecret,
+} from "./production-guard";
 
 export interface CreateEpAuthBetterInput {
   clientId: string;
   host: string;
-  secret: string;
+  /**
+   * JWE secret for the session cookie. Read it straight from the
+   * environment — `undefined` is accepted so a missing variable surfaces
+   * as this package's production guard rather than a type error that
+   * tempts a hardcoded fallback.
+   */
+  secret?: string;
   basePath?: string;
   baseURL?: string;
   /**
@@ -42,6 +53,13 @@ export interface CreateEpAuthBetterInput {
    * both the localhost and 127.0.0.1 variants of `baseURL`.
    */
   trustedOrigins?: string[];
+  /**
+   * Host patterns the EP API may be reached at. Guards the host resolved
+   * per-request by `resolveConfig`, so a tampered or misconfigured bundle
+   * cannot redirect shopper token minting elsewhere. Self Managed Commerce
+   * deployments must list their own host.
+   */
+  hostAllowlist?: string[];
   cartMergeStrategy?: "merge" | "replace" | "prompt";
   checkout?: { sessionSecret: string };
   adapters?: { stripe?: { secretKey: string }; clover?: any };
@@ -68,6 +86,33 @@ function defaultTrustedOrigins(baseURL: string): string[] {
     }
   } catch {
     // Non-URL baseURL — leave the set as-is.
+  }
+  return [...out];
+}
+
+/**
+ * Mirrors better-auth's own `getTrustedOrigins`: the configured list, plus
+ * the baseURL origin, plus `BETTER_AUTH_TRUSTED_ORIGINS`. Without this the
+ * exposed list would be a strict subset of what better-auth actually
+ * accepts, and ADR-0001's single-trust-list guarantee would not hold —
+ * an explicit `trustedOrigins` replaces the defaults, but better-auth
+ * re-adds the deployment's own origin regardless.
+ */
+function resolveTrustedOrigins(
+  configured: string[] | undefined,
+  baseURL: string
+): string[] {
+  const out = new Set<string>(configured ?? defaultTrustedOrigins(baseURL));
+  try {
+    out.add(new URL(baseURL).origin);
+  } catch {
+    // Non-URL baseURL — better-auth will not derive an origin either.
+  }
+  for (const origin of (process.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "").split(
+    ","
+  )) {
+    const trimmed = origin.trim();
+    if (trimmed) out.add(trimmed);
   }
   return [...out];
 }
@@ -107,6 +152,18 @@ export interface EpAuth {
   handler: any;
   config: {
     basePath: string;
+    /**
+     * The resolved origin trust list — the single list every origin check
+     * reads (ADR-0001), including the proxy's CORS reflection and the
+     * origin gate on state-changing routes.
+     */
+    trustedOrigins: string[];
+    /**
+     * The resolved EP API host allowlist. Pass it to
+     * `extractEpProviderConfig` / `buildEpCtx` so every host check in the
+     * deployment reads the same list.
+     */
+    hostAllowlist: readonly string[];
     cartMergeStrategy: "merge" | "replace" | "prompt";
     checkout?: { sessionSecret: string };
     adapters?: { stripe?: { secretKey: string }; clover?: any };
@@ -172,20 +229,20 @@ export function createEpAuth(input: CreateEpAuthBetterInput): EpAuth {
       "checkout.sessionSecret must be at least 16 characters"
     );
   }
+  assertNonSentinelSecret(input.checkout?.sessionSecret, {
+    label: "createEpAuth checkout.sessionSecret",
+  });
   if (!input.clientId) {
     throw new Error("clientId is required");
   }
-  if (!input.secret) {
-    throw new Error("secret is required");
-  }
+  const secret = resolveAuthSecret(input.secret, { label: "createEpAuth" });
 
   const basePath = input.basePath ?? "/api/ep";
   const baseURL = input.baseURL ?? "http://localhost";
-  const trustedOrigins =
-    input.trustedOrigins ?? defaultTrustedOrigins(baseURL);
+  const trustedOrigins = resolveTrustedOrigins(input.trustedOrigins, baseURL);
 
   const auth = betterAuth({
-    secret: input.secret,
+    secret,
     baseURL,
     basePath,
     trustedOrigins,
@@ -193,6 +250,7 @@ export function createEpAuth(input: CreateEpAuthBetterInput): EpAuth {
       epPlugin({
         clientId: input.clientId,
         host: input.host,
+        hostAllowlist: input.hostAllowlist,
         resolveConfig: input.resolveConfig,
       }),
       // `nextCookies()` MUST be the last plugin in the array per
@@ -212,7 +270,9 @@ export function createEpAuth(input: CreateEpAuthBetterInput): EpAuth {
   });
 
   const config = Object.freeze({
-    basePath: input.basePath ?? "/api/ep",
+    basePath,
+    trustedOrigins,
+    hostAllowlist: input.hostAllowlist ?? DEFAULT_HOST_ALLOWLIST,
     cartMergeStrategy: input.cartMergeStrategy ?? "merge",
     checkout: input.checkout,
     adapters: input.adapters,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/create-ep-auth-better.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/create-ep-auth-better.ts
@@ -34,12 +34,6 @@ import {
 export interface CreateEpAuthBetterInput {
   clientId: string;
   host: string;
-  /**
-   * JWE secret for the session cookie. Read it straight from the
-   * environment — `undefined` is accepted so a missing variable surfaces
-   * as this package's production guard rather than a type error that
-   * tempts a hardcoded fallback.
-   */
   secret?: string;
   basePath?: string;
   baseURL?: string;
@@ -53,12 +47,6 @@ export interface CreateEpAuthBetterInput {
    * both the localhost and 127.0.0.1 variants of `baseURL`.
    */
   trustedOrigins?: string[];
-  /**
-   * Host patterns the EP API may be reached at. Guards the host resolved
-   * per-request by `resolveConfig`, so a tampered or misconfigured bundle
-   * cannot redirect shopper token minting elsewhere. Self Managed Commerce
-   * deployments must list their own host.
-   */
   hostAllowlist?: string[];
   cartMergeStrategy?: "merge" | "replace" | "prompt";
   checkout?: { sessionSecret: string };
@@ -90,14 +78,7 @@ function defaultTrustedOrigins(baseURL: string): string[] {
   return [...out];
 }
 
-/**
- * Mirrors better-auth's own `getTrustedOrigins`: the configured list, plus
- * the baseURL origin, plus `BETTER_AUTH_TRUSTED_ORIGINS`. Without this the
- * exposed list would be a strict subset of what better-auth actually
- * accepts, and ADR-0001's single-trust-list guarantee would not hold —
- * an explicit `trustedOrigins` replaces the defaults, but better-auth
- * re-adds the deployment's own origin regardless.
- */
+/** Mirrors better-auth's own getTrustedOrigins (ADR-0001). */
 function resolveTrustedOrigins(
   configured: string[] | undefined,
   baseURL: string
@@ -105,9 +86,7 @@ function resolveTrustedOrigins(
   const out = new Set<string>(configured ?? defaultTrustedOrigins(baseURL));
   try {
     out.add(new URL(baseURL).origin);
-  } catch {
-    // Non-URL baseURL — better-auth will not derive an origin either.
-  }
+  } catch {}
   for (const origin of (process.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "").split(
     ","
   )) {
@@ -152,17 +131,7 @@ export interface EpAuth {
   handler: any;
   config: {
     basePath: string;
-    /**
-     * The resolved origin trust list — the single list every origin check
-     * reads (ADR-0001), including the proxy's CORS reflection and the
-     * origin gate on state-changing routes.
-     */
     trustedOrigins: string[];
-    /**
-     * The resolved EP API host allowlist. Pass it to
-     * `extractEpProviderConfig` / `buildEpCtx` so every host check in the
-     * deployment reads the same list.
-     */
     hostAllowlist: readonly string[];
     cartMergeStrategy: "merge" | "replace" | "prompt";
     checkout?: { sessionSecret: string };

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/ep-plugin.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/ep-plugin.ts
@@ -10,6 +10,11 @@
 import { createAuthEndpoint } from "better-auth/api";
 import { setSessionCookie, getCookieCache } from "better-auth/cookies";
 import type { BetterAuthPlugin } from "better-auth";
+import {
+  DEFAULT_HOST_ALLOWLIST,
+  isAllowedEpHost,
+  reportRejectedEpHost,
+} from "../host-allowlist";
 
 export interface EpPluginOptions {
   /**
@@ -30,6 +35,12 @@ export interface EpPluginOptions {
   resolveConfig?: () => Promise<
     { clientId?: string; host?: string } | null | undefined
   >;
+  /**
+   * Host patterns `resolveConfig` may return. A host outside the list is
+   * logged and discarded in favour of the static `host` above, so a
+   * tampered bundle cannot redirect token minting.
+   */
+  hostAllowlist?: readonly string[];
 }
 
 interface EpAnonymousTokenResponse {
@@ -78,6 +89,14 @@ async function resolveConfigFor(options: EpPluginOptions) {
   const resolved = options.resolveConfig
     ? await options.resolveConfig().catch(() => null)
     : null;
+  const allowlist = options.hostAllowlist ?? DEFAULT_HOST_ALLOWLIST;
+  if (resolved?.host && !isAllowedEpHost(resolved.host, allowlist)) {
+    reportRejectedEpHost(resolved.host, "epPlugin.resolveConfig", allowlist);
+    // Drop the whole pair, never just the host: a clientId is only valid
+    // against the host it was resolved with, and pairing a resolved
+    // clientId with the static bootstrap host makes every token mint 401.
+    return { clientId: options.clientId, host: options.host };
+  }
   return {
     clientId: resolved?.clientId ?? options.clientId,
     host: resolved?.host ?? options.host,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/ep-plugin.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/ep-plugin.ts
@@ -35,11 +35,6 @@ export interface EpPluginOptions {
   resolveConfig?: () => Promise<
     { clientId?: string; host?: string } | null | undefined
   >;
-  /**
-   * Host patterns `resolveConfig` may return. A host outside the list is
-   * logged and discarded in favour of the static `host` above, so a
-   * tampered bundle cannot redirect token minting.
-   */
   hostAllowlist?: readonly string[];
 }
 
@@ -92,9 +87,7 @@ async function resolveConfigFor(options: EpPluginOptions) {
   const allowlist = options.hostAllowlist ?? DEFAULT_HOST_ALLOWLIST;
   if (resolved?.host && !isAllowedEpHost(resolved.host, allowlist)) {
     reportRejectedEpHost(resolved.host, "epPlugin.resolveConfig", allowlist);
-    // Drop the whole pair, never just the host: a clientId is only valid
-    // against the host it was resolved with, and pairing a resolved
-    // clientId with the static bootstrap host makes every token mint 401.
+    // clientId is only valid against the host it was resolved with.
     return { clientId: options.clientId, host: options.host };
   }
   return {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/middleware.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/middleware.ts
@@ -30,6 +30,7 @@
  */
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { hasCookie, parseCookieHeader } from "../../utils/cookie-header";
 import type { EpAuth } from "./create-ep-auth-better";
 
 /**
@@ -51,9 +52,10 @@ export function epAuthMiddleware(epAuth: EpAuth) {
     }
 
     const cookieHeader = request.headers.get("cookie") ?? "";
+    const cookies = parseCookieHeader(cookieHeader);
     if (
-      cookieHeader.includes("better-auth.session_token") &&
-      cookieHeader.includes("better-auth.session_data")
+      hasCookie(cookies, "better-auth.session_token") &&
+      hasCookie(cookies, "better-auth.session_data")
     ) {
       // Already has a session — pass through unchanged.
       return NextResponse.next();

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
@@ -1,8 +1,5 @@
-/**
- * Origin gate — the CSRF layer on state-changing routes, following Go's
- * `CrossOriginProtection`. Request rejection, distinct from CORS (response
- * readability). Trust list is better-auth's `trustedOrigins` (ADR-0001).
- */
+// CSRF gate following Go's CrossOriginProtection. Rejects requests; CORS
+// only governs response readability.
 import { hasWildcard, matchesGlob } from "../../utils/glob-pattern";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
@@ -32,7 +29,6 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
   return origin.startsWith(pattern);
 }
 
-/** Go checks Origin against the request's Host before the allowlist. */
 function originMatchesRequestHost(request: Request, origin: string): boolean {
   const originHost = parseUrl(origin)?.host?.toLowerCase();
   if (!originHost) return false;
@@ -62,7 +58,6 @@ export function passesOriginGate(
   if (site === "same-origin" || site === "none") return true;
 
   const origin = request.headers.get("origin");
-  // Not a browser: no ambient credentials to abuse.
   if (!site && !origin) return true;
   if (!origin) return false;
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
@@ -1,0 +1,106 @@
+/**
+ * Origin gate — the CSRF layer on state-changing routes.
+ *
+ * Semantics follow Go's `CrossOriginProtection`: safe methods always pass;
+ * unsafe methods pass when the browser reports a same-origin (or
+ * browser-initiated) fetch; cross-site requests must present an Origin the
+ * deployment trusts; requests carrying no browser origin signal at all are
+ * treated as non-browser clients and pass. This is request *rejection*, and
+ * is distinct from CORS, which only governs response readability.
+ *
+ * The trust list is better-auth's `trustedOrigins` and nothing else
+ * (ADR-0001), and pattern entries keep better-auth's meaning: patterns
+ * containing `://` match the full origin, bare patterns match the host, and
+ * a pattern without wildcards must equal the origin.
+ */
+import { hasWildcard, matchesGlob } from "../../utils/glob-pattern";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+export function matchesOriginPattern(origin: string, pattern: string): boolean {
+  const url = parseUrl(origin);
+  if (hasWildcard(pattern)) {
+    if (pattern.includes("://")) {
+      return matchesGlob(
+        url && url.origin !== "null" ? url.origin : origin,
+        pattern
+      );
+    }
+    return url ? matchesGlob(url.host, pattern) : false;
+  }
+  // Non-wildcard: http(s) and scheme-less values compare as origins;
+  // custom schemes (Electron shells and the like) compare by prefix.
+  if (!url || url.protocol === "http:" || url.protocol === "https:") {
+    return url !== null && url.origin !== "null" && pattern === url.origin;
+  }
+  return origin.startsWith(pattern);
+}
+
+/**
+ * Go's `CrossOriginProtection` compares the Origin against the request's own
+ * Host before consulting any allowlist, so a same-origin request stays
+ * same-origin even when the deployment's origin is absent from the trust
+ * list. A cross-site attacker cannot forge this: the browser sets Origin.
+ */
+function originMatchesRequestHost(request: Request, origin: string): boolean {
+  const originHost = parseUrl(origin)?.host?.toLowerCase();
+  if (!originHost) return false;
+  const hostHeader = request.headers.get("host")?.toLowerCase();
+  if (hostHeader && hostHeader === originHost) return true;
+  const urlHost = parseUrl(request.url)?.host?.toLowerCase();
+  return Boolean(urlHost) && urlHost === originHost;
+}
+
+export function isTrustedOrigin(
+  origin: string,
+  trustedOrigins: readonly string[] | undefined
+): boolean {
+  if (!origin || !trustedOrigins?.length) return false;
+  return trustedOrigins.some((pattern) =>
+    matchesOriginPattern(origin, pattern)
+  );
+}
+
+/**
+ * `true` when the request may proceed. Exported for tests and for callers
+ * that want to gate without producing a response.
+ */
+export function passesOriginGate(
+  request: Request,
+  trustedOrigins: readonly string[] | undefined
+): boolean {
+  if (SAFE_METHODS.has(request.method.toUpperCase())) return true;
+
+  const site = request.headers.get("sec-fetch-site");
+  if (site === "same-origin" || site === "none") return true;
+
+  const origin = request.headers.get("origin");
+  // No Sec-Fetch-Site and no Origin: not a browser, so there is no
+  // ambient-credential attack to defend against.
+  if (!site && !origin) return true;
+  if (!origin) return false;
+
+  if (originMatchesRequestHost(request, origin)) return true;
+
+  return isTrustedOrigin(origin, trustedOrigins);
+}
+
+/** Returns a 403 response when the gate rejects, or `null` to continue. */
+export function enforceOriginGate(
+  request: Request,
+  trustedOrigins: readonly string[] | undefined
+): Response | null {
+  if (passesOriginGate(request, trustedOrigins)) return null;
+  return new Response(JSON.stringify({ error: "untrusted_origin" }), {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
@@ -26,18 +26,13 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
     }
     return url ? matchesGlob(url.host, pattern) : false;
   }
-  // Non-wildcard: http(s) and scheme-less values compare as origins;
-  // custom schemes (Electron shells and the like) compare by prefix.
   if (!url || url.protocol === "http:" || url.protocol === "https:") {
     return url !== null && url.origin !== "null" && pattern === url.origin;
   }
   return origin.startsWith(pattern);
 }
 
-/**
- * Go compares Origin to the request's own Host before the allowlist, so a
- * same-origin request passes even if the deployment's origin is unlisted.
- */
+/** Go checks Origin against the request's Host before the allowlist. */
 function originMatchesRequestHost(request: Request, origin: string): boolean {
   const originHost = parseUrl(origin)?.host?.toLowerCase();
   if (!originHost) return false;
@@ -57,7 +52,6 @@ export function isTrustedOrigin(
   );
 }
 
-/** `true` when the request may proceed. */
 export function passesOriginGate(
   request: Request,
   trustedOrigins: readonly string[] | undefined
@@ -68,7 +62,7 @@ export function passesOriginGate(
   if (site === "same-origin" || site === "none") return true;
 
   const origin = request.headers.get("origin");
-  // Neither signal: not a browser, so no ambient credentials to abuse.
+  // Not a browser: no ambient credentials to abuse.
   if (!site && !origin) return true;
   if (!origin) return false;
 
@@ -77,7 +71,6 @@ export function passesOriginGate(
   return isTrustedOrigin(origin, trustedOrigins);
 }
 
-/** Returns a 403 response when the gate rejects, or `null` to continue. */
 export function enforceOriginGate(
   request: Request,
   trustedOrigins: readonly string[] | undefined

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/origin-gate.ts
@@ -1,17 +1,7 @@
 /**
- * Origin gate — the CSRF layer on state-changing routes.
- *
- * Semantics follow Go's `CrossOriginProtection`: safe methods always pass;
- * unsafe methods pass when the browser reports a same-origin (or
- * browser-initiated) fetch; cross-site requests must present an Origin the
- * deployment trusts; requests carrying no browser origin signal at all are
- * treated as non-browser clients and pass. This is request *rejection*, and
- * is distinct from CORS, which only governs response readability.
- *
- * The trust list is better-auth's `trustedOrigins` and nothing else
- * (ADR-0001), and pattern entries keep better-auth's meaning: patterns
- * containing `://` match the full origin, bare patterns match the host, and
- * a pattern without wildcards must equal the origin.
+ * Origin gate — the CSRF layer on state-changing routes, following Go's
+ * `CrossOriginProtection`. Request rejection, distinct from CORS (response
+ * readability). Trust list is better-auth's `trustedOrigins` (ADR-0001).
  */
 import { hasWildcard, matchesGlob } from "../../utils/glob-pattern";
 
@@ -45,10 +35,8 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
 }
 
 /**
- * Go's `CrossOriginProtection` compares the Origin against the request's own
- * Host before consulting any allowlist, so a same-origin request stays
- * same-origin even when the deployment's origin is absent from the trust
- * list. A cross-site attacker cannot forge this: the browser sets Origin.
+ * Go compares Origin to the request's own Host before the allowlist, so a
+ * same-origin request passes even if the deployment's origin is unlisted.
  */
 function originMatchesRequestHost(request: Request, origin: string): boolean {
   const originHost = parseUrl(origin)?.host?.toLowerCase();
@@ -69,10 +57,7 @@ export function isTrustedOrigin(
   );
 }
 
-/**
- * `true` when the request may proceed. Exported for tests and for callers
- * that want to gate without producing a response.
- */
+/** `true` when the request may proceed. */
 export function passesOriginGate(
   request: Request,
   trustedOrigins: readonly string[] | undefined
@@ -83,8 +68,7 @@ export function passesOriginGate(
   if (site === "same-origin" || site === "none") return true;
 
   const origin = request.headers.get("origin");
-  // No Sec-Fetch-Site and no Origin: not a browser, so there is no
-  // ambient-credential attack to defend against.
+  // Neither signal: not a browser, so no ambient credentials to abuse.
   if (!site && !origin) return true;
   if (!origin) return false;
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
@@ -1,28 +1,14 @@
 /**
- * Production guards.
- *
- * Keyed on `NODE_ENV === "production"` with no opt-out flag — preview
- * deployments are deliberately held to production standards. Guards throw
- * at factory construction so a misconfigured deployment fails on boot
- * rather than serving forgeable sessions, but they stand down during
- * `next build` (`NEXT_PHASE === "phase-production-build"`) so
- * build-once/inject-env-at-runtime pipelines still build; the throw then
- * lands on the first server that actually has to serve.
+ * Production guards. Enforced everywhere except `development`/`test`, and
+ * stood down during `next build` so build-then-inject-env pipelines still
+ * build — the throw then lands on the first request served.
  */
 
-/**
- * Placeholder used when no secret is configured outside production. It is
- * itself a sentinel, so a deployment that reaches production still carrying
- * it is rejected.
- */
+/** Itself a sentinel, so it cannot survive into production. */
 export const DEV_FALLBACK_SECRET =
   "ep-dev-insecure-secret-not-for-production-0000000000";
 
-/**
- * Public placeholders that have shipped in example code. A copied sentinel
- * in production makes session cookies forgeable, so these are rejected
- * outright rather than merely warned about.
- */
+/** Public placeholders shipped in example code. */
 export const DEV_SECRET_SENTINELS: readonly string[] = [
   "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache",
   "dev-secret-min-16-chars",
@@ -35,12 +21,7 @@ export function isProduction(): boolean {
   return process.env.NODE_ENV === "production";
 }
 
-/**
- * The only environments treated as non-production. Everything else — an
- * unset `NODE_ENV`, `staging`, a bespoke value — is held to production
- * standards, because a deployment serving real shoppers under an
- * unrecognised `NODE_ENV` is the case a `=== "production"` test misses.
- */
+/** Fail closed: an unset or bespoke NODE_ENV counts as production. */
 const DEV_ENVIRONMENTS = new Set(["development", "test"]);
 
 export function isTrustedDevEnvironment(): boolean {
@@ -68,10 +49,7 @@ function describeSecretProblem(secret: string | undefined): string | null {
   return null;
 }
 
-/**
- * Throws in production when `secret` is missing, a known sentinel, or too
- * short. Elsewhere the same finding is a warning.
- */
+/** Throws in production on a missing, sentinel, or too-short secret. */
 export function assertProductionSecret(
   secret: string | undefined,
   opts: { label: string }
@@ -87,13 +65,7 @@ export function assertProductionSecret(
   console.warn(`[ep-commerce] ${message}`);
 }
 
-/**
- * Sentinel check only, for secrets that carry their own length rule.
- * `checkout.sessionSecret` keeps its ≥16-character minimum, but a published
- * placeholder there makes checkout sessions forgeable just as surely as it
- * does auth sessions — and the sentinel list contains the very value the
- * example used to pass for it.
- */
+/** Sentinel check only, for secrets that keep their own length rule. */
 export function assertNonSentinelSecret(
   secret: string | undefined,
   opts: { label: string }
@@ -108,10 +80,7 @@ export function assertNonSentinelSecret(
   console.warn(`[ep-commerce] ${message}`);
 }
 
-/**
- * Runs {@link assertProductionSecret} and returns a usable secret, falling
- * back to {@link DEV_FALLBACK_SECRET} where the guard did not throw.
- */
+/** Asserts, then returns the secret or the dev fallback. */
 export function resolveAuthSecret(
   secret: string | undefined,
   opts: { label: string }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
@@ -1,14 +1,6 @@
-/**
- * Production guards. Enforced everywhere except `development`/`test`, and
- * stood down during `next build` so build-then-inject-env pipelines still
- * build — the throw then lands on the first request served.
- */
-
-/** Itself a sentinel, so it cannot survive into production. */
 export const DEV_FALLBACK_SECRET =
   "ep-dev-insecure-secret-not-for-production-0000000000";
 
-/** Public placeholders shipped in example code. */
 export const DEV_SECRET_SENTINELS: readonly string[] = [
   "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache",
   "dev-secret-min-16-chars",
@@ -21,7 +13,6 @@ export function isProduction(): boolean {
   return process.env.NODE_ENV === "production";
 }
 
-/** Fail closed: an unset or bespoke NODE_ENV counts as production. */
 const DEV_ENVIRONMENTS = new Set(["development", "test"]);
 
 export function isTrustedDevEnvironment(): boolean {
@@ -49,7 +40,6 @@ function describeSecretProblem(secret: string | undefined): string | null {
   return null;
 }
 
-/** Throws in production on a missing, sentinel, or too-short secret. */
 export function assertProductionSecret(
   secret: string | undefined,
   opts: { label: string }
@@ -65,7 +55,6 @@ export function assertProductionSecret(
   console.warn(`[ep-commerce] ${message}`);
 }
 
-/** Sentinel check only, for secrets that keep their own length rule. */
 export function assertNonSentinelSecret(
   secret: string | undefined,
   opts: { label: string }
@@ -80,7 +69,6 @@ export function assertNonSentinelSecret(
   console.warn(`[ep-commerce] ${message}`);
 }
 
-/** Asserts, then returns the secret or the dev fallback. */
 export function resolveAuthSecret(
   secret: string | undefined,
   opts: { label: string }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/production-guard.ts
@@ -1,0 +1,121 @@
+/**
+ * Production guards.
+ *
+ * Keyed on `NODE_ENV === "production"` with no opt-out flag — preview
+ * deployments are deliberately held to production standards. Guards throw
+ * at factory construction so a misconfigured deployment fails on boot
+ * rather than serving forgeable sessions, but they stand down during
+ * `next build` (`NEXT_PHASE === "phase-production-build"`) so
+ * build-once/inject-env-at-runtime pipelines still build; the throw then
+ * lands on the first server that actually has to serve.
+ */
+
+/**
+ * Placeholder used when no secret is configured outside production. It is
+ * itself a sentinel, so a deployment that reaches production still carrying
+ * it is rejected.
+ */
+export const DEV_FALLBACK_SECRET =
+  "ep-dev-insecure-secret-not-for-production-0000000000";
+
+/**
+ * Public placeholders that have shipped in example code. A copied sentinel
+ * in production makes session cookies forgeable, so these are rejected
+ * outright rather than merely warned about.
+ */
+export const DEV_SECRET_SENTINELS: readonly string[] = [
+  "dev-secret-min-48-chars-long-enough-for-better-auth-jwe-cache",
+  "dev-secret-min-16-chars",
+  DEV_FALLBACK_SECRET,
+];
+
+export const MIN_PRODUCTION_SECRET_LENGTH = 32;
+
+export function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+/**
+ * The only environments treated as non-production. Everything else — an
+ * unset `NODE_ENV`, `staging`, a bespoke value — is held to production
+ * standards, because a deployment serving real shoppers under an
+ * unrecognised `NODE_ENV` is the case a `=== "production"` test misses.
+ */
+const DEV_ENVIRONMENTS = new Set(["development", "test"]);
+
+export function isTrustedDevEnvironment(): boolean {
+  return DEV_ENVIRONMENTS.has(process.env.NODE_ENV ?? "");
+}
+
+export function isProductionBuildPhase(): boolean {
+  return process.env.NEXT_PHASE === "phase-production-build";
+}
+
+function guardsEnforced(): boolean {
+  return !isTrustedDevEnvironment() && !isProductionBuildPhase();
+}
+
+function describeSecretProblem(secret: string | undefined): string | null {
+  if (!secret) {
+    return "no secret is configured.";
+  }
+  if (DEV_SECRET_SENTINELS.includes(secret)) {
+    return "the configured secret is a public example placeholder, which makes session cookies forgeable.";
+  }
+  if (secret.length < MIN_PRODUCTION_SECRET_LENGTH) {
+    return `the configured secret is ${secret.length} characters; production requires at least ${MIN_PRODUCTION_SECRET_LENGTH}.`;
+  }
+  return null;
+}
+
+/**
+ * Throws in production when `secret` is missing, a known sentinel, or too
+ * short. Elsewhere the same finding is a warning.
+ */
+export function assertProductionSecret(
+  secret: string | undefined,
+  opts: { label: string }
+): void {
+  const problem = describeSecretProblem(secret);
+  if (!problem) return;
+  const message =
+    `${opts.label}: ${problem} Supply a unique random value of at least ` +
+    `${MIN_PRODUCTION_SECRET_LENGTH} characters (\`openssl rand -base64 32\`).`;
+  if (guardsEnforced()) {
+    throw new Error(message);
+  }
+  console.warn(`[ep-commerce] ${message}`);
+}
+
+/**
+ * Sentinel check only, for secrets that carry their own length rule.
+ * `checkout.sessionSecret` keeps its ≥16-character minimum, but a published
+ * placeholder there makes checkout sessions forgeable just as surely as it
+ * does auth sessions — and the sentinel list contains the very value the
+ * example used to pass for it.
+ */
+export function assertNonSentinelSecret(
+  secret: string | undefined,
+  opts: { label: string }
+): void {
+  if (!secret || !DEV_SECRET_SENTINELS.includes(secret)) return;
+  const message =
+    `${opts.label}: the configured secret is a public example placeholder, ` +
+    `which makes the values it protects forgeable. Supply a unique random value.`;
+  if (guardsEnforced()) {
+    throw new Error(message);
+  }
+  console.warn(`[ep-commerce] ${message}`);
+}
+
+/**
+ * Runs {@link assertProductionSecret} and returns a usable secret, falling
+ * back to {@link DEV_FALLBACK_SECRET} where the guard did not throw.
+ */
+export function resolveAuthSecret(
+  secret: string | undefined,
+  opts: { label: string }
+): string {
+  assertProductionSecret(secret, opts);
+  return secret || DEV_FALLBACK_SECRET;
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
@@ -50,8 +50,9 @@ import { isTrustedDevEnvironment } from "./production-guard";
 
 const MUTATION_FNS = new Set(["addCartItem", "updateCartItem", "removeCartItem"]);
 
+/** Promised `params` only — see the note on `CartRouteContext`. */
 interface ProxyRouteContext {
-  params: Promise<{ fn?: string }> | { fn?: string };
+  params: Promise<{ fn?: string }>;
 }
 
 interface SessionShape {
@@ -122,10 +123,7 @@ export function createEpProxyRoutes(epAuth: EpAuth): EpProxyRoutes {
       if (gate) return gate;
 
       const cors = corsHeaders(request);
-      const params =
-        context.params instanceof Promise
-          ? await context.params
-          : context.params;
+      const params = await context.params;
       const fnName = params.fn ?? "";
       const dispatch = FN_DISPATCH[fnName];
       if (!dispatch) {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
@@ -18,11 +18,13 @@
  *   export const POST = routes.handle;
  *   export const OPTIONS = routes.options;
  *
- * CORS: when Studio (`localhost:3003`) previews against a consumer at
- * a different origin (`localhost:3456`), browsers preflight OPTIONS
- * and require explicit `Access-Control-Allow-Credentials` + matching
- * `Access-Control-Allow-Origin`. The factory accepts a list of
- * allowed origins and reflects them on response.
+ * CORS: when Studio previews against a consumer at a different origin,
+ * browsers preflight OPTIONS and require explicit
+ * `Access-Control-Allow-Credentials` + matching
+ * `Access-Control-Allow-Origin`. The reflected list is the auth
+ * instance's resolved `trustedOrigins` — the one origin trust list
+ * (ADR-0001) — so cross-origin Studio use is a single knob and the proxy
+ * can never accept an origin better-auth would reject mid-mutation.
  */
 import {
   epAddCartItem,
@@ -40,8 +42,11 @@ import type {
 } from "../../ep-server-functions";
 import { withEpSession } from "../../ep-server-functions/session-context";
 import type { EpCtx } from "../../ep-server-functions/build-ep-ctx";
+import { parseCookieHeader } from "../../utils/cookie-header";
 import type { EpAuth } from "./create-ep-auth-better";
+import { enforceOriginGate, isTrustedOrigin } from "./origin-gate";
 import { persistCartId } from "./persist-cart-id";
+import { isTrustedDevEnvironment } from "./production-guard";
 
 const MUTATION_FNS = new Set(["addCartItem", "updateCartItem", "removeCartItem"]);
 
@@ -59,18 +64,6 @@ interface SessionShape {
   } | null;
   cart: { id: string } | null;
   user?: { accountId?: string } | null;
-}
-
-function parseCookies(cookieHeader: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const part of cookieHeader.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    const name = part.slice(0, eq).trim();
-    if (!name) continue;
-    out[name] = decodeURIComponent(part.slice(eq + 1).trim());
-  }
-  return out;
 }
 
 const FN_DISPATCH: Record<
@@ -91,34 +84,17 @@ const FN_DISPATCH: Record<
     epRemoveCartItem(args as unknown as EpRemoveCartItemInput),
 };
 
-export interface CreateEpProxyRoutesOptions {
-  /**
-   * Origins permitted to call the proxy with credentials. Defaults to
-   * common Studio dev origins (`http://localhost:3003`, `http://127.0.0.1:3003`).
-   * In production, set this to whatever Studio host the team uses.
-   */
-  allowedOrigins?: string[];
-}
-
 export interface EpProxyRoutes {
   handle: (request: Request, context: ProxyRouteContext) => Promise<Response>;
   options: (request: Request) => Response;
 }
 
-const DEFAULT_ALLOWED_ORIGINS = [
-  "http://localhost:3003",
-  "http://127.0.0.1:3003",
-];
-
-export function createEpProxyRoutes(
-  epAuth: EpAuth,
-  opts?: CreateEpProxyRoutesOptions
-): EpProxyRoutes {
-  const allowed = new Set(opts?.allowedOrigins ?? DEFAULT_ALLOWED_ORIGINS);
+export function createEpProxyRoutes(epAuth: EpAuth): EpProxyRoutes {
+  const trustedOrigins = epAuth.config.trustedOrigins;
 
   function corsHeaders(request: Request): Record<string, string> {
     const origin = request.headers.get("origin");
-    if (origin && allowed.has(origin)) {
+    if (origin && isTrustedOrigin(origin, trustedOrigins)) {
       return {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Credentials": "true",
@@ -139,6 +115,12 @@ export function createEpProxyRoutes(
     },
 
     async handle(request, context) {
+      // The proxy dispatches cart mutations, so it needs the same CSRF
+      // gate as the cart routes — CORS only governs who may read the
+      // reply, not who may provoke the write.
+      const gate = enforceOriginGate(request, trustedOrigins);
+      if (gate) return gate;
+
       const cors = corsHeaders(request);
       const params =
         context.params instanceof Promise
@@ -161,7 +143,7 @@ export function createEpProxyRoutes(
         unknown
       >;
 
-      const cookies = parseCookies(request.headers.get("cookie") ?? "");
+      const cookies = parseCookieHeader(request.headers.get("cookie") ?? "");
       const sessionResult = (await epAuth.api.getSession({
         cookies,
         headers: Object.fromEntries(request.headers.entries()),
@@ -198,11 +180,24 @@ export function createEpProxyRoutes(
       try {
         result = await withEpSession(epCtx, () => dispatch(args));
       } catch (err) {
+        // The failure detail stays server-side: dispatch errors carry EP
+        // API responses and internal hostnames. The correlationId is the
+        // only handle the caller gets for matching up the log line.
+        const correlationId = crypto.randomUUID();
+        console.error(
+          `[ep-commerce] proxy dispatch_failed fn=${fnName} correlationId=${correlationId}`,
+          err
+        );
         return new Response(
-          JSON.stringify({
-            error: "dispatch_failed",
-            message: (err as Error)?.message,
-          }),
+          JSON.stringify(
+            isTrustedDevEnvironment()
+              ? {
+                  error: "dispatch_failed",
+                  correlationId,
+                  message: (err as Error)?.message,
+                }
+              : { error: "dispatch_failed", correlationId }
+          ),
           {
             status: 500,
             headers: { "Content-Type": "application/json", ...cors },

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/ep-plugin/proxy-routes.ts
@@ -18,13 +18,7 @@
  *   export const POST = routes.handle;
  *   export const OPTIONS = routes.options;
  *
- * CORS: when Studio previews against a consumer at a different origin,
- * browsers preflight OPTIONS and require explicit
- * `Access-Control-Allow-Credentials` + matching
- * `Access-Control-Allow-Origin`. The reflected list is the auth
- * instance's resolved `trustedOrigins` — the one origin trust list
- * (ADR-0001) — so cross-origin Studio use is a single knob and the proxy
- * can never accept an origin better-auth would reject mid-mutation.
+ * CORS reflects the auth instance's resolved `trustedOrigins` (ADR-0001).
  */
 import {
   epAddCartItem,
@@ -116,9 +110,6 @@ export function createEpProxyRoutes(epAuth: EpAuth): EpProxyRoutes {
     },
 
     async handle(request, context) {
-      // The proxy dispatches cart mutations, so it needs the same CSRF
-      // gate as the cart routes — CORS only governs who may read the
-      // reply, not who may provoke the write.
       const gate = enforceOriginGate(request, trustedOrigins);
       if (gate) return gate;
 
@@ -178,9 +169,6 @@ export function createEpProxyRoutes(epAuth: EpAuth): EpProxyRoutes {
       try {
         result = await withEpSession(epCtx, () => dispatch(args));
       } catch (err) {
-        // The failure detail stays server-side: dispatch errors carry EP
-        // API responses and internal hostnames. The correlationId is the
-        // only handle the caller gets for matching up the log line.
         const correlationId = crypto.randomUUID();
         console.error(
           `[ep-commerce] proxy dispatch_failed fn=${fnName} correlationId=${correlationId}`,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/extract-ep-provider-config.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/extract-ep-provider-config.ts
@@ -16,8 +16,16 @@
  * needs to resolve a server session. If Plasmic's codegen output changes
  * shape in a future release, the regex stops matching and
  * `extractEpProviderConfig` returns `null`, letting callers fall through to
- * whatever defaults / env vars they prefer.
+ * whatever defaults / env vars they prefer. Both that miss and an
+ * allowlist rejection are logged where they happen, because the downstream
+ * fallback chain otherwise turns either one into a silent
+ * `bootstrap-placeholder` session that fails much later and elsewhere.
  */
+import {
+  DEFAULT_HOST_ALLOWLIST,
+  isAllowedEpHost,
+  reportRejectedEpHost,
+} from "./host-allowlist";
 
 export interface EpProviderBundleConfig {
   /** clientId configured on the EP Provider global context */
@@ -67,14 +75,32 @@ function extractProp(
   return raw;
 }
 
+export interface ExtractEpProviderConfigOptions {
+  /**
+   * Host patterns the EP API may be reached at. Defaults to Elastic Path's
+   * own domains plus loopback; Self Managed Commerce deployments must list
+   * their host here.
+   */
+  hostAllowlist?: readonly string[];
+}
+
 export function extractEpProviderConfig(
-  prefetchedData: ServerBundleLike | null | undefined
+  prefetchedData: ServerBundleLike | null | undefined,
+  opts?: ExtractEpProviderConfigOptions
 ): EpProviderBundleConfig | null {
+  const hostAllowlist = opts?.hostAllowlist ?? DEFAULT_HOST_ALLOWLIST;
   const allMods: BundleModule[] = [
     ...(prefetchedData?.bundle?.modules?.server ?? []),
     ...(prefetchedData?.bundle?.modules?.browser ?? []),
   ];
-  if (allMods.length === 0) return null;
+  if (allMods.length === 0) {
+    console.error(
+      "[ep-commerce] extractEpProviderConfig: the Plasmic bundle carried no " +
+        "modules, so no EP Provider config could be read. Check that " +
+        "prefetchedData was fetched for a page in the project."
+    );
+    return null;
+  }
 
   // Prefer modules that match a project's globalContextsProviderFileName, but
   // fall back to scanning all server modules — some projects place context
@@ -109,6 +135,15 @@ export function extractEpProviderConfig(
           : undefined;
     if (!resolvedHost) continue;
 
+    if (!isAllowedEpHost(resolvedHost, hostAllowlist)) {
+      reportRejectedEpHost(
+        resolvedHost,
+        "extractEpProviderConfig",
+        hostAllowlist
+      );
+      continue;
+    }
+
     return {
       clientId,
       host: resolvedHost,
@@ -116,5 +151,10 @@ export function extractEpProviderConfig(
     };
   }
 
+  console.error(
+    "[ep-commerce] extractEpProviderConfig: no usable EP Provider config " +
+      "found in the Plasmic bundle. Confirm the project has an EP Commerce " +
+      "Provider global context configured in Studio with a clientId and host."
+  );
   return null;
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/extract-ep-provider-config.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/extract-ep-provider-config.ts
@@ -16,10 +16,7 @@
  * needs to resolve a server session. If Plasmic's codegen output changes
  * shape in a future release, the regex stops matching and
  * `extractEpProviderConfig` returns `null`, letting callers fall through to
- * whatever defaults / env vars they prefer. Both that miss and an
- * allowlist rejection are logged where they happen, because the downstream
- * fallback chain otherwise turns either one into a silent
- * `bootstrap-placeholder` session that fails much later and elsewhere.
+ * whatever defaults / env vars they prefer.
  */
 import {
   DEFAULT_HOST_ALLOWLIST,
@@ -76,11 +73,6 @@ function extractProp(
 }
 
 export interface ExtractEpProviderConfigOptions {
-  /**
-   * Host patterns the EP API may be reached at. Defaults to Elastic Path's
-   * own domains plus loopback; Self Managed Commerce deployments must list
-   * their host here.
-   */
   hostAllowlist?: readonly string[];
 }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
@@ -1,33 +1,23 @@
 /**
- * Host allowlist for the Elastic Path API endpoint. The host arrives from
- * the Plasmic bundle, so an unchecked value redirects shopper token minting.
- *
- * Normalization mirrors better-auth's `matchesHostPattern` plus a port
- * strip; reimplemented because Jest-side tests reach this and better-auth
- * is ESM-only.
+ * The EP API host comes from the Plasmic bundle, so an unchecked value
+ * redirects shopper token minting.
  */
 import { hasWildcard, matchesGlob } from "../utils/glob-pattern";
 import { isProduction } from "./ep-plugin/production-guard";
 
-/**
- * Composable Commerce regions plus the integration host, which is on Fastly
- * so it is listed exactly rather than by wildcard. Self Managed Commerce
- * hosts must come from `hostAllowlist`.
- */
+/** The integration host is on Fastly, so it is listed exactly. */
 export const DEFAULT_HOST_ALLOWLIST: readonly string[] = [
   "*.elasticpath.com",
   "elasticpath.com",
   "epcc-integration.global.ssl.fastly.net",
 ];
 
-/** Outside production only — otherwise a bundle could aim at any local port. */
+/** Outside production only. */
 const LOOPBACK_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "::1"];
 
-/** Strip scheme, path, port, and case, so comparisons are like-for-like. */
 function normalizeHost(value: string): string | null {
   const withoutScheme = value.trim().replace(/^[a-zA-Z][\w+.-]*:\/\//, "");
   const hostOnly = withoutScheme.split("/")[0];
-  // IPv6 literals keep their brackets; everything else drops a :port suffix.
   const withoutPort = hostOnly.startsWith("[")
     ? hostOnly.replace(/^\[([^\]]*)\](?::\d+)?$/, "$1")
     : hostOnly.replace(/:\d+$/, "");
@@ -54,7 +44,6 @@ export function isAllowedEpHost(
   });
 }
 
-/** Logs at the point of failure so a rejection is never silent downstream. */
 export function reportRejectedEpHost(
   host: string,
   source: string,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
@@ -1,18 +1,13 @@
-/**
- * The EP API host comes from the Plasmic bundle, so an unchecked value
- * redirects shopper token minting.
- */
+// The EP API host comes from the Plasmic bundle, so it is untrusted input.
 import { hasWildcard, matchesGlob } from "../utils/glob-pattern";
 import { isProduction } from "./ep-plugin/production-guard";
 
-/** The integration host is on Fastly, so it is listed exactly. */
 export const DEFAULT_HOST_ALLOWLIST: readonly string[] = [
   "*.elasticpath.com",
   "elasticpath.com",
   "epcc-integration.global.ssl.fastly.net",
 ];
 
-/** Outside production only. */
 const LOOPBACK_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "::1"];
 
 function normalizeHost(value: string): string | null {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
@@ -1,0 +1,85 @@
+/**
+ * Host allowlist for the Elastic Path API endpoint.
+ *
+ * The API host arrives from the Plasmic loader bundle rather than from the
+ * deployment's own environment, so it is attacker-influenceable in the same
+ * way any remotely-sourced config is. Every shopper token mint targets that
+ * host, which makes an unchecked value a credential-exfiltration path.
+ *
+ * Normalization mirrors better-auth's public `matchesHostPattern` — strip
+ * scheme, strip path, lowercase both sides — plus a port strip, so
+ * `epcc.internal:8080` matches an `epcc.internal` entry. The function is
+ * reimplemented rather than imported because this module is reachable from
+ * Jest-side tests and better-auth is ESM-only.
+ */
+import { hasWildcard, matchesGlob } from "../utils/glob-pattern";
+import { isProduction } from "./ep-plugin/production-guard";
+
+/**
+ * Elastic Path Composable Commerce regions plus the integration environment,
+ * which is served from Fastly and so is listed by exact host rather than by
+ * wildcard. Elastic Path Self Managed Commerce hosts are not knowable here
+ * and must be supplied by the deployment via `hostAllowlist`.
+ */
+export const DEFAULT_HOST_ALLOWLIST: readonly string[] = [
+  "*.elasticpath.com",
+  "elasticpath.com",
+  "epcc-integration.global.ssl.fastly.net",
+];
+
+/**
+ * Permitted outside production only. A bundle that can name the API host can
+ * otherwise point token minting at any local port — the exact tampering path
+ * this module exists to close.
+ */
+const LOOPBACK_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "::1"];
+
+/** Strip scheme, path, port, and case, so comparisons are like-for-like. */
+function normalizeHost(value: string): string | null {
+  const withoutScheme = value.trim().replace(/^[a-zA-Z][\w+.-]*:\/\//, "");
+  const hostOnly = withoutScheme.split("/")[0];
+  // IPv6 literals keep their brackets; everything else drops a :port suffix.
+  const withoutPort = hostOnly.startsWith("[")
+    ? hostOnly.replace(/^\[([^\]]*)\](?::\d+)?$/, "$1")
+    : hostOnly.replace(/:\d+$/, "");
+  return withoutPort ? withoutPort.toLowerCase() : null;
+}
+
+export function isAllowedEpHost(
+  host: string,
+  allowlist: readonly string[] = DEFAULT_HOST_ALLOWLIST
+): boolean {
+  const hostname = normalizeHost(host);
+  if (!hostname) return false;
+
+  const patterns = isProduction()
+    ? allowlist
+    : [...allowlist, ...LOOPBACK_HOSTS];
+
+  return patterns.some((pattern) => {
+    const normalized = normalizeHost(pattern);
+    if (!normalized) return false;
+    return hasWildcard(normalized)
+      ? matchesGlob(hostname, normalized)
+      : normalized === hostname;
+  });
+}
+
+/**
+ * Logs the rejection at the point of failure — naming the host and the
+ * option that fixes it — so a blocked host never presents downstream as the
+ * generic "no EP Provider config" fallback.
+ */
+export function reportRejectedEpHost(
+  host: string,
+  source: string,
+  allowlist: readonly string[]
+): void {
+  console.error(
+    `[ep-commerce] ${source}: EP API host "${host}" is not in the host ` +
+      `allowlist (${allowlist.join(", ")}), so it was ignored. Elastic Path ` +
+      `Self Managed Commerce deployments must pass their host via the ` +
+      `\`hostAllowlist\` option on createEpAuth, extractEpProviderConfig, ` +
+      `and buildEpCtx.`
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/host-allowlist.ts
@@ -1,25 +1,18 @@
 /**
- * Host allowlist for the Elastic Path API endpoint.
+ * Host allowlist for the Elastic Path API endpoint. The host arrives from
+ * the Plasmic bundle, so an unchecked value redirects shopper token minting.
  *
- * The API host arrives from the Plasmic loader bundle rather than from the
- * deployment's own environment, so it is attacker-influenceable in the same
- * way any remotely-sourced config is. Every shopper token mint targets that
- * host, which makes an unchecked value a credential-exfiltration path.
- *
- * Normalization mirrors better-auth's public `matchesHostPattern` — strip
- * scheme, strip path, lowercase both sides — plus a port strip, so
- * `epcc.internal:8080` matches an `epcc.internal` entry. The function is
- * reimplemented rather than imported because this module is reachable from
- * Jest-side tests and better-auth is ESM-only.
+ * Normalization mirrors better-auth's `matchesHostPattern` plus a port
+ * strip; reimplemented because Jest-side tests reach this and better-auth
+ * is ESM-only.
  */
 import { hasWildcard, matchesGlob } from "../utils/glob-pattern";
 import { isProduction } from "./ep-plugin/production-guard";
 
 /**
- * Elastic Path Composable Commerce regions plus the integration environment,
- * which is served from Fastly and so is listed by exact host rather than by
- * wildcard. Elastic Path Self Managed Commerce hosts are not knowable here
- * and must be supplied by the deployment via `hostAllowlist`.
+ * Composable Commerce regions plus the integration host, which is on Fastly
+ * so it is listed exactly rather than by wildcard. Self Managed Commerce
+ * hosts must come from `hostAllowlist`.
  */
 export const DEFAULT_HOST_ALLOWLIST: readonly string[] = [
   "*.elasticpath.com",
@@ -27,11 +20,7 @@ export const DEFAULT_HOST_ALLOWLIST: readonly string[] = [
   "epcc-integration.global.ssl.fastly.net",
 ];
 
-/**
- * Permitted outside production only. A bundle that can name the API host can
- * otherwise point token minting at any local port — the exact tampering path
- * this module exists to close.
- */
+/** Outside production only — otherwise a bundle could aim at any local port. */
 const LOOPBACK_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "::1"];
 
 /** Strip scheme, path, port, and case, so comparisons are like-for-like. */
@@ -65,11 +54,7 @@ export function isAllowedEpHost(
   });
 }
 
-/**
- * Logs the rejection at the point of failure — naming the host and the
- * option that fixes it — so a blocked host never presents downstream as the
- * generic "no EP Provider config" fallback.
- */
+/** Logs at the point of failure so a rejection is never silent downstream. */
 export function reportRejectedEpHost(
   host: string,
   source: string,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/auth/index.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/auth/index.ts
@@ -23,9 +23,22 @@ export { epAuthMiddleware } from "./ep-plugin/middleware";
 export { createCartRoutes } from "../cart/server-routes";
 export type { CartRoutes } from "../cart/server-routes";
 export { createEpProxyRoutes } from "./ep-plugin/proxy-routes";
-export type {
-  EpProxyRoutes,
-  CreateEpProxyRoutesOptions,
-} from "./ep-plugin/proxy-routes";
+export type { EpProxyRoutes } from "./ep-plugin/proxy-routes";
+export {
+  enforceOriginGate,
+  isTrustedOrigin,
+  passesOriginGate,
+} from "./ep-plugin/origin-gate";
+export {
+  assertProductionSecret,
+  resolveAuthSecret,
+} from "./ep-plugin/production-guard";
+export {
+  DEFAULT_HOST_ALLOWLIST,
+  isAllowedEpHost,
+} from "./host-allowlist";
 export { extractEpProviderConfig } from "./extract-ep-provider-config";
-export type { EpProviderBundleConfig } from "./extract-ep-provider-config";
+export type {
+  EpProviderBundleConfig,
+  ExtractEpProviderConfigOptions,
+} from "./extract-ep-provider-config";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
@@ -27,7 +27,7 @@ describe("createCartRoutes origin gate", () => {
         Origin: "http://evil.test",
         "Sec-Fetch-Site": "cross-site",
       }),
-      { params: { path: [] } }
+      { params: Promise.resolve({ path: [] }) }
     );
 
     expect(res.status).not.toBe(403);
@@ -38,7 +38,7 @@ describe("createCartRoutes origin gate", () => {
     const { routes, getSession } = buildRoutes();
     const res = await routes.handle(
       request("POST", { "Sec-Fetch-Site": "same-origin" }),
-      { params: { path: ["items"] } }
+      { params: Promise.resolve({ path: ["items"] }) }
     );
 
     expect(res.status).not.toBe(403);
@@ -52,7 +52,7 @@ describe("createCartRoutes origin gate", () => {
         "Sec-Fetch-Site": "cross-site",
         Origin: "https://preview.vercel.app",
       }),
-      { params: { path: ["items"] } }
+      { params: Promise.resolve({ path: ["items"] }) }
     );
 
     expect(res.status).not.toBe(403);
@@ -66,7 +66,7 @@ describe("createCartRoutes origin gate", () => {
         "Sec-Fetch-Site": "cross-site",
         Origin: "http://evil.test",
       }),
-      { params: { path: ["items"] } }
+      { params: Promise.resolve({ path: ["items"] }) }
     );
 
     expect(res.status).toBe(403);
@@ -78,16 +78,29 @@ describe("createCartRoutes origin gate", () => {
     const { routes } = buildRoutes();
     const res = await routes.handle(
       request("DELETE", { Origin: "http://evil.test" }),
-      { params: { path: ["items", "item-1"] } }
+      { params: Promise.resolve({ path: ["items", "item-1"] }) }
     );
 
     expect(res.status).toBe(403);
   });
 
+  it("still accepts a plain (non-promised) params object at runtime", async () => {
+    // `params` is typed Promise-only so Next 15's build-time route validator
+    // accepts the handler, but `await` means a caller passing the object
+    // directly — Next 14 style, or a test — keeps working.
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(request("GET"), {
+      params: { path: [] },
+    } as any);
+
+    expect(res.status).not.toBe(403);
+    expect(getSession).toHaveBeenCalled();
+  });
+
   it("lets non-browser clients through when neither signal is present", async () => {
     const { routes, getSession } = buildRoutes();
     const res = await routes.handle(request("POST"), {
-      params: { path: ["items"] },
+      params: Promise.resolve({ path: ["items"] }),
     });
 
     expect(res.status).not.toBe(403);

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
@@ -85,9 +85,6 @@ describe("createCartRoutes origin gate", () => {
   });
 
   it("still accepts a plain (non-promised) params object at runtime", async () => {
-    // `params` is typed Promise-only so Next 15's build-time route validator
-    // accepts the handler, but `await` means a caller passing the object
-    // directly — Next 14 style, or a test — keeps working.
     const { routes, getSession } = buildRoutes();
     const res = await routes.handle(request("GET"), {
       params: { path: [] },

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/__tests__/server-routes-origin-gate.test.ts
@@ -1,0 +1,96 @@
+import { createCartRoutes } from "../server-routes";
+
+const TRUSTED = ["http://localhost:3456", "https://*.vercel.app"];
+
+function buildRoutes() {
+  const getSession = jest.fn().mockResolvedValue({ session: null, cart: null });
+  const epAuth = {
+    api: { getSession },
+    config: { trustedOrigins: TRUSTED },
+  } as any;
+  return { routes: createCartRoutes(epAuth), getSession };
+}
+
+function request(method: string, headers: Record<string, string> = {}) {
+  return new Request("http://localhost:3456/api/ep/cart/items", {
+    method,
+    headers,
+    ...(method === "GET" ? {} : { body: "{}" }),
+  });
+}
+
+describe("createCartRoutes origin gate", () => {
+  it("lets safe methods through regardless of origin", async () => {
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(
+      request("GET", {
+        Origin: "http://evil.test",
+        "Sec-Fetch-Site": "cross-site",
+      }),
+      { params: { path: [] } }
+    );
+
+    expect(res.status).not.toBe(403);
+    expect(getSession).toHaveBeenCalled();
+  });
+
+  it("lets same-origin mutations through", async () => {
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(
+      request("POST", { "Sec-Fetch-Site": "same-origin" }),
+      { params: { path: ["items"] } }
+    );
+
+    expect(res.status).not.toBe(403);
+    expect(getSession).toHaveBeenCalled();
+  });
+
+  it("lets cross-site mutations from a trusted origin through", async () => {
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(
+      request("POST", {
+        "Sec-Fetch-Site": "cross-site",
+        Origin: "https://preview.vercel.app",
+      }),
+      { params: { path: ["items"] } }
+    );
+
+    expect(res.status).not.toBe(403);
+    expect(getSession).toHaveBeenCalled();
+  });
+
+  it("rejects cross-site mutations from an untrusted origin before reading the session", async () => {
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(
+      request("POST", {
+        "Sec-Fetch-Site": "cross-site",
+        Origin: "http://evil.test",
+      }),
+      { params: { path: ["items"] } }
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "untrusted_origin" });
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects untrusted-origin deletes too", async () => {
+    const { routes } = buildRoutes();
+    const res = await routes.handle(
+      request("DELETE", { Origin: "http://evil.test" }),
+      { params: { path: ["items", "item-1"] } }
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("lets non-browser clients through when neither signal is present", async () => {
+    const { routes, getSession } = buildRoutes();
+    const res = await routes.handle(request("POST"), {
+      params: { path: ["items"] },
+    });
+
+    expect(res.status).not.toBe(403);
+    expect(getSession).toHaveBeenCalled();
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
@@ -32,7 +32,9 @@
  * headers that better-auth's nextCookies() plugin emits.
  */
 import type { EpAuth } from "../auth/ep-plugin/create-ep-auth-better";
+import { enforceOriginGate } from "../auth/ep-plugin/origin-gate";
 import { persistCartId } from "../auth/ep-plugin/persist-cart-id";
+import { parseCookieHeader } from "../utils/cookie-header";
 
 interface CartRouteContext {
   params: Promise<{ path?: string[] }> | { path?: string[] };
@@ -46,18 +48,6 @@ interface SessionShape {
     expires: number;
   } | null;
   cart: { id: string } | null;
-}
-
-function parseCookies(cookieHeader: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const part of cookieHeader.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq < 0) continue;
-    const name = part.slice(0, eq).trim();
-    if (!name) continue;
-    out[name] = decodeURIComponent(part.slice(eq + 1).trim());
-  }
-  return out;
 }
 
 async function callEp(
@@ -102,7 +92,10 @@ export interface CartRoutes {
 export function createCartRoutes(epAuth: EpAuth): CartRoutes {
   return {
     async handle(request, context) {
-      const cookies = parseCookies(request.headers.get("cookie") ?? "");
+      const gate = enforceOriginGate(request, epAuth.config.trustedOrigins);
+      if (gate) return gate;
+
+      const cookies = parseCookieHeader(request.headers.get("cookie") ?? "");
       const sessionResult = (await epAuth.api.getSession({
         cookies,
         headers: Object.fromEntries(request.headers.entries()),

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
@@ -36,11 +36,8 @@ import { enforceOriginGate } from "../auth/ep-plugin/origin-gate";
 import { persistCartId } from "../auth/ep-plugin/persist-cart-id";
 import { parseCookieHeader } from "../utils/cookie-header";
 
-/**
- * Promise-only: Next 15's route validator diffs against
- * `{ params: Promise<SegmentParams> }` and a union fails it. `await` still
- * accepts a plain object at runtime.
- */
+// Promise-only: a union fails Next 15's route validator. `await` still
+// accepts a plain object at runtime.
 interface CartRouteContext {
   params: Promise<{ path?: string[] }>;
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
@@ -36,8 +36,16 @@ import { enforceOriginGate } from "../auth/ep-plugin/origin-gate";
 import { persistCartId } from "../auth/ep-plugin/persist-cart-id";
 import { parseCookieHeader } from "../utils/cookie-header";
 
+/**
+ * Next 15 always hands route handlers a promised `params`, and its build-time
+ * route validator structurally diffs this type against
+ * `{ params: Promise<SegmentParams> }` — a `Promise<T> | T` union fails that
+ * check and breaks `next build` for every TypeScript consumer. `await`
+ * still accepts a plain object at runtime, so callers that pass one
+ * directly keep working.
+ */
 interface CartRouteContext {
-  params: Promise<{ path?: string[] }> | { path?: string[] };
+  params: Promise<{ path?: string[] }>;
 }
 
 interface SessionShape {
@@ -109,10 +117,7 @@ export function createCartRoutes(epAuth: EpAuth): CartRoutes {
         );
       }
 
-      const params =
-        context.params instanceof Promise
-          ? await context.params
-          : context.params;
+      const params = await context.params;
       const path = params.path ?? [];
       const method = request.method;
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart/server-routes.ts
@@ -37,12 +37,9 @@ import { persistCartId } from "../auth/ep-plugin/persist-cart-id";
 import { parseCookieHeader } from "../utils/cookie-header";
 
 /**
- * Next 15 always hands route handlers a promised `params`, and its build-time
- * route validator structurally diffs this type against
- * `{ params: Promise<SegmentParams> }` — a `Promise<T> | T` union fails that
- * check and breaks `next build` for every TypeScript consumer. `await`
- * still accepts a plain object at runtime, so callers that pass one
- * directly keep working.
+ * Promise-only: Next 15's route validator diffs against
+ * `{ params: Promise<SegmentParams> }` and a union fails it. `await` still
+ * accepts a plain object at runtime.
  */
 interface CartRouteContext {
   params: Promise<{ path?: string[] }>;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/build-ep-ctx.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/build-ep-ctx.test.ts
@@ -5,7 +5,7 @@ const EP_PROVIDER_MODULE = `
 function E(r){
   return g.createElement(e, {
     clientId:o&&"clientId"in o?o.clientId:"cid-abc",
-    customHost:o&&"customHost"in o?o.customHost:"https://custom.ep.com",
+    customHost:o&&"customHost"in o?o.customHost:"https://epcc-integration.global.ssl.fastly.net",
     host:o&&"host"in o?o.host:"custom",
     serverCartMode:o&&"serverCartMode"in o?o.serverCartMode:!0
   });
@@ -32,7 +32,7 @@ describe("buildEpCtx", () => {
     expect(ctx).toEqual(
       expect.objectContaining({
         clientId: "cid-abc",
-        host: "https://custom.ep.com",
+        host: "https://epcc-integration.global.ssl.fastly.net",
         serverCartMode: true,
         accessToken: "tok-abc",
       })
@@ -46,7 +46,45 @@ describe("buildEpCtx", () => {
     expect(ctx.cartId).toBeUndefined();
     expect(ctx.accountId).toBeUndefined();
     expect(ctx.clientId).toBe("cid-abc");
-    expect(ctx.host).toBe("https://custom.ep.com");
+    expect(ctx.host).toBe("https://epcc-integration.global.ssl.fastly.net");
+  });
+
+  it("rejects a host outside the allowlist, and accepts it once the deployment opts in", () => {
+    const smcData = {
+      bundle: {
+        projects: [{ globalContextsProviderFileName: "global__p.js" }],
+        modules: {
+          server: [
+            {
+              type: "code",
+              fileName: "global__p.js",
+              code: EP_PROVIDER_MODULE.replace(
+                "https://epcc-integration.global.ssl.fastly.net",
+                "https://commerce.selfmanaged.example"
+              ),
+            },
+          ],
+        },
+      },
+    };
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(() =>
+      buildEpCtx(smcData, { session: { accessToken: "tok" } })
+    ).toThrow(/EP Provider config not found/);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("commerce.selfmanaged.example")
+    );
+
+    const ctx = buildEpCtx(smcData, {
+      session: { accessToken: "tok" },
+      hostAllowlist: ["commerce.selfmanaged.example"],
+    });
+    expect(ctx.host).toBe("https://commerce.selfmanaged.example");
+
+    errorSpy.mockRestore();
   });
 
   it("throws a clear error when prefetchedData has no EP Provider config", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
@@ -36,9 +36,15 @@ export interface EpCtx {
 
 export function buildEpCtx(
   prefetchedData: unknown,
-  opts: { session: BuildEpCtxSessionInput }
+  opts: {
+    session: BuildEpCtxSessionInput;
+    /** Host patterns the EP API may be reached at. */
+    hostAllowlist?: readonly string[];
+  }
 ): EpCtx {
-  const config = extractEpProviderConfig(prefetchedData as any);
+  const config = extractEpProviderConfig(prefetchedData as any, {
+    hostAllowlist: opts.hostAllowlist,
+  });
   if (!config) {
     throw new Error(
       "buildEpCtx: EP Provider config not found in prefetchedData. " +

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/build-ep-ctx.ts
@@ -38,7 +38,6 @@ export function buildEpCtx(
   prefetchedData: unknown,
   opts: {
     session: BuildEpCtxSessionInput;
-    /** Host patterns the EP API may be reached at. */
     hostAllowlist?: readonly string[];
   }
 ): EpCtx {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
@@ -23,18 +23,9 @@ import {
 } from "./cart-mutations";
 
 /**
- * Duck-type for "something that can register custom functions" — a Plasmic
- * loader, or a test double.
- *
- * Deliberately permissive on `meta`. Two tighter shapes were tried and both
- * broke `next build` for consumers calling `registerEpCustomFunctions(PLASMIC)`:
- * a hand-written `Record<string, unknown>` is not assignable from the
- * loader's `CustomFunctionMeta<F>`; and borrowing `typeof registerFunction`
- * from `@plasmicapp/host` fails too, because `CustomFunctionMeta` is
- * re-declared in both `@plasmicapp/host` and `@plasmicapp/loader-react` and
- * TypeScript treats the copies as unrelated ("two different types with this
- * name exist"). Only a signature that ignores the metadata's identity
- * accepts every loader.
+ * Permissive on `meta` by necessity: `CustomFunctionMeta` is re-declared in
+ * both @plasmicapp/host and @plasmicapp/loader-react and TypeScript treats
+ * the copies as unrelated, so any stricter shape rejects some loader.
  */
 interface Registerable {
   registerFunction: (fn: any, meta: any) => void;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
@@ -22,11 +22,8 @@ import {
   epUpdateCartItem,
 } from "./cart-mutations";
 
-/**
- * Permissive on `meta` by necessity: `CustomFunctionMeta` is re-declared in
- * both @plasmicapp/host and @plasmicapp/loader-react and TypeScript treats
- * the copies as unrelated, so any stricter shape rejects some loader.
- */
+// `meta` stays `any`: CustomFunctionMeta is re-declared in both
+// @plasmicapp/host and loader-react, so any stricter shape rejects a loader.
 interface Registerable {
   registerFunction: (fn: any, meta: any) => void;
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/register-custom-functions.ts
@@ -22,11 +22,22 @@ import {
   epUpdateCartItem,
 } from "./cart-mutations";
 
+/**
+ * Duck-type for "something that can register custom functions" — a Plasmic
+ * loader, or a test double.
+ *
+ * Deliberately permissive on `meta`. Two tighter shapes were tried and both
+ * broke `next build` for consumers calling `registerEpCustomFunctions(PLASMIC)`:
+ * a hand-written `Record<string, unknown>` is not assignable from the
+ * loader's `CustomFunctionMeta<F>`; and borrowing `typeof registerFunction`
+ * from `@plasmicapp/host` fails too, because `CustomFunctionMeta` is
+ * re-declared in both `@plasmicapp/host` and `@plasmicapp/loader-react` and
+ * TypeScript treats the copies as unrelated ("two different types with this
+ * name exist"). Only a signature that ignores the metadata's identity
+ * accepts every loader.
+ */
 interface Registerable {
-  registerFunction: (
-    fn: (...args: unknown[]) => unknown,
-    meta: Record<string, unknown>
-  ) => void;
+  registerFunction: (fn: any, meta: any) => void;
 }
 
 const IMPORT_PATH = "@elasticpath/plasmic-ep-commerce-elastic-path/server";

--- a/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/server.ts
@@ -61,15 +61,22 @@ export {
   epAuthMiddleware,
   createCartRoutes,
   createEpProxyRoutes,
+  enforceOriginGate,
+  isTrustedOrigin,
+  passesOriginGate,
+  assertProductionSecret,
+  resolveAuthSecret,
+  DEFAULT_HOST_ALLOWLIST,
+  isAllowedEpHost,
 } from "./auth";
 export type {
   EpAuth,
   EpAuthConfig,
   EpSession,
   EpProviderBundleConfig,
+  ExtractEpProviderConfigOptions,
   EpPluginOptions,
   EpProxyRoutes,
-  CreateEpProxyRoutesOptions,
 } from "./auth";
 
 // Server-side custom functions for Studio Server Queries (PRD #262 / #272)

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
@@ -1,0 +1,54 @@
+/**
+ * Server-side `Cookie:` header parsing, shared by the auth middleware and
+ * the cart / proxy route handlers. Browser-side cookie access lives in
+ * `./cookies.ts` (js-cookie) and is not interchangeable with this.
+ */
+
+/**
+ * better-auth writes its cookies under a `__Secure-` prefix whenever the
+ * deployment is served over HTTPS, and splits oversized `session_data`
+ * payloads into `<name>.0`, `<name>.1`, … chunks. Presence checks that
+ * compare names literally miss both forms.
+ */
+const SECURE_PREFIX = "__Secure-";
+
+export function parseCookieHeader(
+  cookieHeader: string
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const name = part.slice(0, eq).trim();
+    if (!name) continue;
+    const raw = part.slice(eq + 1).trim();
+    try {
+      out[name] = decodeURIComponent(raw);
+    } catch {
+      // Malformed percent-encoding — keep the raw value rather than
+      // throwing a 500 out of a route handler.
+      out[name] = raw;
+    }
+  }
+  return out;
+}
+
+export function readCookie(
+  cookies: Record<string, string>,
+  name: string
+): string | undefined {
+  return cookies[name] ?? cookies[`${SECURE_PREFIX}${name}`];
+}
+
+/** True when `name` is present directly, `__Secure-` prefixed, or chunked. */
+export function hasCookie(
+  cookies: Record<string, string>,
+  name: string
+): boolean {
+  if (readCookie(cookies, name) !== undefined) return true;
+  return Object.keys(cookies).some(
+    (key) =>
+      key.startsWith(`${name}.`) ||
+      key.startsWith(`${SECURE_PREFIX}${name}.`)
+  );
+}

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
@@ -1,5 +1,3 @@
-/** Server-side Cookie header parsing. Browser access is in ./cookies.ts. */
-
 const SECURE_PREFIX = "__Secure-";
 
 export function parseCookieHeader(

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/cookie-header.ts
@@ -1,15 +1,5 @@
-/**
- * Server-side `Cookie:` header parsing, shared by the auth middleware and
- * the cart / proxy route handlers. Browser-side cookie access lives in
- * `./cookies.ts` (js-cookie) and is not interchangeable with this.
- */
+/** Server-side Cookie header parsing. Browser access is in ./cookies.ts. */
 
-/**
- * better-auth writes its cookies under a `__Secure-` prefix whenever the
- * deployment is served over HTTPS, and splits oversized `session_data`
- * payloads into `<name>.0`, `<name>.1`, … chunks. Presence checks that
- * compare names literally miss both forms.
- */
 const SECURE_PREFIX = "__Secure-";
 
 export function parseCookieHeader(
@@ -25,8 +15,6 @@ export function parseCookieHeader(
     try {
       out[name] = decodeURIComponent(raw);
     } catch {
-      // Malformed percent-encoding — keep the raw value rather than
-      // throwing a 500 out of a route handler.
       out[name] = raw;
     }
   }
@@ -40,7 +28,7 @@ export function readCookie(
   return cookies[name] ?? cookies[`${SECURE_PREFIX}${name}`];
 }
 
-/** True when `name` is present directly, `__Secure-` prefixed, or chunked. */
+/** Matches `name`, `__Secure-name`, and better-auth's `name.0` chunks. */
 export function hasCookie(
   cookies: Record<string, string>,
   name: string

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/glob-pattern.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/glob-pattern.ts
@@ -1,10 +1,4 @@
-/**
- * Glob matching for origin and host allowlists, reproducing the semantics
- * better-auth applies to `trustedOrigins` entries: `*` and `?` stand in for
- * any run of / any single character that is not a path separator.
- * better-auth's own matcher is internal to the library, so the behaviour is
- * mirrored here rather than imported.
- */
+/** Mirrors better-auth's trustedOrigins glob semantics; its matcher is internal. */
 
 const REGEXP_SPECIALS = /[\\^$.*+?()[\]{}|]/g;
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/glob-pattern.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/glob-pattern.ts
@@ -1,0 +1,27 @@
+/**
+ * Glob matching for origin and host allowlists, reproducing the semantics
+ * better-auth applies to `trustedOrigins` entries: `*` and `?` stand in for
+ * any run of / any single character that is not a path separator.
+ * better-auth's own matcher is internal to the library, so the behaviour is
+ * mirrored here rather than imported.
+ */
+
+const REGEXP_SPECIALS = /[\\^$.*+?()[\]{}|]/g;
+
+export function globToRegExp(pattern: string): RegExp {
+  let body = "";
+  for (const ch of pattern) {
+    if (ch === "*") body += "[^/\\\\]*?";
+    else if (ch === "?") body += "[^/\\\\]";
+    else body += ch.replace(REGEXP_SPECIALS, "\\$&");
+  }
+  return new RegExp(`^${body}$`);
+}
+
+export function hasWildcard(pattern: string): boolean {
+  return pattern.includes("*") || pattern.includes("?");
+}
+
+export function matchesGlob(value: string, pattern: string): boolean {
+  return globToRegExp(pattern).test(value);
+}


### PR DESCRIPTION
Batches the six mechanical fixes from security PRD #279. Design is recorded in `docs/adr/0001-single-origin-trust-list.md` and the package `CONTEXT.md`.

Common thread: a misconfigured deployment should refuse to run rather than degrade quietly.

## Security batch (#279)

- **HIGH-2** — `createEpAuth` refuses to serve when the session secret is missing, is a known example placeholder, or is under 32 characters. Guards stand down during `next build` so build-then-inject-env pipelines still work; the throw lands on the first request served.
- **MED-1** — `allowedOrigins` and its `localhost:3003` production default are deleted. CORS reflection derives from the auth instance's resolved `trustedOrigins` (ADR-0001), which includes the `baseURL` origin and `BETTER_AUTH_TRUSTED_ORIGINS` — not just the caller's array. This structurally fixes the silent cart-id-persistence 403 from Studio.
- **MED-2** — cart and proxy routes reject untrusted cross-site requests with `403 untrusted_origin`, on Go `CrossOriginProtection` semantics including its Origin-vs-Host check.
- **MED-3** — production `dispatch_failed` returns `{ error, correlationId }` only; the full error goes to `console.error`.
- **LOW-1/2** — middleware parses the Cookie header instead of substring-matching it, and understands `__Secure-` and chunked `session_data`. Dead RSC cookie-write block removed.
- **LOW-3** — the EP API host from the Plasmic bundle is checked against an allowlist before any token is minted. Rejections log at the point of failure.

## Also fixed here

Found while verifying with a real `next build`. All predate this branch; plain `tsc` misses them.

- **Two Next 15 build blockers** made the package impossible to build against with TypeScript. Route contexts exported a `Promise<T> | T` union that fails Next's structural check (now `Promise<T>`, with `await` preserving plain-object callers). `Registerable.registerFunction` restated the host signature in a way no loader satisfies.
- **`plasmic-mcp-registry`** — `PlasmicLike` used contravariant function properties plus an index signature class types can't satisfy, so `withRegistryCapture(PLASMIC)` never compiled. The only change outside the EP package and example.
- **Example checkout context** read no session at all: it omitted the required `cookies` and read better-auth's internal field names through `as any`, so the shopper token and cart id were always empty. Verified fixed end to end — `POST /api/checkout/sessions` now returns 201 with the real `cartId`; it previously could only return 400.

## Two decisions to confirm

- **Production signal is fail-closed.** The issue specified `NODE_ENV === "production"`; this enforces unless `NODE_ENV` is `development` or `test`. Deliberate deviation — an unset or bespoke `NODE_ENV` was the case that let a published fallback secret through.
- **`NEXT_PHASE` still bypasses the guard**, as specified. Note a Dockerfile with `ENV NEXT_PHASE=phase-production-build` carries it into the running container.

## Verification

1935 Jest + 85 Vitest. Package and registry build clean; `publint` reports no errors; the example builds with strict type checking.

Beyond unit tests, verified against a running server: the guard across ten environment combinations, the origin gate over real HTTP (six request shapes), CORS reflection, `trustedOrigins` parity asserted against better-auth's own resolved list, host-allowlist accept and reject, and the Studio cross-origin flow — one config line turns 403 into 200 while an untrusted origin still gets 403.

## Release

**Breaking** (`allowedOrigins` removed; guards throw). **Do not publish from this PR.** 0.2.0 ships after #282 and #288 land, as one release with a single migration note.

## Out of scope

#282 · #288 (README security model — that issue owns it, so it is not duplicated here) · secret splitting · logger abstraction (#243).

Closes #384
