### PR TITLE
fix(ep-commerce): cart mutation errors and multilocation quantity updates

### DIFF
--- a/plasmicpkgs/commerce-providers/elastic-path/COMPONENTS.md
+++ b/plasmicpkgs/commerce-providers/elastic-path/COMPONENTS.md
@@ -818,6 +818,16 @@ For each Server Query in the Plasmic UI:
 
 Then bind the consuming component's `product` / `cart` / `products` prop (advanced section) to `$q.<queryName>.data`.
 
+### Add to Cart errors (`$ctx.addToCartState.error`)
+
+`EPAddToCartButton` exposes `{ isLoading, isDisabled, error }` via the DataProvider named `addToCartState`. On a proxy or Elastic Path failure, `error` is a non-empty string.
+
+Designers must bind their own text, banner, visibility condition, or other UI to `$ctx.addToCartState.error`. The component does **not** render a default error banner or toast. Existing designs only show an error where that binding exists.
+
+Use the component's **error** preview state in Studio to design the bound UI.
+
+Quantity and remove failures are **not** designer-facing in this release: quantity updates revert the displayed value and log; remove failures leave the item in the cart and log.
+
 ### Required Next.js setup
 
 1. **`platformOptions: { nextjs: { appDir: true } }`** in `plasmic-init.ts`. Without this the loader fetches the Pages Router bundle which omits `serverQueriesExecFuncFileName` per-page metadata.

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityButton.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityButton.tsx
@@ -57,7 +57,11 @@ export function EPCartItemQuantityButton(
   const quantityCtx = useCartItemQuantity();
   const inEditor = !!usePlasmicCanvasContext();
 
-  const isDisabled =
+  // Limit-reached only — do NOT native-disable while loading. Studio often
+  // wraps this button in a chrome box; a native `disabled` button stops
+  // receiving clicks, and subsequent clicks hit the inert wrapper instead.
+  // Loading is enforced inside increment/decrement via an in-flight guard.
+  const isLimitDisabled =
     previewState === "disabled"
       ? true
       : previewState === "enabled"
@@ -66,8 +70,16 @@ export function EPCartItemQuantityButton(
           ? !(quantityCtx?.canIncrement ?? true)
           : !(quantityCtx?.canDecrement ?? true);
 
-  const handleClick = () => {
-    if (isDisabled || !quantityCtx) return;
+  const isBusy = previewState === "auto" && !!quantityCtx?.isLoading;
+  const isDisabled = isLimitDisabled;
+
+  const handleClick = (
+    e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLElement>
+  ) => {
+    // Clicks may land on nested text nodes from the Studio slot.
+    e.preventDefault();
+    e.stopPropagation();
+    if (isLimitDisabled || isBusy || !quantityCtx) return;
     if (action === "increment") {
       quantityCtx.increment();
     } else {
@@ -76,25 +88,21 @@ export function EPCartItemQuantityButton(
   };
 
   return (
-    <div
+    <button
+      type="button"
       className={className}
       onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
+      disabled={isLimitDisabled && !inEditor}
       aria-label={
         action === "increment" ? "Increase quantity" : "Decrease quantity"
       }
-      aria-disabled={isDisabled}
+      aria-disabled={isDisabled || isBusy || undefined}
+      aria-busy={isBusy || undefined}
       data-disabled={isDisabled || undefined}
+      data-loading={isBusy || undefined}
     >
       {children}
-    </div>
+    </button>
   );
 }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityControl.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemQuantityControl.tsx
@@ -7,10 +7,13 @@ import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
 import React, { useState, useCallback, useEffect, useRef } from "react";
-import useUpdateItem from "../cart/use-update-item";
+import { mutate as swrMutate } from "swr";
 import { Registerable } from "../registerable";
 import { createLogger } from "../utils/logger";
 import { MOCK_CART_LINE_ITEMS } from "../utils/design-time-data";
+import { callEpProxy } from "../ep-server-functions/proxy-fetch";
+import { epCartCacheKey } from "../cart-provider/cache-keys";
+import type { Cart } from "../types/cart";
 import {
   CartItemQuantityContext,
   CartItemQuantityContextValue,
@@ -92,30 +95,72 @@ export function EPCartItemQuantityControl(
   } = props;
 
   const currentItem = useSelector("currentCartItem") as
-    | { id: string; quantity: number; locationSlug?: string }
+    | {
+        id: string;
+        quantity: number;
+        locationSlug?: string;
+        stockAvailable?: number | null;
+      }
     | undefined;
   const inEditor = !!usePlasmicCanvasContext();
-  const updateItem = useUpdateItem();
 
   const useMock = previewState !== "auto" || (!currentItem && inEditor);
 
   const mockQuantity =
     previewState === "minReached" ? minQuantity : MOCK_CART_LINE_ITEMS[0].quantity;
 
-  const serverQuantity = useMock ? mockQuantity : (currentItem?.quantity ?? 1);
+  const serverQuantity = useMock
+    ? mockQuantity
+    : Number(currentItem?.quantity ?? 1);
 
   const [localQuantity, setLocalQuantity] = useState(serverQuantity);
   const [isLoading, setIsLoading] = useState(false);
+  // After a stock-rejection from EP on an *increment*, remember the highest
+  // qty that succeeded so we stop offering + even when stockAvailable isn't
+  // on the line item.
+  const [stockCap, setStockCap] = useState<number | null>(null);
+  const inFlightRef = useRef(false);
+  const quantityRef = useRef(serverQuantity);
+  const itemIdRef = useRef(currentItem?.id);
+  // Keep the location slug across SWR refreshes that may briefly omit it —
+  // multilocation updates require it on every write.
+  const locationRef = useRef<string | undefined>(
+    currentItem?.locationSlug?.trim() || undefined
+  );
+  quantityRef.current = localQuantity;
+  if (currentItem?.locationSlug?.trim()) {
+    locationRef.current = currentItem.locationSlug.trim();
+  }
 
   // Sync local state when server data changes (after mutation resolves)
   const prevServerQuantity = useRef(serverQuantity);
   useEffect(() => {
     if (prevServerQuantity.current !== serverQuantity) {
       setLocalQuantity(serverQuantity);
-      setIsLoading(false);
+      quantityRef.current = serverQuantity;
+      if (!inFlightRef.current) {
+        setIsLoading(false);
+      }
       prevServerQuantity.current = serverQuantity;
     }
   }, [serverQuantity]);
+
+  // New line-item identity → reset busy + stock-cap state.
+  useEffect(() => {
+    if (itemIdRef.current !== currentItem?.id) {
+      itemIdRef.current = currentItem?.id;
+      inFlightRef.current = false;
+      setIsLoading(false);
+      setStockCap(null);
+      locationRef.current = currentItem?.locationSlug?.trim() || undefined;
+      if (currentItem?.quantity != null) {
+        const q = Number(currentItem.quantity);
+        setLocalQuantity(q);
+        quantityRef.current = q;
+        prevServerQuantity.current = q;
+      }
+    }
+  }, [currentItem?.id, currentItem?.quantity, currentItem?.locationSlug]);
 
   const effectiveIsLoading = useMock
     ? previewState === "loading"
@@ -123,58 +168,116 @@ export function EPCartItemQuantityControl(
 
   const effectiveQuantity = useMock ? mockQuantity : localQuantity;
 
+  // Prefer live stock from the line item; fall back to a cap learned from
+  // an EP "not enough stock" rejection on a prior increment.
+  const stockAvailable =
+    typeof currentItem?.stockAvailable === "number"
+      ? currentItem.stockAvailable
+      : null;
+  const effectiveMax = Math.min(
+    maxQuantity,
+    stockAvailable ?? stockCap ?? maxQuantity
+  );
+
   const canDecrement = effectiveQuantity > minQuantity;
-  const canIncrement = effectiveQuantity < maxQuantity;
+  const canIncrement = effectiveQuantity < effectiveMax;
 
   const doUpdate = useCallback(
     async (newQuantity: number) => {
-      if (!currentItem?.id || useMock) return;
+      const itemId = itemIdRef.current ?? currentItem?.id;
+      if (!itemId || useMock) return;
+      if (inFlightRef.current) return;
+      // Snapshot the last known-good qty before this write. Optimistic UI
+      // already moved quantityRef to newQuantity.
+      const previousQty = prevServerQuantity.current;
+      const location =
+        locationRef.current ||
+        currentItem?.locationSlug?.trim() ||
+        undefined;
+      inFlightRef.current = true;
       setIsLoading(true);
       try {
-        await updateItem({
-          id: currentItem.id,
+        const updated = await callEpProxy<Cart>("updateCartItem", {
+          itemId,
           quantity: newQuantity,
-          ...(currentItem.locationSlug && { location: currentItem.locationSlug }),
-        } as { id: string; quantity: number; location?: string });
+          ...(location ? { location } : {}),
+        });
+        await swrMutate(epCartCacheKey(), updated, { revalidate: false });
+        setLocalQuantity(newQuantity);
+        quantityRef.current = newQuantity;
+        prevServerQuantity.current = newQuantity;
       } catch (err) {
-        // Revert optimistic update on error
-        setLocalQuantity(serverQuantity);
         const message =
           err instanceof Error ? err.message : "Failed to update quantity";
         log.error("Quantity update failed", { error: message } as Record<
           string,
           unknown
         >);
+
+        const revertTo = Math.max(minQuantity, Number(previousQty) || minQuantity);
+        setLocalQuantity(revertTo);
+        quantityRef.current = revertTo;
+        prevServerQuantity.current = revertTo;
+
+        // Only freeze + when an increment was rejected for stock — a
+        // decrement can also surface the same EP message when location is
+        // missing, and that must not permanently disable +.
+        if (/stock/i.test(message) && newQuantity > previousQty) {
+          setStockCap(revertTo);
+        }
+
+        // Refresh cart so UI matches EP after a failed write.
+        try {
+          await swrMutate(epCartCacheKey());
+        } catch {
+          // ignore revalidation errors
+        }
+      } finally {
+        inFlightRef.current = false;
+        setIsLoading(false);
       }
     },
-    [currentItem?.id, updateItem, useMock, serverQuantity]
+    [
+      currentItem?.id,
+      currentItem?.locationSlug,
+      useMock,
+      minQuantity,
+    ]
   );
 
   const increment = useCallback(() => {
-    if (!canIncrement) return;
-    const newQty = effectiveQuantity + 1;
+    if (inFlightRef.current) return;
+    const current = quantityRef.current;
+    if (current >= effectiveMax) return;
+    const newQty = current + 1;
     setLocalQuantity(newQty);
-    doUpdate(newQty);
-  }, [canIncrement, effectiveQuantity, doUpdate]);
+    quantityRef.current = newQty;
+    void doUpdate(newQty);
+  }, [effectiveMax, doUpdate]);
 
   const decrement = useCallback(() => {
-    if (!canDecrement) return;
-    const newQty = effectiveQuantity - 1;
+    if (inFlightRef.current) return;
+    const current = quantityRef.current;
+    if (current <= minQuantity) return;
+    const newQty = current - 1;
     setLocalQuantity(newQty);
-    doUpdate(newQty);
-  }, [canDecrement, effectiveQuantity, doUpdate]);
+    quantityRef.current = newQty;
+    void doUpdate(newQty);
+  }, [minQuantity, doUpdate]);
 
   const setQuantity = useCallback(
     (next: number) => {
+      if (inFlightRef.current) return;
       const clamped = Math.min(
-        maxQuantity,
-        Math.max(minQuantity, Math.trunc(next))
+        effectiveMax,
+        Math.max(minQuantity, Math.trunc(Number(next)))
       );
-      if (clamped === effectiveQuantity) return;
+      if (clamped === quantityRef.current) return;
       setLocalQuantity(clamped);
-      doUpdate(clamped);
+      quantityRef.current = clamped;
+      void doUpdate(clamped);
     },
-    [minQuantity, maxQuantity, effectiveQuantity, doUpdate]
+    [minQuantity, effectiveMax, doUpdate]
   );
 
   const contextValue: CartItemQuantityContextValue = {
@@ -183,7 +286,7 @@ export function EPCartItemQuantityControl(
     canDecrement,
     canIncrement,
     minQuantity,
-    maxQuantity,
+    maxQuantity: effectiveMax,
     increment,
     decrement,
     setQuantity,

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemRemoveButton.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/EPCartItemRemoveButton.tsx
@@ -7,9 +7,11 @@ import registerComponent, {
   CodeComponentMeta,
 } from "@plasmicapp/host/registerComponent";
 import React, { useState } from "react";
-import useRemoveItem from "../cart/use-remove-item";
+import { mutate as swrMutate } from "swr";
 import { Registerable } from "../registerable";
 import { createLogger } from "../utils/logger";
+import { callEpProxy } from "../ep-server-functions/proxy-fetch";
+import { epCartCacheKey } from "../cart-provider/cache-keys";
 
 const log = createLogger("EPCartItemRemoveButton");
 
@@ -53,7 +55,6 @@ export function EPCartItemRemoveButton(props: EPCartItemRemoveButtonProps) {
   const currentItem = useSelector("currentCartItem") as
     | { id: string; name?: string }
     | undefined;
-  const removeItem = useRemoveItem();
   const inEditor = !!usePlasmicCanvasContext();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -64,10 +65,11 @@ export function EPCartItemRemoveButton(props: EPCartItemRemoveButtonProps) {
     : isLoading;
 
   const handleRemove = async () => {
-    if (!currentItem?.id || useMock) return;
+    if (!currentItem?.id || useMock || effectiveIsLoading) return;
     setIsLoading(true);
     try {
-      await removeItem({ id: currentItem.id });
+      await callEpProxy("removeCartItem", { itemId: currentItem.id });
+      await swrMutate(epCartCacheKey());
       log.info("Item removed from cart", {
         itemId: currentItem.id,
       } as Record<string, unknown>);
@@ -88,23 +90,16 @@ export function EPCartItemRemoveButton(props: EPCartItemRemoveButtonProps) {
       name="removeItemState"
       data={{ isLoading: effectiveIsLoading }}
     >
-      <div
+      <button
+        type="button"
         className={className}
         onClick={handleRemove}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleRemove();
-          }
-        }}
+        disabled={effectiveIsLoading || (!currentItem && !inEditor && !useMock)}
         aria-label={`Remove ${currentItem?.name ?? "item"} from cart`}
-        aria-disabled={effectiveIsLoading}
         data-loading={effectiveIsLoading || undefined}
       >
         {children}
-      </div>
+      </button>
     </DataProvider>
   );
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/cart-drawer/__tests__/cart-drawer-components.test.tsx
@@ -36,16 +36,16 @@ jest.mock("../../cart-provider/use-ep-cart", () => ({
   },
 }));
 
-const mockUseUpdateItem = jest.fn();
-jest.mock("../../cart/use-update-item", () => ({
+const mockCallEpProxy = jest.fn();
+jest.mock("../../ep-server-functions/proxy-fetch", () => ({
   __esModule: true,
-  default: mockUseUpdateItem,
+  callEpProxy: (...args: unknown[]) => mockCallEpProxy(...args),
 }));
 
-const mockUseRemoveItem = jest.fn();
-jest.mock("../../cart/use-remove-item", () => ({
+const mockSwrMutate = jest.fn();
+jest.mock("swr", () => ({
   __esModule: true,
-  default: mockUseRemoveItem,
+  mutate: (...args: unknown[]) => mockSwrMutate(...args),
 }));
 
 const mockUseLocations = jest.fn();
@@ -156,8 +156,8 @@ beforeEach(() => {
   // Defaults: runtime mode (not editor), no cart data
   mockUsePlasmicCanvasContext.mockReturnValue(null);
   mockUseCart.mockReturnValue({ data: null, error: null });
-  mockUseUpdateItem.mockReturnValue(jest.fn());
-  mockUseRemoveItem.mockReturnValue(jest.fn());
+  mockCallEpProxy.mockResolvedValue(undefined);
+  mockSwrMutate.mockResolvedValue(undefined);
   mockUseLocations.mockReturnValue({ locations: [], loading: false });
   mockUseStock.mockReturnValue({ productStock: {}, loading: false });
   mockUseSelector.mockReturnValue(undefined);
@@ -1022,9 +1022,8 @@ describe("EPCartItemQuantityControl", () => {
     expect(ctxValue.canIncrement).toBe(false);
   });
 
-  it("increment calls updateItem with new quantity", async () => {
-    const mockUpdate = jest.fn().mockResolvedValue(undefined);
-    mockUseUpdateItem.mockReturnValue(mockUpdate);
+  it("increment calls updateCartItem proxy with new quantity", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
     mockUseSelector.mockReturnValue({ id: "item-1", quantity: 2 });
 
     let ctxValue: any;
@@ -1037,38 +1036,19 @@ describe("EPCartItemQuantityControl", () => {
       </EPCartItemQuantityControl>
     );
     await act(async () => { ctxValue.increment(); });
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "item-1", quantity: 3 })
-    );
+    expect(mockCallEpProxy).toHaveBeenCalledWith("updateCartItem", {
+      itemId: "item-1",
+      quantity: 3,
+    });
+    expect(mockSwrMutate).toHaveBeenCalled();
   });
 
-  it("decrement calls updateItem with new quantity", async () => {
-    const mockUpdate = jest.fn().mockResolvedValue(undefined);
-    mockUseUpdateItem.mockReturnValue(mockUpdate);
-    mockUseSelector.mockReturnValue({ id: "item-1", quantity: 3 });
-
-    let ctxValue: any;
-    render(
-      <EPCartItemQuantityControl>
-        <HookReader
-          hook={useCartItemQuantity}
-          onResult={(v: any) => { ctxValue = v; }}
-        />
-      </EPCartItemQuantityControl>
-    );
-    await act(async () => { ctxValue.decrement(); });
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "item-1", quantity: 2 })
-    );
-  });
-
-  it("passes locationSlug in update when present", async () => {
-    const mockUpdate = jest.fn().mockResolvedValue(undefined);
-    mockUseUpdateItem.mockReturnValue(mockUpdate);
+  it("increment includes location when the line item has a locationSlug", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
     mockUseSelector.mockReturnValue({
       id: "item-1",
-      quantity: 2,
-      locationSlug: "store-a",
+      quantity: 1,
+      locationSlug: "warehouse-east",
     });
 
     let ctxValue: any;
@@ -1081,14 +1061,54 @@ describe("EPCartItemQuantityControl", () => {
       </EPCartItemQuantityControl>
     );
     await act(async () => { ctxValue.increment(); });
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ location: "store-a" })
+    expect(mockCallEpProxy).toHaveBeenCalledWith("updateCartItem", {
+      itemId: "item-1",
+      quantity: 2,
+      location: "warehouse-east",
+    });
+  });
+
+  it("canIncrement is false when at stockAvailable", () => {
+    mockUseSelector.mockReturnValue({
+      id: "item-1",
+      quantity: 2,
+      stockAvailable: 2,
+    });
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl maxQuantity={99}>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
     );
+    expect(ctxValue.canIncrement).toBe(false);
+  });
+
+  it("decrement calls updateCartItem proxy with new quantity", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
+    mockUseSelector.mockReturnValue({ id: "item-1", quantity: 3 });
+
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
+    );
+    await act(async () => { ctxValue.decrement(); });
+    expect(mockCallEpProxy).toHaveBeenCalledWith("updateCartItem", {
+      itemId: "item-1",
+      quantity: 2,
+    });
+    expect(mockSwrMutate).toHaveBeenCalled();
   });
 
   it("reverts quantity on update error", async () => {
-    const mockUpdate = jest.fn().mockRejectedValue(new Error("Network error"));
-    mockUseUpdateItem.mockReturnValue(mockUpdate);
+    mockCallEpProxy.mockRejectedValue(new Error("Network error"));
     mockUseSelector.mockReturnValue({ id: "item-1", quantity: 2 });
 
     let ctxValue: any;
@@ -1103,6 +1123,101 @@ describe("EPCartItemQuantityControl", () => {
     await act(async () => { ctxValue.increment(); });
     // After error, quantity should revert to server value
     expect(ctxValue.quantity).toBe(2);
+  });
+
+  it("revalidates the cart cache after a failed quantity update", async () => {
+    mockCallEpProxy.mockRejectedValue(new Error("Network error"));
+    mockUseSelector.mockReturnValue({ id: "item-1", quantity: 2 });
+
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
+    );
+    await act(async () => { ctxValue.increment(); });
+    expect(mockSwrMutate).toHaveBeenCalledWith("ep-cart");
+  });
+
+  it("ignores a second increment while an update is in flight", async () => {
+    let resolveUpdate: (value: unknown) => void = () => {};
+    mockCallEpProxy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+    mockUseSelector.mockReturnValue({ id: "item-1", quantity: 2 });
+
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
+    );
+
+    await act(async () => {
+      ctxValue.increment();
+      ctxValue.increment();
+    });
+    expect(mockCallEpProxy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveUpdate({ id: "cart-1", lineItems: [] });
+    });
+  });
+
+  it("decrement includes location when the line item has a locationSlug", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
+    mockUseSelector.mockReturnValue({
+      id: "item-1",
+      quantity: 3,
+      locationSlug: "warehouse-east",
+    });
+
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
+    );
+    await act(async () => { ctxValue.decrement(); });
+    expect(mockCallEpProxy).toHaveBeenCalledWith("updateCartItem", {
+      itemId: "item-1",
+      quantity: 2,
+      location: "warehouse-east",
+    });
+  });
+
+  it("stockAvailable maximum prevents another increment call", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
+    mockUseSelector.mockReturnValue({
+      id: "item-1",
+      quantity: 2,
+      stockAvailable: 2,
+    });
+
+    let ctxValue: any;
+    render(
+      <EPCartItemQuantityControl maxQuantity={99}>
+        <HookReader
+          hook={useCartItemQuantity}
+          onResult={(v: any) => { ctxValue = v; }}
+        />
+      </EPCartItemQuantityControl>
+    );
+    expect(ctxValue.canIncrement).toBe(false);
+    await act(async () => { ctxValue.increment(); });
+    expect(mockCallEpProxy).not.toHaveBeenCalled();
   });
 
   it("uses mock data when previewState=withData", () => {
@@ -1218,7 +1333,19 @@ describe("EPCartItemQuantityButton", () => {
   it("previewState=enabled forces enabled even when context says disabled", () => {
     renderButton("increment", { ...mockCtx, canIncrement: false }, "enabled");
     const btn = screen.getByRole("button");
-    expect(btn.getAttribute("aria-disabled")).toBe("false");
+    // Enabled state omits aria-disabled rather than setting "false"
+    expect(btn.getAttribute("aria-disabled")).toBeNull();
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("sets aria-busy while context is loading in auto preview", () => {
+    renderButton("increment", { ...mockCtx, isLoading: true });
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(mockCtx.increment).not.toHaveBeenCalled();
   });
 
   it("aria-label for increment", () => {
@@ -1233,18 +1360,6 @@ describe("EPCartItemQuantityButton", () => {
     expect(
       screen.getByRole("button").getAttribute("aria-label")
     ).toBe("Decrease quantity");
-  });
-
-  it("Enter key triggers click", () => {
-    renderButton("increment");
-    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
-    expect(mockCtx.increment).toHaveBeenCalledTimes(1);
-  });
-
-  it("Space key triggers click", () => {
-    renderButton("decrement");
-    fireEvent.keyDown(screen.getByRole("button"), { key: " " });
-    expect(mockCtx.decrement).toHaveBeenCalledTimes(1);
   });
 
   it("does not crash without context", () => {
@@ -1262,6 +1377,7 @@ describe("EPCartItemQuantityButton", () => {
     renderButton("increment", { ...mockCtx, canIncrement: false });
     const btn = screen.getByRole("button");
     expect(btn.getAttribute("data-disabled")).toBe("true");
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
   });
 });
 
@@ -1270,9 +1386,8 @@ describe("EPCartItemQuantityButton", () => {
 // ---------------------------------------------------------------------------
 
 describe("EPCartItemRemoveButton", () => {
-  it("calls removeItem on click", async () => {
-    const mockRemove = jest.fn().mockResolvedValue(undefined);
-    mockUseRemoveItem.mockReturnValue(mockRemove);
+  it("calls removeCartItem proxy on click", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
     mockUseSelector.mockReturnValue({ id: "item-1", name: "Product A" });
 
     render(
@@ -1283,12 +1398,14 @@ describe("EPCartItemRemoveButton", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button"));
     });
-    expect(mockRemove).toHaveBeenCalledWith({ id: "item-1" });
+    expect(mockCallEpProxy).toHaveBeenCalledWith("removeCartItem", {
+      itemId: "item-1",
+    });
+    expect(mockSwrMutate).toHaveBeenCalled();
   });
 
-  it("does not call removeItem when no item id", async () => {
-    const mockRemove = jest.fn();
-    mockUseRemoveItem.mockReturnValue(mockRemove);
+  it("does not call removeCartItem when no item id", async () => {
+    mockCallEpProxy.mockResolvedValue(undefined);
     mockUseSelector.mockReturnValue(undefined);
 
     render(
@@ -1299,12 +1416,11 @@ describe("EPCartItemRemoveButton", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button"));
     });
-    expect(mockRemove).not.toHaveBeenCalled();
+    expect(mockCallEpProxy).not.toHaveBeenCalled();
   });
 
   it("clears loading state after error", async () => {
-    const mockRemove = jest.fn().mockRejectedValue(new Error("Fail"));
-    mockUseRemoveItem.mockReturnValue(mockRemove);
+    mockCallEpProxy.mockRejectedValue(new Error("Fail"));
     mockUseSelector.mockReturnValue({ id: "item-1", name: "Product A" });
 
     render(
@@ -1316,8 +1432,7 @@ describe("EPCartItemRemoveButton", () => {
       fireEvent.click(screen.getByRole("button"));
     });
     const btn = screen.getByRole("button");
-    // After error, loading should be cleared — aria-disabled should be false
-    expect(btn.getAttribute("aria-disabled")).toBe("false");
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("aria-label includes item name", () => {
@@ -1344,38 +1459,6 @@ describe("EPCartItemRemoveButton", () => {
     ).toBe("Remove item from cart");
   });
 
-  it("Enter key triggers remove", async () => {
-    const mockRemove = jest.fn().mockResolvedValue(undefined);
-    mockUseRemoveItem.mockReturnValue(mockRemove);
-    mockUseSelector.mockReturnValue({ id: "item-1", name: "Product A" });
-
-    render(
-      <EPCartItemRemoveButton>
-        <span>Remove</span>
-      </EPCartItemRemoveButton>
-    );
-    await act(async () => {
-      fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
-    });
-    expect(mockRemove).toHaveBeenCalledWith({ id: "item-1" });
-  });
-
-  it("Space key triggers remove", async () => {
-    const mockRemove = jest.fn().mockResolvedValue(undefined);
-    mockUseRemoveItem.mockReturnValue(mockRemove);
-    mockUseSelector.mockReturnValue({ id: "item-1", name: "Product A" });
-
-    render(
-      <EPCartItemRemoveButton>
-        <span>Remove</span>
-      </EPCartItemRemoveButton>
-    );
-    await act(async () => {
-      fireEvent.keyDown(screen.getByRole("button"), { key: " " });
-    });
-    expect(mockRemove).toHaveBeenCalledWith({ id: "item-1" });
-  });
-
   it("previewState=loading shows loading state", () => {
     mockUseSelector.mockReturnValue({ id: "item-1" });
     render(
@@ -1385,11 +1468,11 @@ describe("EPCartItemRemoveButton", () => {
     );
     const btn = screen.getByRole("button");
     expect(btn.getAttribute("data-loading")).toBe("true");
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("previewState prevents actual remove call", async () => {
-    const mockRemove = jest.fn();
-    mockUseRemoveItem.mockReturnValue(mockRemove);
+    mockCallEpProxy.mockResolvedValue(undefined);
     mockUseSelector.mockReturnValue({ id: "item-1" });
 
     render(
@@ -1400,6 +1483,6 @@ describe("EPCartItemRemoveButton", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button"));
     });
-    expect(mockRemove).not.toHaveBeenCalled();
+    expect(mockCallEpProxy).not.toHaveBeenCalled();
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/cart-mutations.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/cart-mutations.test.ts
@@ -61,6 +61,54 @@ const CART_RESPONSE = {
   },
 };
 
+const CART_WITH_ITEM_RESPONSE = {
+  data: {
+    data: {
+      id: "cart-id",
+      type: "cart",
+      attributes: { name: "Cart" },
+      meta: {
+        display_price: {
+          with_tax: { amount: 5000, currency: "USD", formatted: "$50.00" },
+          without_tax: { amount: 5000, currency: "USD", formatted: "$50.00" },
+        },
+      },
+    },
+    included: {
+      items: [
+        {
+          id: "li-1",
+          type: "cart_item",
+          product_id: "prod-1",
+          name: "Test",
+          quantity: 1,
+          unit_price: { amount: 1000, currency: "USD" },
+        },
+      ],
+    },
+  },
+};
+
+function mockSuccessfulAdd(cartId = "cart-id") {
+  mockManageCarts.mockResolvedValue({
+    data: {
+      data: { id: cartId },
+      included: { items: [{ id: "li-1" }] },
+    },
+  });
+  const base =
+    cartId === "cart-id"
+      ? CART_WITH_ITEM_RESPONSE
+      : {
+          ...CART_WITH_ITEM_RESPONSE,
+          data: {
+            ...CART_WITH_ITEM_RESPONSE.data,
+            data: { ...CART_WITH_ITEM_RESPONSE.data.data, id: cartId },
+          },
+        };
+  mockGetACart.mockResolvedValue(base);
+}
+
 beforeEach(() => {
   mockManageCarts.mockReset();
   mockCreateACart.mockReset();
@@ -74,8 +122,7 @@ beforeEach(() => {
 
 describe("epAddCartItem", () => {
   it("adds an item to the cart carried by the ALS session and returns the normalized cart", async () => {
-    mockManageCarts.mockResolvedValue({});
-    mockGetACart.mockResolvedValue(CART_RESPONSE);
+    mockSuccessfulAdd();
 
     const result = await withEpSession(
       { ...SESSION_BASE, cartId: "cart-id" },
@@ -84,6 +131,7 @@ describe("epAddCartItem", () => {
 
     expect(result).not.toBeNull();
     expect(result.id).toBe("cart-id");
+    expect(result.lineItems).toHaveLength(1);
     expect(mockManageCarts).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { cartID: "cart-id" },
@@ -110,14 +158,7 @@ describe("epAddCartItem", () => {
     mockCreateACart.mockResolvedValue({
       data: { data: { id: "new-cart-id", type: "cart" } },
     });
-    mockManageCarts.mockResolvedValue({});
-    mockGetACart.mockResolvedValue({
-      ...CART_RESPONSE,
-      data: {
-        ...CART_RESPONSE.data,
-        data: { ...CART_RESPONSE.data.data, id: "new-cart-id" },
-      },
-    });
+    mockSuccessfulAdd("new-cart-id");
 
     const result = await withEpSession(SESSION_BASE, () =>
       epAddCartItem({ productId: "prod-1", quantity: 1 })
@@ -144,9 +185,37 @@ describe("epAddCartItem", () => {
     ).rejects.toThrow(/out of stock/);
   });
 
+  it("throws when manageCarts soft-fails with { error } (throwOnError defaults false)", async () => {
+    mockManageCarts.mockResolvedValue({
+      error: {
+        errors: [{ detail: "The product is not available for purchase" }],
+      },
+    });
+
+    await expect(
+      withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+        epAddCartItem({ productId: "prod-1", quantity: 1 })
+      )
+    ).rejects.toThrow(/not available for purchase/);
+    expect(mockGetACart).not.toHaveBeenCalled();
+  });
+
+  it("throws when manageCarts succeeds but the re-fetched cart has no line items", async () => {
+    mockManageCarts.mockResolvedValue({
+      data: { data: { id: "cart-id" }, included: { items: [] } },
+      response: { status: 201 },
+    });
+    mockGetACart.mockResolvedValue(CART_RESPONSE); // included.items: []
+
+    await expect(
+      withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+        epAddCartItem({ productId: "prod-1", quantity: 1 })
+      )
+    ).rejects.toThrow(/cart still empty after add/);
+  });
+
   it("uses sku rather than productId when the input provides a sku (variant selection)", async () => {
-    mockManageCarts.mockResolvedValue({});
-    mockGetACart.mockResolvedValue(CART_RESPONSE);
+    mockSuccessfulAdd();
 
     await withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
       epAddCartItem({ productId: "prod-1", quantity: 1, sku: "SKU-RED-LG" })
@@ -169,8 +238,7 @@ describe("epAddCartItem", () => {
   });
 
   it("forwards customInputs (variant labels, gift messages) onto the cart item", async () => {
-    mockManageCarts.mockResolvedValue({});
-    mockGetACart.mockResolvedValue(CART_RESPONSE);
+    mockSuccessfulAdd();
 
     await withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
       epAddCartItem({
@@ -194,8 +262,7 @@ describe("epAddCartItem", () => {
   });
 
   it("forwards bundleConfiguration and location for EP-specific cart-item shapes", async () => {
-    mockManageCarts.mockResolvedValue({});
-    mockGetACart.mockResolvedValue(CART_RESPONSE);
+    mockSuccessfulAdd();
 
     const bundle = { selected: { components: { kit: { sku: "X" } } } };
 
@@ -333,7 +400,18 @@ describe("epApplyCartAdjustment", () => {
 describe("epUpdateCartItem", () => {
   it("updates an item's quantity on the session cart and returns the normalized cart", async () => {
     mockUpdateACartItem.mockResolvedValue({});
-    mockGetACart.mockResolvedValue(CART_RESPONSE);
+    // First getACart resolves location from the existing line; second is the
+    // post-update normalized fetch.
+    mockGetACart
+      .mockResolvedValueOnce({
+        data: {
+          data: { id: "cart-id" },
+          included: {
+            items: [{ id: "item-1", type: "cart_item", quantity: 1 }],
+          },
+        },
+      })
+      .mockResolvedValueOnce(CART_RESPONSE);
 
     const result = await withEpSession(
       { ...SESSION_BASE, cartId: "cart-id" },
@@ -354,6 +432,68 @@ describe("epUpdateCartItem", () => {
     );
   });
 
+  it("includes location on update when provided (multi-location stock)", async () => {
+    mockUpdateACartItem.mockResolvedValue({});
+    mockGetACart.mockResolvedValue(CART_RESPONSE);
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+      epUpdateCartItem({
+        itemId: "item-1",
+        quantity: 2,
+        location: "warehouse-east",
+      })
+    );
+
+    expect(mockUpdateACartItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          data: expect.objectContaining({
+            location: "warehouse-east",
+            quantity: 2,
+          }),
+        },
+      })
+    );
+    // Caller supplied location — no pre-read of the cart for location.
+    expect(mockGetACart).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves location from the existing cart line when the caller omits it", async () => {
+    mockUpdateACartItem.mockResolvedValue({});
+    mockGetACart
+      .mockResolvedValueOnce({
+        data: {
+          data: { id: "cart-id" },
+          included: {
+            items: [
+              {
+                id: "item-1",
+                type: "cart_item",
+                quantity: 2,
+                location: "store-downtown",
+              },
+            ],
+          },
+        },
+      })
+      .mockResolvedValueOnce(CART_RESPONSE);
+
+    await withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+      epUpdateCartItem({ itemId: "item-1", quantity: 1 })
+    );
+
+    expect(mockUpdateACartItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          data: expect.objectContaining({
+            location: "store-downtown",
+            quantity: 1,
+          }),
+        },
+      })
+    );
+  });
+
   it("throws when called without an active EP session", async () => {
     await expect(
       epUpdateCartItem({ itemId: "item-1", quantity: 1 })
@@ -367,6 +507,25 @@ describe("epUpdateCartItem", () => {
       )
     ).rejects.toThrow(/no cart/i);
     expect(mockUpdateACartItem).not.toHaveBeenCalled();
+  });
+  it("throws when updateACartItem soft-fails with { error }", async () => {
+    mockGetACart.mockResolvedValue({
+      data: {
+        data: { id: "cart-id" },
+        included: { items: [{ id: "item-1", type: "cart_item", quantity: 1 }] },
+      },
+    });
+    mockUpdateACartItem.mockResolvedValue({
+      error: { errors: [{ detail: "quantity exceeds stock" }] },
+    });
+
+    await expect(
+      withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+        epUpdateCartItem({ itemId: "item-1", quantity: 99 })
+      )
+    ).rejects.toThrow(/quantity exceeds stock/);
+    // Location pre-read happens; post-update cart fetch must not.
+    expect(mockGetACart).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -399,5 +558,18 @@ describe("epRemoveCartItem", () => {
       withEpSession(SESSION_BASE, () => epRemoveCartItem({ itemId: "item-1" }))
     ).rejects.toThrow(/no cart/i);
     expect(mockDeleteACartItem).not.toHaveBeenCalled();
+  });
+
+  it("throws when deleteACartItem soft-fails with { error }", async () => {
+    mockDeleteACartItem.mockResolvedValue({
+      error: { errors: [{ detail: "cart item not found" }] },
+    });
+
+    await expect(
+      withEpSession({ ...SESSION_BASE, cartId: "cart-id" }, () =>
+        epRemoveCartItem({ itemId: "item-1" })
+      )
+    ).rejects.toThrow(/cart item not found/);
+    expect(mockGetACart).not.toHaveBeenCalled();
   });
 });

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/proxy-fetch.test.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/__tests__/proxy-fetch.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ *
+ * callEpProxy soft vs hard failure:
+ * - omit fallback → throw (mutations)
+ * - pass fallback (including null / []) → return fallback (reads)
+ *
+ * Empty successful JSON bodies (e.g. `null` or `[]` as the response body)
+ * are returned as parsed JSON on 2xx; no current mutation caller treats a
+ * successful empty body as failure at the proxy layer.
+ */
+
+const mockFetch = jest.fn();
+(globalThis as any).fetch = mockFetch;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { callEpProxy } = require("../proxy-fetch");
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  delete (window as any).__epProxyOrigin;
+});
+
+describe("callEpProxy", () => {
+  it("returns parsed JSON on a successful response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "cart-1" }),
+    });
+
+    await expect(callEpProxy("getCart", {})).resolves.toEqual({ id: "cart-1" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/ep/proxy/getCart",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+      })
+    );
+  });
+
+  it("throws on network failure when fallback is omitted", async () => {
+    mockFetch.mockRejectedValue(new Error("Failed to fetch"));
+
+    await expect(callEpProxy("addCartItem", { productId: "p1" })).rejects.toThrow(
+      "Failed to fetch"
+    );
+  });
+
+  it("throws on non-2xx when fallback is omitted", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    await expect(callEpProxy("addCartItem", { productId: "p1" })).rejects.toThrow(
+      /ep proxy addCartItem failed \(500\)/
+    );
+  });
+
+  it("preserves the proxy/server error message on non-2xx", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ message: "There is not enough stock to add" }),
+    });
+
+    await expect(callEpProxy("updateCartItem", { itemId: "i1" })).rejects.toThrow(
+      "There is not enough stock to add"
+    );
+  });
+
+  it("throws on invalid JSON when fallback is omitted", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("Unexpected token");
+      },
+    });
+
+    await expect(callEpProxy("addCartItem", { productId: "p1" })).rejects.toThrow(
+      "Unexpected token"
+    );
+  });
+
+  it("returns null when an explicit null fallback is passed", async () => {
+    mockFetch.mockRejectedValue(new Error("Failed to fetch"));
+
+    await expect(callEpProxy("getCart", {}, null)).resolves.toBeNull();
+  });
+
+  it("returns [] when an explicit empty-array fallback is passed", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ message: "unavailable" }),
+    });
+
+    await expect(callEpProxy("getProductList", {}, [])).resolves.toEqual([]);
+  });
+
+  it("returns a successful empty JSON array body without treating it as failure", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    await expect(callEpProxy("getProductList", {}, [])).resolves.toEqual([]);
+  });
+});

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/cart-mutations.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/cart-mutations.ts
@@ -16,6 +16,41 @@ import {
 } from "./custom-cart-item";
 import type { EpServerAuth } from "./types";
 
+/**
+ * Hey API defaults to `throwOnError: false`, so EP rejections resolve as
+ * `{ error }` instead of throwing. Format that payload (or a thrown value)
+ * into a readable message for callers / the ATC button.
+ */
+function formatEpSdkError(error: unknown, fallback: string): string {
+  if (!error) return fallback;
+  if (typeof error === "string" && error.trim()) return error;
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "object") {
+    const e = error as {
+      errors?: Array<{ detail?: string; title?: string; message?: string }>;
+      message?: string;
+    };
+    const fromErrors = e.errors
+      ?.map((item) => item.detail || item.title || item.message)
+      .filter((s): s is string => Boolean(s && s.trim()))
+      .join("; ");
+    if (fromErrors) return fromErrors;
+    if (e.message) return e.message;
+  }
+  return fallback;
+}
+
+function assertEpSdkOk(
+  result: { error?: unknown },
+  label: string
+): void {
+  if (result.error) {
+    throw new Error(
+      `${label}: ${formatEpSdkError(result.error, "unknown error")}`
+    );
+  }
+}
+
 async function fetchNormalizedCart(
   client: ReturnType<typeof buildEpClient>,
   auth: EpServerAuth,
@@ -43,6 +78,12 @@ export interface EpAddCartItemInput {
 export interface EpUpdateCartItemInput {
   itemId: string;
   quantity: number;
+  /**
+   * EP location slug for multi-location inventory. When the line was added
+   * with a location, updates must include it so EP validates stock against
+   * that pool (same as the legacy use-update-item hook).
+   */
+  location?: string;
 }
 
 export interface EpRemoveCartItemInput {
@@ -98,13 +139,39 @@ export async function epAddCartItem(input: EpAddCartItemInput): Promise<Cart> {
     itemData.location = input.location;
   }
 
-  await manageCarts({
+  const addRes = await manageCarts({
     client,
     path: { cartID: cartId },
     body: { data: itemData as never },
   });
+  assertEpSdkOk(addRes, "epAddCartItem");
+  if (!addRes.data) {
+    const status =
+      (addRes as { response?: { status?: number } }).response?.status ?? "?";
+    throw new Error(
+      `epAddCartItem: manageCarts returned no data (HTTP ${status})`
+    );
+  }
 
-  return fetchNormalizedCart(client, auth, cartId);
+  const cart = await fetchNormalizedCart(client, auth, cartId);
+  // Soft EP failures (e.g. unpublished catalog product) can resolve without
+  // `error` while leaving the cart empty — surface that instead of a quiet
+  // empty success that looks like "add did nothing".
+  if (cart.lineItems.length === 0) {
+    const includedCount =
+      (
+        addRes.data as { included?: { items?: unknown[] } } | undefined
+      )?.included?.items?.length ?? 0;
+    throw new Error(
+      `epAddCartItem: cart still empty after add ` +
+        `(productId=${input.productId}` +
+        `${input.sku ? `, sku=${input.sku}` : ""}, ` +
+        `manageCartsIncludedItems=${includedCount}). ` +
+        `Check the product is purchasable in the published catalog and that ` +
+        `currency/catalog rules allow adding it.`
+    );
+  }
+  return cart;
 }
 
 export async function epUpdateCartItem(
@@ -119,17 +186,50 @@ export async function epUpdateCartItem(
   }
   const client = buildEpClient(auth);
 
-  await updateACartItem({
+  // Multilocation inventory: quantity changes (including decreases) are
+  // validated against a stock pool. Without the line's location slug EP
+  // checks the wrong pool and returns "not enough stock to add…", even
+  // when lowering quantity. Prefer the caller-supplied slug; otherwise
+  // read it from the existing cart line so clients can't drop it.
+  let location = input.location?.trim() || undefined;
+  if (!location) {
+    const existing = await getACart({
+      client,
+      path: { cartID: auth.cartId },
+      query: { include: ["items"] },
+    });
+    const items = existing?.data?.included?.items ?? [];
+    const match = items.find(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        "id" in item &&
+        (item as { id?: string }).id === input.itemId
+    ) as { location?: string } | undefined;
+    const fromLine =
+      typeof match?.location === "string" ? match.location.trim() : "";
+    if (fromLine) {
+      location = fromLine;
+    }
+  }
+
+  const updateData: Record<string, unknown> = {
+    type: "cart_item",
+    id: input.itemId,
+    quantity: input.quantity,
+  };
+  if (location) {
+    updateData.location = location;
+  }
+
+  const updateRes = await updateACartItem({
     client,
     path: { cartID: auth.cartId, cartitemID: input.itemId },
     body: {
-      data: {
-        type: "cart_item",
-        id: input.itemId,
-        quantity: input.quantity,
-      },
+      data: updateData as never,
     },
   });
+  assertEpSdkOk(updateRes, "epUpdateCartItem");
 
   return fetchNormalizedCart(client, auth, auth.cartId);
 }
@@ -201,10 +301,11 @@ export async function epRemoveCartItem(
   }
   const client = buildEpClient(auth);
 
-  await deleteACartItem({
+  const deleteRes = await deleteACartItem({
     client,
     path: { cartID: auth.cartId, cartitemID: input.itemId },
   });
+  assertEpSdkOk(deleteRes, "epRemoveCartItem");
 
   return fetchNormalizedCart(client, auth, auth.cartId);
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getCart.ts
@@ -30,7 +30,8 @@ export async function epGetCart(
   if (!isUsableAuth(auth) && shouldUseProxy()) {
     return callEpProxy<ReturnType<typeof normalizeCart> | null>(
       "getCart",
-      {}
+      {},
+      null
     );
   }
 

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/getProduct.ts
@@ -35,7 +35,7 @@ export async function epGetProduct({
   // route so the call uses the better-auth session cookie just like
   // SSR does, without exposing tokens to the browser bundle.
   if (!isUsableAuth(auth) && shouldUseProxy()) {
-    return callEpProxy<Product | null>("getProduct", { id });
+    return callEpProxy<Product | null>("getProduct", { id }, null);
   }
 
   if (!isUsableAuth(auth)) return null;

--- a/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/proxy-fetch.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/ep-server-functions/proxy-fetch.ts
@@ -2,7 +2,7 @@
  * Browser-side proxy fetch for the EP server functions.
  *
  * Why this exists: in Studio canvas (and the data-query "Configure"
- * preview panel) the registered `ep*` functions run in a browser
+ * preview panel) the registered `ep*` server functions run in a browser
  * context with no AsyncLocalStorage session and no reachable
  * EPCommerceProvider client (the picker preview runs in the Studio
  * main frame, separate from the canvas iframe). To still resolve real
@@ -62,15 +62,63 @@ function resolveProxyUrl(fnName: string): string {
     : `${PROXY_PATH}/${fnName}`;
 }
 
+async function readProxyErrorMessage(
+  res: Response,
+  fnName: string
+): Promise<string> {
+  const fallback = `ep proxy ${fnName} failed (${res.status})`;
+  try {
+    const body = (await res.json()) as {
+      message?: string;
+      error?: string | { message?: string };
+    };
+    if (typeof body.message === "string" && body.message.trim()) {
+      return body.message;
+    }
+    if (typeof body.error === "string" && body.error.trim()) {
+      return body.error;
+    }
+    if (
+      body.error &&
+      typeof body.error === "object" &&
+      typeof body.error.message === "string" &&
+      body.error.message.trim()
+    ) {
+      return body.error.message;
+    }
+  } catch {
+    // ignore parse failures — use status fallback
+  }
+  return fallback;
+}
+
 /**
  * Calls `<fnName>` via the consumer's EP proxy route with the supplied
- * args as the JSON body. Returns the parsed JSON on success, or
- * `fallback` on any failure (network error, non-2xx, parse error).
+ * args as the JSON body.
+ *
+ * Soft vs hard failure:
+ * - When `fallback` is **passed** (including `null`), network / non-2xx /
+ *   parse errors return that value — used by read paths (`getCart`,
+ *   `getProduct`, …) that prefer empty UI over throwing.
+ * - When `fallback` is **omitted**, failures throw so mutation callers
+ *   (add to cart, place order, adjustments) surface the real error.
  */
-export async function callEpProxy<T>(
+export function callEpProxy<T>(
   fnName: string,
   args: Record<string, unknown>,
   fallback?: T
+): Promise<T> {
+  // Detect "fallback was passed" via `arguments` on a sync wrapper —
+  // `arguments` is illegal inside async functions under our TS target.
+  const softFail = arguments.length >= 3;
+  return callEpProxyImpl(fnName, args, softFail, fallback as T);
+}
+
+async function callEpProxyImpl<T>(
+  fnName: string,
+  args: Record<string, unknown>,
+  softFail: boolean,
+  fallback: T
 ): Promise<T> {
   const url = resolveProxyUrl(fnName);
   let res: Response;
@@ -81,15 +129,23 @@ export async function callEpProxy<T>(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(args),
     });
-  } catch {
-    return (fallback ?? null) as T;
+  } catch (err) {
+    if (softFail) return fallback;
+    throw err instanceof Error
+      ? err
+      : new Error(`ep proxy ${fnName}: network error`);
   }
   if (!res.ok) {
-    return (fallback ?? null) as T;
+    const message = await readProxyErrorMessage(res, fnName);
+    if (softFail) return fallback;
+    throw new Error(message);
   }
   try {
     return (await res.json()) as T;
-  } catch {
-    return (fallback ?? null) as T;
+  } catch (err) {
+    if (softFail) return fallback;
+    throw err instanceof Error
+      ? err
+      : new Error(`ep proxy ${fnName}: invalid JSON response`);
   }
 }

--- a/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.test.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.test.tsx
@@ -93,8 +93,7 @@ describe("EPAddToCartButton", () => {
 
     expect(mockCallEpProxy).toHaveBeenCalledWith(
       "addCartItem",
-      expect.objectContaining({ productId: "variant-1", quantity: 2 }),
-      null
+      expect.objectContaining({ productId: "variant-1", quantity: 2 })
     );
   });
 
@@ -146,6 +145,68 @@ describe("EPAddToCartButton", () => {
     });
 
     expect(readState().error).toMatch(/out of stock/);
+  });
+
+  it("clears a previous addToCartState.error when a new attempt begins", async () => {
+    setUp();
+    mockCallEpProxy.mockRejectedValueOnce(new Error("out of stock"));
+
+    render(<EPAddToCartButton>Add</EPAddToCartButton>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Add"));
+    });
+    expect(readState().error).toMatch(/out of stock/);
+
+    let resolveProxy: (v: unknown) => void = () => {};
+    mockCallEpProxy.mockImplementation(
+      () => new Promise((resolve) => { resolveProxy = resolve; })
+    );
+
+    fireEvent.click(screen.getByText("Add"));
+    // setError(null) runs before the proxy await — designers see a cleared
+    // $ctx.addToCartState.error for the new attempt.
+    expect(readState().error).toBeNull();
+    expect(readState().isLoading).toBe(true);
+
+    await act(async () => {
+      resolveProxy({ id: "cart-1", lineItems: [] });
+    });
+    expect(readState().error).toBeNull();
+  });
+
+  it("does not call onAddedToCart when the mutation fails", async () => {
+    setUp();
+    const onAddedToCart = jest.fn();
+    mockCallEpProxy.mockRejectedValue(new Error("out of stock"));
+
+    render(
+      <EPAddToCartButton onAddedToCart={onAddedToCart}>Add</EPAddToCartButton>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Add"));
+    });
+
+    expect(readState().error).toMatch(/out of stock/);
+    expect(onAddedToCart).not.toHaveBeenCalled();
+  });
+
+  it("calls onAddedToCart after a successful mutation", async () => {
+    setUp();
+    const onAddedToCart = jest.fn();
+    mockCallEpProxy.mockResolvedValue({ id: "cart-1", lineItems: [] });
+
+    render(
+      <EPAddToCartButton onAddedToCart={onAddedToCart}>Add</EPAddToCartButton>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Add"));
+    });
+
+    expect(onAddedToCart).toHaveBeenCalledTimes(1);
+    expect(readState().error).toBeNull();
   });
 
   it("previewState='loading' forces isLoading=true regardless of runtime state", () => {

--- a/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.tsx
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/registerEPAddToCartButton.tsx
@@ -115,19 +115,15 @@ export function EPAddToCartButton(props: EPAddToCartButtonProps) {
         ? { _selectedOptions: cartItem.selectedOptions }
         : undefined;
 
-      await callEpProxy(
-        "addCartItem",
-        {
-          productId: cartItem.variantId || cartItem.productId || product.id,
-          quantity: cartItem.quantity ?? 1,
-          ...(customInputs ? { customInputs } : {}),
-          ...(cartItem.bundleConfiguration
-            ? { bundleConfiguration: cartItem.bundleConfiguration }
-            : {}),
-          ...(cartItem.locationId ? { location: cartItem.locationId } : {}),
-        },
-        null
-      );
+      await callEpProxy("addCartItem", {
+        productId: cartItem.variantId || cartItem.productId || product.id,
+        quantity: cartItem.quantity ?? 1,
+        ...(customInputs ? { customInputs } : {}),
+        ...(cartItem.bundleConfiguration
+          ? { bundleConfiguration: cartItem.bundleConfiguration }
+          : {}),
+        ...(cartItem.locationId ? { location: cartItem.locationId } : {}),
+      });
 
       // Refresh any EPCartProvider in the tree.
       await swrMutate(epCartCacheKey());

--- a/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize.ts
+++ b/plasmicpkgs/commerce-providers/elastic-path/src/utils/normalize.ts
@@ -356,8 +356,10 @@ const normalizeLineItem = (
     options,
   };
 
-  // Carry through the location slug from the EP cart item response
-  const locationSlug = epItem.location;
+  // Carry through the location slug from the EP cart item response.
+  // Read via a wide cast — the shopper SDK response type omits `location`
+  // on CartItemResponse even though EP returns it for multilocation lines.
+  const locationSlug = (epItem as { location?: string }).location;
   if (locationSlug) {
     lineItem.locationSlug = locationSlug;
   }


### PR DESCRIPTION
## Summary

* Reject cart mutation proxy/SDK failures instead of silently resolving to `null`.
* Surface Add to Cart errors through `$ctx.addToCartState.error`.
* Preserve/recover multilocation `location` on quantity updates.
* Harden quantity controls with in-flight protection, optimistic updates + rollback, and stock-aware increment limits.
* Use the strict proxy path for remove mutations.

## What changed

### Error handling

`callEpProxy` now throws when no fallback is supplied, while reads can continue to soft-fail by passing an explicit fallback:

```ts
// Read: soft failure
callEpProxy("getCart", input, null);

// Mutation: reject on failure
callEpProxy("addCartItem", input);
```

Elastic Path add/update/remove mutations also validate SDK `{ error }` responses instead of treating them as successful.

### Add to Cart

Failures now reach the existing Studio-facing state:

```text
$ctx.addToCartState.error
```

Previous errors are cleared on a new attempt, and `onAddedToCart` only runs after a successful mutation.

No default toast or banner is added; designers can bind their own UI to the error state.

### Multilocation quantity updates

Cart-line `location` is retained as `locationSlug` and passed with quantity updates.

If location is missing from the client request, the server attempts to recover it from the existing cart line before updating Elastic Path.

This fixes repeated multilocation +/- failures and incorrect insufficient-stock errors during decrement.

### Quantity / remove

Quantity updates now:

* prevent overlapping requests
* optimistically update and roll back on failure
* revalidate the cart after failure
* respect known stock limits
* preserve button/ARIA busy and disabled behaviour

Remove now rejects proxy/SDK failures and refreshes the cart after success. Failed remove leaves the item in the cart.

Quantity/remove errors remain log-only in this MR.

## Designer impact

Designers can bind custom error UI to `$ctx.addToCartState.error`.

Existing projects will not automatically display an error unless UI is bound to that value.

## Implementor notes

* Two-argument `callEpProxy` calls now reject on failure.
* Reads that should soft-fail must pass an explicit fallback.
* Quantity updates accept an optional `location`; if omitted, the server may perform an additional cart read to recover it.

## Testing

### Automated

* Focused tests: **157 passed**
* Package Jest: **1932 passed**
* Package Vitest: **31 passed**
* `git diff --check`: **passed**

Coverage includes proxy strict/fallback behaviour, SDK soft errors, ATC error/callback handling, multilocation location passing/recovery, quantity rollback/in-flight behaviour, stock limits, remove behaviour, and button accessibility/Studio preview states.

### Manual

Verified:

* successful and failed Add to Cart
* repeated multilocation +/-
* `location` present in update requests
* rapid-click/in-flight behaviour
* rollback after failed quantity updates
* remove behaviour
* single-location/non-location regression checks


Fixes #392
