### PR TITLE
fix(plasmic-mcp): report the real version instead of a hardcoded 0.1.0

### DIFF
--- a/packages/plasmic-mcp/src/index.ts
+++ b/packages/plasmic-mcp/src/index.ts
@@ -28,12 +28,7 @@ import { parseArgs } from "./cli.js";
 import { getAuth, writeAuth } from "./auth.js";
 import { acquireAuth } from "./auth-flow.js";
 import * as logger from "./logger.js";
-
-// Injected at build time via esbuild `define` from package.json (see build.mjs).
-// Falls back to "dev" when run directly through tsx.
-declare const __MCP_VERSION__: string;
-const VERSION =
-  typeof __MCP_VERSION__ !== "undefined" ? __MCP_VERSION__ : "dev";
+import { VERSION } from "./version.js";
 
 const US_EAST_HOST = "https://useast.storefront.elasticpath.com";
 const EU_WEST_HOST = "https://euwest.storefront.elasticpath.com";

--- a/packages/plasmic-mcp/src/server.ts
+++ b/packages/plasmic-mcp/src/server.ts
@@ -32,6 +32,7 @@ import { PlasmicApiClient } from "./api-client.js";
 import { getAuth } from "./auth.js";
 import { requireAuth } from "./auth-guard.js";
 import { requireSession, setSession } from "./session.js";
+import { VERSION } from "./version.js";
 import { loadProject } from "./model-loader.js";
 import { listPackages, addPackage, removePackage, upgradePackage, listAvailablePackages, listPackageComponents } from "./package-manager.js";
 import { syncFromDevHost, clearRegistryCache, recordVariantMetadataSync } from "./devhost-sync.js";
@@ -381,7 +382,7 @@ function handleMutationError(label: string, err: unknown, callId?: string) {
 export function createServer(): McpServer {
   const server = new McpServer({
     name: "plasmic",
-    version: "0.1.0",
+    version: VERSION,
   }, {
     capabilities: {
       logging: {},
@@ -1125,7 +1126,7 @@ export function createServer(): McpServer {
           case "health-check": {
             const healthResult: Record<string, unknown> = {
               status: "ok",
-              version: "0.1.0",
+              version: VERSION,
               authenticated: apiClient !== null,
             };
             if (auth) {

--- a/packages/plasmic-mcp/src/version.ts
+++ b/packages/plasmic-mcp/src/version.ts
@@ -1,0 +1,12 @@
+/**
+ * The server's own version, injected at build time by esbuild's `define` from
+ * package.json (see build.mjs). Falls back to "dev" when run through tsx.
+ *
+ * Everything that reports a version must read it from here. Hardcoded values
+ * drift silently and leave no way to tell which build is installed.
+ */
+
+declare const __MCP_VERSION__: string;
+
+export const VERSION =
+  typeof __MCP_VERSION__ !== "undefined" ? __MCP_VERSION__ : "dev";


### PR DESCRIPTION
## Problem

Two hardcoded literals meant nothing the server reported about itself was true:

- `server.ts:384` — the `McpServer` registration, so `serverInfo.version` in the `initialize` response. Claude Desktop logs this.
- `server.ts:1128` — `project.health-check`.

Both returned `"0.1.0"` for every build ever shipped. `build.mjs` has always injected the true version as `__MCP_VERSION__`, but only `--version` read it. The practical cost: an installed bundle couldn't be identified without reading files on disk — which is how a four-month-old build sat in Desktop unnoticed.

## Fix

Resolve the version once in `version.ts` and read it from every call site. `index.ts` drops its duplicated `declare`/fallback.

## Verification

Through the packed `.mcpb`, not just the source build:

```
serverInfo:    {"name":"plasmic","version":"0.2.2"}          (was 0.1.0)
health-check:  {"status":"ok","version":"0.2.2",...}         (was 0.1.0)
--version:     @elasticpath/plasmic-mcp v0.2.2              (unchanged)
```

Typecheck clean; 2193 unit tests across 52 files pass; `smoke-mcpb.mjs` passes; `project set` loads a real 33-component project in 5.7s.

Note: no version bump here, so releasing this needs a `0.2.3` bump (both `package.json` and `manifest.json`) — `plasmic-mcp-v0.2.2` is already tagged.