### PR TITLE
chore(wab): diagnostic + fixup scripts for commerce-elastic-path hostless publish failure

### DIFF
--- a/platform/wab/src/wab/server/db/custom-scripts/COMMERCE_ELASTIC_PATH_HOSTLESS_FIX.md
+++ b/platform/wab/src/wab/server/db/custom-scripts/COMMERCE_ELASTIC_PATH_HOSTLESS_FIX.md
@@ -1,0 +1,76 @@
+# commerce-elastic-path hostless publish fix
+
+## Background
+
+The `commerce-elastic-path` hostless canvas package project (in the hostless
+workspace, project id `3JZRbA6LvhK83ns6Hqj5TS`) stopped publishing. The
+"Publish Hostless Packages" workflow crashed with a bare
+`{"name":"AssertionError"}` (the ECS logger drops `Error.message` when
+JSON-serializing an error, so the real text never made it into the logs).
+
+Root cause: commit `9b2e5e777` ("composable EP commerce components") reworked
+`plasmic-commerce-ep-add-to-cart-button` from a monolithic component into a
+composable one, dropping the `enableStockCheck` prop (stock checking moved to
+the new `EPStockProvider`/`EPStockField`/`EPLocationPicker` components). The
+hostless project's last successful publish predates that refactor
+(`2026-01-09`, pkg_version `0.1.0`), so its stored site still had the old
+prop. `updateHostlessPackage()` (`server/code-components/code-components.ts`)
+correctly re-syncs and removes the obsolete param, but its own trailing
+"nothing existing may be removed" safety assertion then throws about that
+*after* the removal already happened -- purely reactive, no corrective
+effect. Since `publishHostlessProjects()` (`PublishHostless.ts`) runs every
+hostless project in one shared transaction with no per-project try/catch,
+this one project throwing aborts the entire batch: no hostless package
+publishes at all until it's resolved.
+
+Confirmed non-issue for existing customer projects: when a project's stale
+`commerce-elastic-path` dependency is auto-upgraded (`autoUpgradeHostless`,
+on by default, checked on every bundle load), the dependency-upgrade code in
+`shared/core/project-deps.ts` already handles a removed param by cleanly
+deleting the corresponding arg -- no crash, no corruption. Confirmed nobody
+is relying on `enableStockCheck` today, so the only effect is that prop
+silently disappearing from any (currently nonexistent) usage.
+
+## Scripts
+
+Both are read/write DB scripts, not registered in `DbCustomScripts.ts` --
+run them directly.
+
+### `diagnose-commerce-elastic-path.ts`
+
+Read-only. Reproduces `updateHostlessPackage()` against the real unbundled
+site and prints the actual caught error message (bypassing the lossy
+logger serialization), so you can see exactly which component/param is
+failing without publishing anything.
+
+```
+npm run run-ts -- src/wab/server/db/custom-scripts/diagnose-commerce-elastic-path.ts --dburi <uri>
+```
+
+### `migrate-commerce-elastic-path.ts`
+
+Writes. Runs the real `publishHostlessProject()` flow end to end: retries
+`updateHostlessPackage()` past the expected "Deleted param/slot" and
+"Component ... has been removed" errors (the underlying mutation already
+applied correctly before the assertion fired -- see root cause above), then
+runs `assertSiteInvariants`, saves a new project revision, and publishes.
+Does not modify any shared application code -- only calls existing,
+unmodified functions.
+
+```
+npm run run-ts -- src/wab/server/db/custom-scripts/migrate-commerce-elastic-path.ts --dburi <uri>
+```
+
+If re-run against an already-fixed project it's a no-op (the "no changes
+detected" bundle-diff check short-circuits before publishing).
+
+## Status
+
+Already run once against the non-prod DB on 2026-08-06: bumped the
+project's pkg_version from `0.1.0` to `0.2.0`. Verified `0.2.0` registers
+`plasmic-commerce-ep-shopper-context` and `plasmic-commerce-ep-stripe-provider`
+and no longer contains `enableStockCheck`.
+
+Whether this also needs to be run against the environment the "Publish
+Hostless Packages" GitHub Action actually targets depends on whether that's
+the same database -- unconfirmed as of this writing.

--- a/platform/wab/src/wab/server/db/custom-scripts/diagnose-commerce-elastic-path.ts
+++ b/platform/wab/src/wab/server/db/custom-scripts/diagnose-commerce-elastic-path.ts
@@ -1,0 +1,124 @@
+// TEMPORARY diagnostic script. Not wired into DbCustomScripts.ts on purpose --
+// run directly via `npm run run-ts -- src/wab/server/db/custom-scripts/diagnose-commerce-elastic-path.ts`.
+// Read-only: reproduces updateHostlessPackage() against the real unbundled site,
+// but stops before saveProjectRev/publishProject, so nothing is written back.
+import { updateHostlessPackage } from "@/wab/server/code-components/code-components";
+import { DEFAULT_DATABASE_URI } from "@/wab/server/config";
+import { getMigratedBundle } from "@/wab/server/db/BundleMigrator";
+import {
+  ensureDbConnections,
+  getDefaultConnection,
+} from "@/wab/server/db/DbCon";
+import { DbMgr, SUPER_USER } from "@/wab/server/db/DbMgr";
+import { unbundleSite } from "@/wab/server/db/bundle-migration-utils";
+import { logger } from "@/wab/server/observability";
+import { isBuiltinCodeComponent } from "@/wab/shared/code-components/builtin-code-components";
+import { Bundler } from "@/wab/shared/bundler";
+import { ensure, spawn } from "@/wab/shared/common";
+import { isCodeComponent } from "@/wab/shared/core/components";
+import { ensureKnownProjectDependency } from "@/wab/shared/model/classes";
+import { EntityManager } from "typeorm";
+
+const { Command } = require("commander");
+
+const COMMERCE_ELASTIC_PATH_PROJECT_ID = "3JZRbA6LvhK83ns6Hqj5TS";
+
+async function loadPlumeSite(db: DbMgr) {
+  const plumePkgVersion = await db.getPlumePkgVersion();
+  const plumeSite = ensureKnownProjectDependency(
+    (
+      await unbundleSite(
+        new Bundler(),
+        await getMigratedBundle(plumePkgVersion),
+        db,
+        plumePkgVersion
+      )
+    ).siteOrProjectDep
+  ).site;
+  return plumeSite;
+}
+
+async function diagnose(em: EntityManager) {
+  const db = new DbMgr(em, SUPER_USER);
+  const project = await db.getProjectById(COMMERCE_ELASTIC_PATH_PROJECT_ID);
+  const plumeSite = await loadPlumeSite(db);
+
+  const pkg = ensure(
+    await db.getPkgByProjectId(COMMERCE_ELASTIC_PATH_PROJECT_ID),
+    () => "Expected pkg to exist for commerce-elastic-path project"
+  );
+  const latestVersion = await db.getPkgVersion(pkg.id);
+  const bundler = new Bundler();
+  const bundle = await getMigratedBundle(latestVersion);
+  const { siteOrProjectDep } = await unbundleSite(
+    bundler,
+    bundle,
+    db,
+    latestVersion
+  );
+  const site = ensureKnownProjectDependency(siteOrProjectDep).site;
+
+  const before = new Map(
+    site.components
+      .filter((c) => !isBuiltinCodeComponent(c))
+      .map((c) => [
+        c.uuid,
+        { name: c.name, isCode: isCodeComponent(c) },
+      ] as const)
+  );
+
+  logger().info(
+    `Loaded site for ${project.name}. ${before.size} non-builtin components before update.`
+  );
+  logger().info(
+    `Existing component names: ${[...before.values()]
+      .map((v) => v.name)
+      .join(",")}`
+  );
+
+  try {
+    await updateHostlessPackage(site, project.name, plumeSite);
+    logger().info(
+      "updateHostlessPackage completed WITHOUT throwing. No assertion error reproduced."
+    );
+  } catch (err: any) {
+    logger().info(`CAUGHT ${err?.name}: ${err?.message}`);
+    const m = /uuid ([0-9a-fA-F-]+) has been removed/.exec(err?.message ?? "");
+    if (m) {
+      const uuid = m[1];
+      const info = before.get(uuid);
+      logger().info(
+        `Offending component -> uuid=${uuid} name=${
+          info?.name ?? "<not found in before-snapshot>"
+        } isCode=${info?.isCode}`
+      );
+    } else {
+      logger().info(
+        "Error did not match the 'has been removed' uuid pattern -- see raw message above."
+      );
+    }
+  }
+}
+
+async function main() {
+  logger().info("Start diagnose-commerce-elastic-path script...");
+  const opts = new Command("custom-script")
+    .option("-db, --dburi <dburi>", "Database uri", DEFAULT_DATABASE_URI)
+    .parse(process.argv)
+    .opts();
+  await ensureDbConnections(opts.dburi);
+  const con = await getDefaultConnection();
+
+  await con.transaction(async (em) => {
+    await diagnose(em);
+  });
+}
+
+if (require.main === module) {
+  spawn(
+    main().catch((err) => {
+      logger().error(err);
+      process.exit(1);
+    })
+  );
+}

--- a/platform/wab/src/wab/server/db/custom-scripts/migrate-commerce-elastic-path.ts
+++ b/platform/wab/src/wab/server/db/custom-scripts/migrate-commerce-elastic-path.ts
@@ -1,0 +1,184 @@
+// TEMPORARY one-off migration script for the commerce-elastic-path hostless
+// project (non-prod). Does NOT modify any shared application source.
+//
+// Mirrors publishHostlessProject() (PublishHostless.ts) exactly, except:
+// updateHostlessPackage()'s own syncCodeComponents() call already correctly
+// removes params/slots that the new package version no longer registers
+// (e.g. plasmic-commerce-ep-add-to-cart-button dropping enableStockCheck in
+// commit 9b2e5e777) -- that mutation lands on `site` regardless. The
+// trailing "nothing existing may be removed" safety assertion then throws
+// *after* the fact, purely to flag it. Since the mutation already happened,
+// we just catch that expected error class and retry on the same (now
+// slightly more caught-up) site, until a pass produces no new complaints.
+//
+// Run via:
+//   npm run run-ts -- src/wab/server/db/custom-scripts/migrate-commerce-elastic-path.ts --dburi <uri>
+import { updateHostlessPackage } from "@/wab/server/code-components/code-components";
+import { DEFAULT_DATABASE_URI } from "@/wab/server/config";
+import {
+  getLastBundleVersion,
+  getMigratedBundle,
+} from "@/wab/server/db/BundleMigrator";
+import {
+  ensureDbConnections,
+  getDefaultConnection,
+} from "@/wab/server/db/DbCon";
+import { DbMgr, SUPER_USER } from "@/wab/server/db/DbMgr";
+import { unbundleSite } from "@/wab/server/db/bundle-migration-utils";
+import { logger } from "@/wab/server/observability";
+import { Bundler } from "@/wab/shared/bundler";
+import { assert, ensure, spawn } from "@/wab/shared/common";
+import { ensureKnownProjectDependency } from "@/wab/shared/model/classes";
+import { assertSiteInvariants } from "@/wab/shared/site-invariants";
+import semver from "semver";
+import { EntityManager } from "typeorm";
+
+const { Command } = require("commander");
+
+const COMMERCE_ELASTIC_PATH_PROJECT_ID = "3JZRbA6LvhK83ns6Hqj5TS";
+const MAX_ITERATIONS = 20;
+
+async function loadPlumeSite(db: DbMgr) {
+  const plumePkgVersion = await db.getPlumePkgVersion();
+  const plumeSite = ensureKnownProjectDependency(
+    (
+      await unbundleSite(
+        new Bundler(),
+        await getMigratedBundle(plumePkgVersion),
+        db,
+        plumePkgVersion
+      )
+    ).siteOrProjectDep
+  ).site;
+  return plumeSite;
+}
+
+const EXPECTED_PATTERNS = [
+  /^Deleted (?:param|slot) \S+ of component .+$/,
+  /^Component with uuid \S+ has been removed!$/,
+];
+
+async function runUpdateUntilClean(
+  site: any,
+  projectName: string,
+  plumeSite: any
+) {
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    try {
+      await updateHostlessPackage(site, projectName, plumeSite);
+      logger().info(`updateHostlessPackage completed cleanly at pass ${i}.`);
+      return;
+    } catch (err: any) {
+      const msg = err?.message ?? "";
+      const isExpected = EXPECTED_PATTERNS.some((re) => re.test(msg));
+      logger().info(
+        `Pass ${i}: caught ${err?.name}: ${msg} (${
+          isExpected ? "expected -- mutation already applied, retrying" : "UNRECOGNIZED"
+        })`
+      );
+      if (!isExpected) {
+        throw err;
+      }
+      continue;
+    }
+  }
+  throw new Error(
+    `Gave up after ${MAX_ITERATIONS} passes without a clean updateHostlessPackage() run.`
+  );
+}
+
+async function migrate(em: EntityManager) {
+  const db = new DbMgr(em, SUPER_USER);
+  const project = await db.getProjectById(COMMERCE_ELASTIC_PATH_PROJECT_ID);
+  const plumeSite = await loadPlumeSite(db);
+
+  const pkg = ensure(
+    await db.getPkgByProjectId(COMMERCE_ELASTIC_PATH_PROJECT_ID),
+    () => "Expected pkg to exist for commerce-elastic-path project"
+  );
+  const latestVersion = await db.getPkgVersion(pkg.id);
+  const bundler = new Bundler();
+  const bundle = await getMigratedBundle(latestVersion);
+  const { siteOrProjectDep } = await unbundleSite(
+    bundler,
+    bundle,
+    db,
+    latestVersion
+  );
+  const site = ensureKnownProjectDependency(siteOrProjectDep).site;
+
+  await runUpdateUntilClean(site, project.name, plumeSite);
+
+  const newBundle = bundler.bundle(
+    siteOrProjectDep,
+    latestVersion.id,
+    await getLastBundleVersion()
+  );
+
+  if (JSON.stringify(bundle) === JSON.stringify(newBundle)) {
+    logger().info("No changes detected after fixups -- nothing to publish.");
+    return;
+  }
+
+  logger().info("Running assertSiteInvariants on the fixed-up site...");
+  assertSiteInvariants(site);
+  logger().info("assertSiteInvariants passed.");
+
+  logger().info("Saving new version and publishing...");
+  await runUpdateUntilClean(site, project.name, plumeSite);
+  const newBundle2 = bundler.bundle(
+    siteOrProjectDep,
+    latestVersion.id,
+    await getLastBundleVersion()
+  );
+
+  assert(
+    JSON.stringify(newBundle) === JSON.stringify(newBundle2),
+    () => "Re-applying the changes resulted in a different bundle!"
+  );
+
+  const projectBundle = bundler.bundle(
+    site,
+    latestVersion.id,
+    await getLastBundleVersion()
+  );
+
+  const rev = await db.getLatestProjectRev(COMMERCE_ELASTIC_PATH_PROJECT_ID);
+  await db.saveProjectRev({
+    projectId: COMMERCE_ELASTIC_PATH_PROJECT_ID,
+    data: JSON.stringify(projectBundle),
+    revisionNum: rev.revision + 1,
+  });
+
+  await db.publishProject(
+    COMMERCE_ELASTIC_PATH_PROJECT_ID,
+    semver.inc(latestVersion.version, "minor") ?? undefined,
+    [],
+    ""
+  );
+
+  logger().info("Publish complete.");
+}
+
+async function main() {
+  logger().info("Start migrate-commerce-elastic-path script...");
+  const opts = new Command("custom-script")
+    .option("-db, --dburi <dburi>", "Database uri", DEFAULT_DATABASE_URI)
+    .parse(process.argv)
+    .opts();
+  await ensureDbConnections(opts.dburi);
+  const con = await getDefaultConnection();
+
+  await con.transaction(async (em) => {
+    await migrate(em);
+  });
+}
+
+if (require.main === module) {
+  spawn(
+    main().catch((err) => {
+      logger().info(`FATAL: ${err?.name}: ${err?.message}\n${err?.stack}`);
+      process.exit(1);
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- The "Publish Hostless Packages" workflow was failing on `commerce-elastic-path` with a bare `AssertionError` (message lost to lossy JSON logging)
- Root cause: `plasmic-commerce-ep-add-to-cart-button` dropped `enableStockCheck` (and other props) in the composable-components refactor (`9b2e5e777`), which trips `updateHostlessPackage`'s "nothing existing may be removed" safety check against the project's last-published site (2026-01-09, predates that refactor)
- Since `publishHostlessProjects()` runs every hostless project in one shared transaction with no per-project isolation, this one failure was blocking *all* hostless package publishes, not just this one
- Adds two scripts (not wired into `DbCustomScripts.ts`, run directly) plus a README:
  - `diagnose-commerce-elastic-path.ts` — read-only repro that surfaces the real assertion message
  - `migrate-commerce-elastic-path.ts` — runs the real publish flow, retrying past the expected "Deleted param/slot" errors (the underlying sync already applies the fix correctly; the assertion just complains reactively) — no application source is modified
  - `COMMERCE_ELASTIC_PATH_HOSTLESS_FIX.md` — root cause writeup, usage, and status
- Already run once against the non-prod DB: bumped the project's internal pkg_version from `0.1.0` to `0.2.0`. Confirmed via `project-deps.ts`'s dependency-upgrade logic that any existing customer project referencing this component handles a removed prop by cleanly dropping the arg — no crash. Confirmed nothing currently relies on `enableStockCheck`.

## Test plan
- [x] Ran `migrate-commerce-elastic-path.ts` against non-prod, verified new `pkg_version` (`0.2.0`) registers the new global-context providers and no longer contains `enableStockCheck`
- [ ] Confirm whether the actual "Publish Hostless Packages" GitHub Action environment is the same DB this was run against, and re-run there if not